### PR TITLE
Assert dstObj in arraycopyEval is not a dataAddrPtr in P/AArch64

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -7576,6 +7576,11 @@ OMR::ARM64::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::CodeGenerator 
       srcAddrNode = node->getChild(2);
       dstAddrNode = node->getChild(3);
       lengthNode = node->getChild(4);
+#if defined(OMR_GC_SPARSE_HEAP_ALLOCATION)
+      if (TR::Compiler->om.isOffHeapAllocationEnabled())
+         // For correct card-marking calculation, the dstObjNode should be the baseObj not the dataAddrPointer
+         TR_ASSERT_FATAL(!dstObjNode->isDataAddrPointer(), "The dstObjNode child of arraycopy cannot be a dataAddrPointer");
+#endif /* defined(OMR_GC_SPARSE_HEAP_ALLOCATION) */
       }
 
    stopUsingCopyReg1 = stopUsingCopyReg(srcObjNode, srcObjReg, cg);

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -5989,6 +5989,11 @@ TR::Register *OMR::Power::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::
       srcAddrNode = node->getChild(2);
       dstAddrNode = node->getChild(3);
       lengthNode = node->getChild(4);
+#if defined(OMR_GC_SPARSE_HEAP_ALLOCATION)
+      if (TR::Compiler->om.isOffHeapAllocationEnabled())
+         // For correct card-marking calculation, the dstObjNode should be the baseObj not the dataAddrPointer
+         TR_ASSERT_FATAL(!dstObjNode->isDataAddrPointer(), "The dstObjNode child of arraycopy cannot be a dataAddrPointer");
+#endif /* defined(OMR_GC_SPARSE_HEAP_ALLOCATION) */
       }
 
    stopUsingCopyReg1 = TR::TreeEvaluator::stopUsingCopyReg(srcObjNode, srcObjReg, cg);


### PR DESCRIPTION
For OffHeap, the arraycopy transformations uses the correct base object as the dstObj node, instead of the dataAddrPtr load. 
To ensure correctness this PR adds an asserts that checks that the dstObj is not a dataAddrPtr.

```
Valid:
n60n        arraycopy  java/lang/System.arraycopy(Ljava/lang/Object;ILjava/lang/Object;II)V[#405  unresolved notAccessed static Method] [flags 0x400 0x0 ] (Unsigned forwardArrayCopy noArra>
n58n          aload  <parm 0 [Ljava/lang/Object;>[#403  Parm]                          
n59n          aload  <parm 1 [Ljava/lang/Object;>[#404  Parm]                            
n54n          aloadi  <contiguousArrayDataAddrFieldSymbol>[#352  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [    0x78f0fb0e00a0] bci=[-1,0,20] rc=1 vc=33 vn=- li=- udi=- nc=1 fl>
n55n            aload  <parm 0 [Ljava/lang/Object;>[#403  Parm]                
n56n          aloadi  <contiguousArrayDataAddrFieldSymbol>[#352  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [    0x78f0fb0e0140] bci=[-1,2,20] rc=1 vc=33 vn=- li=- udi=- nc=1 fl>
n57n            aload  <parm 1 [Ljava/lang/Object;>[#404  Parm]                         
n53n          lconst 8 (highWordZero X!=0 X>=0 cannotOverflow )             

Not-Valid:
n60n        arraycopy  java/lang/System.arraycopy(Ljava/lang/Object;ILjava/lang/Object;II)V[#405  unresolved notAccessed static Method] [flags 0x400 0x0 ] (Unsigned forwardArrayCopy noArra>
n58n          aload  <parm 0 [Ljava/lang/Object;>[#403  Parm]       
n62n          aloadi  <contiguousArrayDataAddrFieldSymbol>[#352  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [    0x78f0fb0e00a0] bci=[-1,0,20] rc=1 vc=33 vn=- li=- udi=- nc=1 fl>                   
n59n            aload  <parm 1 [Ljava/lang/Object;>[#404  Parm]                            
n54n          aloadi  <contiguousArrayDataAddrFieldSymbol>[#352  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [    0x78f0fb0e00a0] bci=[-1,0,20] rc=1 vc=33 vn=- li=- udi=- nc=1 fl>
n55n            aload  <parm 0 [Ljava/lang/Object;>[#403  Parm]                
n56n          aloadi  <contiguousArrayDataAddrFieldSymbol>[#352  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [    0x78f0fb0e0140] bci=[-1,2,20] rc=1 vc=33 vn=- li=- udi=- nc=1 fl>
n57n            aload  <parm 1 [Ljava/lang/Object;>[#404  Parm]                         
n53n          lconst 8 (highWordZero X!=0 X>=0 cannotOverflow )      
```

Reason being the writeBarrier code assumes the dstObj node being the base object and uses that for card-dirtying address calculation.

Following: eclipse-openj9/openj9#20264
X/Z in OpenJ9: https://github.com/eclipse-openj9/openj9/pull/20480