### PR TITLE
Fix loop strider reassociation and hoisting logic for off-heap

### DIFF
--- a/compiler/optimizer/OMRTransformUtil.cpp
+++ b/compiler/optimizer/OMRTransformUtil.cpp
@@ -454,7 +454,7 @@ OMR::TransformUtil::generateDataAddrLoadTrees(TR::Compilation *comp, TR::Node *a
 #endif /* OMR_GC_SPARSE_HEAP_ALLOCATION */
 
 TR::Node *
-OMR::TransformUtil::generateArrayElementAddressTrees(TR::Compilation *comp, TR::Node *arrayNode, TR::Node *offsetNode)
+OMR::TransformUtil::generateArrayElementAddressTrees(TR::Compilation *comp, TR::Node *arrayNode, TR::Node *offsetNode, TR::Node *originatingByteCodeNode)
    {
    TR::Node *arrayAddressNode = NULL;
    TR::Node *totalOffsetNode = NULL;
@@ -468,24 +468,24 @@ OMR::TransformUtil::generateArrayElementAddressTrees(TR::Compilation *comp, TR::
       {
       arrayAddressNode = generateDataAddrLoadTrees(comp, arrayNode);
       if (offsetNode)
-         arrayAddressNode = TR::Node::create(TR::aladd, 2, arrayAddressNode, offsetNode);
+         arrayAddressNode = TR::Node::create(originatingByteCodeNode, TR::aladd, 2, arrayAddressNode, offsetNode);
       }
    else if (comp->target().is64Bit())
 #else
    if (comp->target().is64Bit())
 #endif /* OMR_GC_SPARSE_HEAP_ALLOCATION */
       {
-      totalOffsetNode = TR::Node::lconst(TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
+      totalOffsetNode = TR::Node::lconst(originatingByteCodeNode, TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
       if (offsetNode)
-         totalOffsetNode = TR::Node::create(TR::ladd, 2, offsetNode, totalOffsetNode);
-      arrayAddressNode = TR::Node::create(TR::aladd, 2, arrayNode, totalOffsetNode);
+         totalOffsetNode = TR::Node::create(originatingByteCodeNode, TR::ladd, 2, offsetNode, totalOffsetNode);
+      arrayAddressNode = TR::Node::create(originatingByteCodeNode, TR::aladd, 2, arrayNode, totalOffsetNode);
       }
    else
       {
-      totalOffsetNode = TR::Node::iconst(static_cast<int32_t>(TR::Compiler->om.contiguousArrayHeaderSizeInBytes()));
+      totalOffsetNode = TR::Node::iconst(originatingByteCodeNode, static_cast<int32_t>(TR::Compiler->om.contiguousArrayHeaderSizeInBytes()));
       if (offsetNode)
-         totalOffsetNode = TR::Node::create(TR::iadd, 2, offsetNode, totalOffsetNode);
-      arrayAddressNode = TR::Node::create(TR::aiadd, 2, arrayNode, totalOffsetNode);
+         totalOffsetNode = TR::Node::create(originatingByteCodeNode, TR::iadd, 2, offsetNode, totalOffsetNode);
+      arrayAddressNode = TR::Node::create(originatingByteCodeNode, TR::aiadd, 2, arrayNode, totalOffsetNode);
       }
 
    return arrayAddressNode;

--- a/compiler/optimizer/OMRTransformUtil.hpp
+++ b/compiler/optimizer/OMRTransformUtil.hpp
@@ -226,7 +226,8 @@ class OMR_EXTENSIBLE TransformUtil
    static TR::Node *generateArrayElementAddressTrees(
       TR::Compilation *comp,
       TR::Node *arrayNode,
-      TR::Node *offsetNode = NULL);
+      TR::Node *offsetNode = NULL,
+      TR::Node *originatingByteCodeNode = NULL);
 
    /**
     * \brief


### PR DESCRIPTION
To prevent double hoisting of dataAddr pointer, limit reassociation and hoisting criteria to include only those that have dataAddr pointer as their first child.

The offset node doesn't rely on array header size when using dataAddr pointer to get to data elements so no need for reassociation; we can use the original offset node with newly hoisted array load node.