### PR TITLE
Add Open XL toolchain and config changes for z/OS

### DIFF
--- a/cmake/modules/OmrDetectSystemInformation.cmake
+++ b/cmake/modules/OmrDetectSystemInformation.cmake
@@ -202,19 +202,25 @@ macro(omr_detect_system_information)
 				# just use GNU config
 				set(_OMR_TOOLCONFIG "gnu")
 			endif()
+		elseif((CMAKE_C_COMPILER_ID MATCHES "IBMClang$") OR (CMAKE_C_COMPILER MATCHES ".*ibm-clang.*"))
+			set(_OMR_TOOLCONFIG "openxl")
+			set(CMAKE_C_COMPILER_IS_OPENXL ON CACHE BOOL "ibm-clang is the C compiler")
 		elseif(CMAKE_C_COMPILER_ID MATCHES "^XL(Clang)?$" OR CMAKE_C_COMPILER_ID STREQUAL "zOS")
 			# In CMake 3.14 and prior, XLClang uses CMAKE_C_COMPILER_ID "XL"
 			# In CMake 3.15 and beyond, XLClang uses CMAKE_C_COMPILER_ID "XLClang"
 			set(_OMR_TOOLCONFIG "xlc")
+			message(STATUS "CMAKE_C_COMPILER is ${CMAKE_C_COMPILER}")
 			if(CMAKE_C_COMPILER MATCHES ".*xlclang$")
 				# Checking the CMAKE_C_COMPILER command is necessary to determine if XLClang is
 				# the compiler, since XLClang might have CMAKE_C_COMPILER_ID "XL" or "XLClang"
 				# depending on the CMake version. Without this check, it's ambiguous whether the
 				# compiler is XLC or XLClang.
 				set(CMAKE_C_COMPILER_IS_XLCLANG TRUE CACHE BOOL "XLClang is the C compiler")
+			else()
+				message(STATUS "NO XLClang match. Using xlc toolchain.")
 			endif()
 		else()
-			message(FATAL_ERROR "OMR: Unknown compiler ID: '${CMAKE_CXX_COMPILER_ID}'")
+			message(FATAL_ERROR "OMR: Unknown compiler ID: '${CMAKE_C_COMPILER_ID}'")
 		endif()
 		set(OMR_TOOLCONFIG ${_OMR_TOOLCONFIG} CACHE STRING "Name of toolchain configuration options to use")
 	endif()

--- a/cmake/modules/ddr/DDRSetStub.cmake.in
+++ b/cmake/modules/ddr/DDRSetStub.cmake.in
@@ -145,7 +145,7 @@ function(process_source_files src_files)
 			# Adding this option to the command alleviates this issue.
 			list(APPEND pp_command "-xc++")
 		endif()
-		if("@OMR_OS_ZOS@" AND "@OMR_ENV_DATA64@")
+		if("@OMR_OS_ZOS@" AND "@OMR_ENV_DATA64@" AND NOT "@OMR_TOOLCONFIG@" STREQUAL "openxl")
 			# We need to set 64 bit code generation to ensure that limits.h macros are set correctly.
 			list(APPEND pp_command "-Wc,lp64")
 		endif()

