### PR TITLE
Remove obsolete AlignTLHAlloc TR::Node flag

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -7564,26 +7564,6 @@ OMR::Node::setIsBigDecimalLoad()
    _flags.set(bigDecimal_load);
    }
 
-
-
-bool
-OMR::Node::shouldAlignTLHAlloc()
-   {
-   TR_ASSERT(self()->getOpCodeValue() == TR::New, "Opcode value must be TR::New");
-   return _flags.testAny(alignTLHAlloc);
-   }
-
-void
-OMR::Node::setAlignTLHAlloc(bool v)
-   {
-   TR::Compilation * c = TR::comp();
-   TR_ASSERT(self()->getOpCodeValue() == TR::New, "Opcode value must be TR::New");
-   if (performNodeTransformation2(c, "O^O NODE FLAGS: Setting align on TLH flag on node %p to %d\n", self(), v))
-      _flags.set(alignTLHAlloc, v);
-   }
-
-
-
 bool
 OMR::Node::isCopyToNewVirtualRegister()
    {

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1533,10 +1533,6 @@ public:
    bool isLoadAndTest()          { return _flags.testAny(loadAndTest); }
    void setIsLoadAndTest(bool v) { _flags.set(loadAndTest, v); }
 
-   // Flag for TR::New
-   bool shouldAlignTLHAlloc();
-   void setAlignTLHAlloc(bool v);
-
    // Flag used by TR_PassThrough
    bool isCopyToNewVirtualRegister();
    void setCopyToNewVirtualRegister(bool v = true);
@@ -2045,10 +2041,7 @@ protected:
       // Flag used by iload, iloadi, lload, lloadi, aload, aloadi
       loadAndTest                           = 0x00008000,
 
-      // Flag used by TR::New when the codegen supports
-      // alignment on the TLH when allocating the object
-      //
-      alignTLHAlloc                         = 0x00002000,
+      // Available                          = 0x00002000,  // AVAILABLE FOR USE
 
       // Flag used by TR_PassThrough
       copyToNewVirtualRegister              = 0x00001000,


### PR DESCRIPTION
No uses in OMR or any downstream project.