### PR TITLE
Accelerate Unsafe CAS Intrinsics on Aarch64

### DIFF
--- a/compiler/compile/OMRMethod.cpp
+++ b/compiler/compile/OMRMethod.cpp
@@ -168,14 +168,14 @@ OMR::Method::getParameterIterator(TR::Compilation&, TR_ResolvedMethod *)
    }
 
 bool
-OMR::Method::isUnsafeCAS(TR::Compilation *comp)
+OMR::Method::isUnsafeCAS()
    {
    TR_UNIMPLEMENTED();
    return false;
    }
 
 bool
-OMR::Method::isUnsafeWithObjectArg(TR::Compilation *comp)
+OMR::Method::isUnsafeWithObjectArg()
    {
    TR_UNIMPLEMENTED();
    return false;

--- a/compiler/compile/OMRMethod.hpp
+++ b/compiler/compile/OMRMethod.hpp
@@ -149,8 +149,8 @@ class Method
    virtual uint32_t numberOfExplicitParameters();
    virtual bool isArchetypeSpecimen(){ return false; }
    virtual void setArchetypeSpecimen(bool b = true);
-   virtual bool isUnsafeWithObjectArg(TR::Compilation * = NULL);
-   virtual bool isUnsafeCAS(TR::Compilation * = NULL);
+   virtual bool isUnsafeWithObjectArg();
+   virtual bool isUnsafeCAS();
    virtual bool isFinalInObject();
 
 

--- a/compiler/compile/ResolvedMethod.cpp
+++ b/compiler/compile/ResolvedMethod.cpp
@@ -330,7 +330,6 @@ bool         TR_ResolvedMethod::isSameMethod(TR_ResolvedMethod *)          { TR_
 bool         TR_ResolvedMethod::isNewInstanceImplThunk()                   { TR_UNIMPLEMENTED(); return false; }
 bool         TR_ResolvedMethod::isJNINative()                              { TR_UNIMPLEMENTED(); return false; }
 bool         TR_ResolvedMethod::isJITInternalNative()                      { TR_UNIMPLEMENTED(); return false; }
-//bool         TR_ResolvedMethod::isUnsafeWithObjectArg(TR::Compilation *)    { TR_UNIMPLEMENTED(); return false; }
 void *       TR_ResolvedMethod::resolvedMethodAddress()                    { TR_UNIMPLEMENTED(); return 0; }
 void *       TR_ResolvedMethod::startAddressForJittedMethod()              { TR_UNIMPLEMENTED(); return 0; }
 void *       TR_ResolvedMethod::startAddressForJNIMethod(TR::Compilation *) { TR_UNIMPLEMENTED(); return 0; }

--- a/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
+++ b/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
@@ -435,15 +435,11 @@ bool TR_RedundantAsyncCheckRemoval::callDoesAnImplicitAsyncCheck(TR::Node *callN
    if (symbol->isNative() &&
        ((symbol->getRecognizedMethod()==TR::sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z) ||
        (symbol->getRecognizedMethod()==TR::sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z) ||
-       (symbol->getRecognizedMethod()==TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z)))
-      return false;
-
-   if (symbol->isNative() &&
-       (comp()->target().cpu.isPower() || comp()->target().cpu.isX86() || comp()->target().cpu.isZ()) &&
-       ((symbol->getRecognizedMethod()==TR::jdk_internal_misc_Unsafe_compareAndExchangeInt) ||
-        (symbol->getRecognizedMethod()==TR::jdk_internal_misc_Unsafe_compareAndExchangeLong) ||
-        (symbol->getRecognizedMethod()==TR::jdk_internal_misc_Unsafe_compareAndExchangeObject) ||
-        (symbol->getRecognizedMethod()==TR::jdk_internal_misc_Unsafe_compareAndExchangeReference)))
+       (symbol->getRecognizedMethod()==TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z) ||
+       (symbol->getRecognizedMethod()==TR::jdk_internal_misc_Unsafe_compareAndExchangeInt) ||
+       (symbol->getRecognizedMethod()==TR::jdk_internal_misc_Unsafe_compareAndExchangeLong) ||
+       (symbol->getRecognizedMethod()==TR::jdk_internal_misc_Unsafe_compareAndExchangeObject) ||
+       (symbol->getRecognizedMethod()==TR::jdk_internal_misc_Unsafe_compareAndExchangeReference)))
       return false;
 #endif
    return true;


### PR DESCRIPTION
Support for acceleration of `compareAndExchange[Int|Long|Reference]` has been extended to Arm. As a result, the check in
`callDoesAnImplicitAsyncCheck` needs to be updated as well.

Cleans up `isUnsafeCAS` and `isUnsafeWithObjectArg` to remove unused comp parameter.

Needs to be check in with:
https://github.com/eclipse-openj9/openj9/pull/20432
Due to the changes to the parameters of `isUnsafeCAS` and `isUnsafeWithObjectArg`.