### PR TITLE
Fix OpenXL Warnings

### DIFF
--- a/compiler/optimizer/OMRCFGSimplifier.cpp
+++ b/compiler/optimizer/OMRCFGSimplifier.cpp
@@ -931,7 +931,7 @@ bool OMR::CFGSimplifier::simplifySimpleStore(bool needToDuplicateTree)
    if (trace())
       traceMsg(comp(), "End simplifySimpleStore. New select node is n%dn\n", select->getGlobalIndex());
 
-   TR::Block *dest;
+   TR::Block *dest = NULL;
    if (diamond) {
       dest = toBlock(_next1->getSuccessors().front()->getTo());
       _cfg->addEdge(_block, dest);

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -1890,7 +1890,7 @@ static TR::Node *intDemoteSimplifier(TR::Node * node, TR::Block * block, TR::Sim
    //    /     \
    // subtree  lconst 22
    //
-   int64_t andVal;
+   int64_t andVal = 0;
    switch (targetSize)
       {
       case 1: andVal = 0xFF; break;
@@ -3356,7 +3356,7 @@ TR::Node *getQuotientUsingMagicNumberMultiply(TR::Node *node, TR::Block *block, 
    TR::Node * firstChild = node->getFirstChild(), * secondChild = node->getSecondChild();
 
    // the node we'll create and return to the caller
-   TR::Node * replacementNode;
+   TR::Node * replacementNode = NULL;
 
    if(node->getOpCodeValue() == TR::idiv || node->getOpCodeValue() == TR::irem)
       {

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -5084,7 +5084,8 @@ void TR_Debug::setupDebugger(void *startaddr, void *endaddr, bool before)
          Argv[0] = "/tr/zos-tools/bin/dbxattach";
          // for break_before, although command file is always the same,
          // we generate it dynamically for consistency with other platforms
-         if (cf = fopen(cfname, "wb+"))
+         cf = fopen(cfname, "wb+");
+         if (NULL != cf)
             {
             fprintf(cf, "set $unsafebps\n");
             fprintf(cf, "set $unsafegoto\n");
@@ -5115,7 +5116,8 @@ void TR_Debug::setupDebugger(void *startaddr, void *endaddr, bool before)
             fclose(cf);
             }
          // check for dbx that cfname file could be read (dbx does not do this check)
-         if (cf = fopen(cfname, "r"))
+         cf = fopen(cfname, "r");
+         if (NULL != cf)
             {
             struct inheritance inh = { 0 }; /* use all the default inheritance stuff */
             int fdCount = 0; /* inherit all file descriptors from parent */

--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -1226,7 +1226,8 @@ genericLongShiftSingle(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCode::
             }
          else if (firstChild->getOpCodeValue() == TR::land && firstChild->getReferenceCount() == 1)
             {
-            if (trgReg = TR::TreeEvaluator::tryToReplaceShiftLandWithRotateInstruction(firstChild, cg, value, node->getOpCodeValue() == TR::lshl))
+            trgReg = TR::TreeEvaluator::tryToReplaceShiftLandWithRotateInstruction(firstChild, cg, value, node->getOpCodeValue() == TR::lshl);
+            if (NULL != trgReg)
                {
                node->setRegister(trgReg);
                cg->decReferenceCount(firstChild);
@@ -1240,7 +1241,8 @@ genericLongShiftSingle(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCode::
          // Generate RISBGN for (lshr + land) and (lushr + land) sequences
          if (firstChild->getOpCodeValue() == TR::land && firstChild->getReferenceCount() == 1)
             {
-            if (trgReg = TR::TreeEvaluator::tryToReplaceShiftLandWithRotateInstruction(firstChild, cg, -value, node->getOpCodeValue() == TR::lshr))
+            trgReg = TR::TreeEvaluator::tryToReplaceShiftLandWithRotateInstruction(firstChild, cg, -value, node->getOpCodeValue() == TR::lshr);
+            if (NULL != trgReg)
                {
                node->setRegister(trgReg);
                cg->decReferenceCount(firstChild);
@@ -3350,7 +3352,8 @@ OMR::Z::TreeEvaluator::iandEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Node * firstChild = node->getFirstChild();
    TR::Node * secondChild = node->getSecondChild();
 
-   if (targetRegister = genericRotateAndInsertHelper(node, cg))
+   targetRegister = genericRotateAndInsertHelper(node, cg);
+   if (NULL != targetRegister)
       {
       node->setRegister(targetRegister);
 
@@ -3501,7 +3504,8 @@ OMR::Z::TreeEvaluator::lorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
    // See if rotate-left can be used
    //
-   if (targetRegister = genericRotateLeft(node, cg))
+   targetRegister = genericRotateLeft(node, cg);
+   if (NULL != targetRegister)
       {
       node->setRegister(targetRegister);
 
@@ -3604,7 +3608,8 @@ OMR::Z::TreeEvaluator::lxorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
    // See if rotate-left can be used
    //
-   if (targetRegister = genericRotateLeft(node, cg))
+   targetRegister = genericRotateLeft(node, cg);
+   if (NULL != targetRegister)
       {
       node->setRegister(targetRegister);
 

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -743,6 +743,8 @@ OMR::Z::TreeEvaluator::returnEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       case TR::Return:
          comp->setReturnInfo(TR_VoidReturn);
          break;
+      default:
+         break;
       }
 
    TR::Instruction * inst = generateS390PseudoInstruction(cg, TR::InstOpCode::retn, node, dependencies);

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -2112,7 +2112,8 @@ OMR::Z::Machine::findBestFreeRegister(TR::Instruction   *currentInstruction,
          }
       else
          {
-         if (bestRegister = self()->findBestLegalEvenRegister(availRegMask))
+         bestRegister = self()->findBestLegalEvenRegister(availRegMask);
+         if (NULL != bestRegister)
             // Set the pair's sibling to a high weight so that assignment to this real reg is unlikely
             {
             _registerFile[toRealRegister(bestRegister)->getRegisterNumber() + 1]->setWeight(S390_REGISTER_PAIR_SIBLING);
@@ -2161,7 +2162,8 @@ OMR::Z::Machine::findBestFreeRegister(TR::Instruction   *currentInstruction,
          }
       else
          {
-         if (bestRegister = self()->findBestLegalOddRegister(availRegMask))
+         bestRegister = self()->findBestLegalOddRegister(availRegMask);
+         if (NULL != bestRegister)
             // Set the pair's sibling to a high weight so that assignment to this real reg is unlikely
             {
             _registerFile[toRealRegister(bestRegister)->getRegisterNumber() - 1]->setWeight(S390_REGISTER_PAIR_SIBLING);
@@ -2200,7 +2202,8 @@ OMR::Z::Machine::findBestFreeRegister(TR::Instruction   *currentInstruction,
          }
       else
          {
-         if (bestRegister = self()->findBestLegalSiblingFPRegister(true,availRegMask))
+         bestRegister = self()->findBestLegalSiblingFPRegister(true,availRegMask);
+         if (NULL != bestRegister)
             // Set the pair's sibling to a high weight so that assignment to this real reg is unlikely
             {
             _registerFile[toRealRegister(bestRegister)->getRegisterNumber() + 2]->setWeight(S390_REGISTER_PAIR_SIBLING);
@@ -2239,7 +2242,8 @@ OMR::Z::Machine::findBestFreeRegister(TR::Instruction   *currentInstruction,
          }
       else
          {
-         if (bestRegister = self()->findBestLegalSiblingFPRegister(false,availRegMask))
+         bestRegister = self()->findBestLegalSiblingFPRegister(false,availRegMask);
+         if (NULL != bestRegister)
             // Set the pair's sibling to a high weight so that assignment to this real reg is unlikely
             {
             _registerFile[toRealRegister(bestRegister)->getRegisterNumber() - 2]->setWeight(S390_REGISTER_PAIR_SIBLING);
@@ -3219,7 +3223,8 @@ OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction                       
                // to prevent exception in findBestSwapRegister
                currentTargetVirtual->setAssignedRegister(targetRegister);
 
-            if (reg = self()->findBestSwapRegister(virtualRegister, currentTargetVirtual))
+            reg = self()->findBestSwapRegister(virtualRegister, currentTargetVirtual);
+            if (NULL != reg)
                {
                spareReg = reg;
                }

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -153,6 +153,8 @@ OMR::Z::Machine::registerCopy(TR::CodeGenerator* cg,
       case TR_VRF:
          cursor = generateVRRaInstruction(cg, TR::InstOpCode::VLR, node, targetReg, sourceReg, precedingInstruction);
          break;
+      default:
+         break;
       }
 
    cg->traceRAInstruction(cursor);
@@ -2474,6 +2476,8 @@ OMR::Z::Machine::freeBestRegister(TR::Instruction * currentInstruction, TR::Regi
          maskI = first = TR::RealRegister::FirstVRF;
          last = TR::RealRegister::LastVRF;
          break;
+      default:
+         break;
       }
 
    int32_t preference = 0, pref_favored = 0;
@@ -2669,6 +2673,8 @@ OMR::Z::Machine::spillRegister(TR::Instruction * currentInstruction, TR::Registe
 
        opCode = TR::InstOpCode::VL;
        break;
+      default:
+         break;
      }
 
    TR::MemoryReference * tempMR = generateS390MemoryReference(currentNode, location->getSymbolReference(), self()->cg());
@@ -2841,6 +2847,8 @@ OMR::Z::Machine::reverseSpillState(TR::Instruction      *currentInstruction,
       case TR_VRF:
          dataSize = 16;
          opCode = TR::InstOpCode::VST;
+         break;
+      default:
          break;
       }
 


### PR DESCRIPTION
Suppresses warnings when building on OpenXL

Warnings:
- uninitialized variables
- enum values not handled in switch
- Assignment inside if statement condition
https://hyc-runtimes-jenkins.swg-devops.com/job/jvm.29.personal/34234/