--- a/cmake/modules/platform/toolcfg/openxl.cmake
+++ b/cmake/modules/platform/toolcfg/openxl.cmake
@@ -1,0 +1,140 @@
+###############################################################################
+# Copyright IBM Corp. and others 2024
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution
+# and is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception [1] and GNU General Public
+# License, version 2 with the OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+###############################################################################
+
+if(OMR_OS_ZOS)
+	set(OMR_ZOS_COMPILE_ARCHITECTURE "arch10" CACHE STRING "z/OS compile machine architecture" FORCE)
+	set(OMR_ZOS_COMPILE_TARGET "ZOSV2R4" CACHE STRING "z/OS compile target operating system" FORCE)
+	set(OMR_ZOS_COMPILE_TUNE "12" CACHE STRING "z/OS compile machine architecture tuning" FORCE)
+	set(OMR_ZOS_LINK_COMPAT "ZOSV2R4" CACHE STRING "z/OS link compatible operating system" FORCE)
+	set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "--shared")
+	set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "--shared")
+
+	set(CMAKE_ASM_FLAGS "-fno-integrated-as")
+	string(APPEND CMAKE_ASM_FLAGS " \"-Wa,-mgoff\"")
+	if(OMR_ENV_DATA64)
+		string(APPEND CMAKE_ASM_FLAGS " \"-Wa,-mSYSPARM(BIT64)\"")
+	endif()
+
+	list(APPEND OMR_PLATFORM_COMPILE_OPTIONS
+		"-fstrict-aliasing"
+		"-mzos-target=${OMR_ZOS_COMPILE_TARGET}"
+		"-m64"
+	)
+
+	list(APPEND OMR_PLATFORM_C_COMPILE_OPTIONS
+		-march=${OMR_ZOS_COMPILE_ARCHITECTURE}
+	)
+
+	# -std=gnu++14 is used over -std=cpp++14, as the gnu* options are closest to
+	# -qlanglvl=extended (enabling most extensions by default). This is preferred
+	# in order to avoid defining _EXT repeatedly in most places.
+	list(APPEND OMR_PLATFORM_CXX_COMPILE_OPTIONS
+		-march=${OMR_ZOS_COMPILE_ARCHITECTURE}
+		"-std=gnu++14"
+		-fasm
+	)
+
+	list(APPEND OMR_PLATFORM_SHARED_COMPILE_OPTIONS
+		-fvisibility=default
+	)
+
+	if(OMR_ENV_DATA64)
+		list(APPEND OMR_PLATFORM_DEFINITIONS
+			-DJ9ZOS39064
+		)
+	else()
+		list(APPEND OMR_PLATFORM_DEFINITIONS
+			-D_LARGE_FILES
+		)
+	endif()
+
+	# Testarossa build variables. Longer term the distinction between TR and the rest
+	# of the OMR code should be heavily reduced. In the mean time, we keep
+	# the distinction.
+
+	# TR_COMPILE_OPTIONS are variables appended to CMAKE_{C,CXX}_FLAGS, and so
+	# apply to both C and C++ compilations.
+	list(APPEND TR_COMPILE_OPTIONS
+		-DYYLMAX=1000
+	)
+
+	list(APPEND TR_CXX_COMPILE_OPTIONS
+		-Wuninitialized
+		-mnocsect
+	)
+
+	# Configure the platform-dependent library for multithreading.
+	set(OMR_PLATFORM_THREAD_LIBRARY "")
+endif()
+
+set(SPP_CMD ${CMAKE_C_COMPILER})
+set(SPP_FLAGS -E -P)
+
+if(OMR_OS_ZOS)
+	function(_omr_toolchain_process_exports TARGET_NAME)
+		# Any type of target which says it has exports should get the DLL, and EXPORTALL
+		# compile flags.
+		# Open XL equivalent has been added below.
+		target_compile_options(${TARGET_NAME}
+			PRIVATE
+				-fvisibility=default
+		)
+
+		get_target_property(target_type ${TARGET_NAME} TYPE)
+		if(NOT target_type STREQUAL "SHARED_LIBRARY")
+			return()
+		endif()
+		add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+			COMMAND "${CMAKE_COMMAND}"
+				"-DLIBRARY_FILE_NAME=$<TARGET_FILE_NAME:${TARGET_NAME}>"
+				"-DRUNTIME_DIR=$<TARGET_FILE_DIR:${TARGET_NAME}>"
+				"-DARCHIVE_DIR=$<TARGET_PROPERTY:${TARGET_NAME},ARCHIVE_OUTPUT_DIRECTORY>"
+				-P "${omr_SOURCE_DIR}/cmake/modules/platform/toolcfg/zos_rename_exports.cmake"
+		)
+	endfunction()
+else()
+	function(_omr_toolchain_process_exports TARGET_NAME)
+		get_target_property(target_type ${TARGET_NAME} TYPE)
+		if(NOT target_type STREQUAL "SHARED_LIBRARY")
+			return()
+		endif()
+
+		set(exp_file "$<TARGET_PROPERTY:${TARGET_NAME},BINARY_DIR>/${TARGET_NAME}.exp")
+		omr_process_template(
+			"${omr_SOURCE_DIR}/cmake/modules/platform/toolcfg/xlc_exports.exp.in"
+			"${exp_file}"
+		)
+		set_property(TARGET ${TARGET_NAME} APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-bE:${TARGET_NAME}.exp")
+	endfunction()
+
+	function(_omr_toolchain_separate_debug_symbols tgt)
+		set(exe_file "$<TARGET_FILE:${tgt}>")
+		omr_get_target_output_genex(${tgt} output_name)
+		set(dbg_file "${output_name}${OMR_DEBUG_INFO_OUTPUT_EXTENSION}")
+		add_custom_command(
+			TARGET "${tgt}"
+			POST_BUILD
+			COMMAND "${CMAKE_COMMAND}" -E copy ${exe_file} ${dbg_file}
+			COMMAND "${CMAKE_STRIP}" -X32_64 -t ${exe_file}
+		)
+		set_target_properties(${tgt} PROPERTIES OMR_DEBUG_FILE "${dbg_file}")
+	endfunction()
+endif()


### PR DESCRIPTION
Adds the initial set of changes to support compilation with Open XL on z/OS. This will define the alternative flags and configuration that needs to be used by the wyvern compiler while running on z/OS.

(This is one part of the multiple changes added for supporting Open XL compilation on OMR)