### PR TITLE
Support opaque and acquire/release memory semantics

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -6244,7 +6244,7 @@ TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, 
    bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
    bool lazyVolatile = false;
    if (node->getSymbolReference()->getSymbol()->isShadow() &&
-       node->getSymbolReference()->getSymbol()->isOrdered() && cg->comp()->target().isSMP())
+       node->getSymbolReference()->getSymbol()->isAcquireRelease() && cg->comp()->target().isSMP())
       {
       needSync = true;
       lazyVolatile = true;

--- a/compiler/arm/codegen/FPTreeEvaluator.cpp
+++ b/compiler/arm/codegen/FPTreeEvaluator.cpp
@@ -1202,7 +1202,8 @@ TR::Register *OMR::ARM::TreeEvaluator::floadEvaluator(TR::Node *node, TR::CodeGe
       trgReg = floatTrgReg;
       }
 
-   if (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
+   if (node->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() &&
+       cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
       generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? TR::InstOpCode::dmb_v6 : TR::InstOpCode::dmb, node);
       }
@@ -1249,7 +1250,8 @@ TR::Register *OMR::ARM::TreeEvaluator::dloadEvaluator(TR::Node *node, TR::CodeGe
       trgReg = doubleTrgReg;
       }
 
-   if (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
+   if (node->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() &&
+       cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
       generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? TR::InstOpCode::dmb_v6 : TR::InstOpCode::dmb, node);
       }
@@ -1264,7 +1266,8 @@ TR::Register *OMR::ARM::TreeEvaluator::fstoreEvaluator(TR::Node *node, TR::CodeG
    TR::Register *sourceReg = cg->evaluate(firstChild);
    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, 4, cg);
 
-   if (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
+   if (node->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() &&
+       cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
       generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? TR::InstOpCode::dmb_v6 : TR::InstOpCode::dmb, node);
       }
@@ -1320,7 +1323,8 @@ TR::Register *OMR::ARM::TreeEvaluator::dstoreEvaluator(TR::Node *node, TR::CodeG
    TR::Register *sourceReg = cg->evaluate(firstChild);
    bool  isUnresolved = node->getSymbolReference()->isUnresolved();
 
-   if (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
+   if (node->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() &&
+       cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
       generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? TR::InstOpCode::dmb_v6 : TR::InstOpCode::dmb, node);
       }
@@ -1391,7 +1395,8 @@ TR::Register *OMR::ARM::TreeEvaluator::fstoreiEvaluator(TR::Node *node, TR::Code
    TR::Register *sourceReg = cg->evaluate(secondChild);
    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, 4, cg);
 
-   if (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
+   if (node->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() &&
+       cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
       generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? TR::InstOpCode::dmb_v6 : TR::InstOpCode::dmb, node);
       }
@@ -1445,7 +1450,8 @@ TR::Register *OMR::ARM::TreeEvaluator::dstoreiEvaluator(TR::Node *node, TR::Code
    TR::Node *secondChild = node->getSecondChild();
    TR::Register *sourceReg = cg->evaluate(secondChild);
 
-   if (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
+   if (node->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() &&
+       cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
       generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? TR::InstOpCode::dmb_v6 : TR::InstOpCode::dmb, node);
       }
@@ -1882,7 +1888,7 @@ TR::Register *OMR::ARM::TreeEvaluator::i2fEvaluator(TR::Node *node, TR::CodeGene
       (firstChild->getOpCodeValue() == TR::iload || firstChild->getOpCodeValue() == TR::iloadi) &&
       (firstChild->getNumChildren() > 0) &&
       (firstChild->getFirstChild()->getNumChildren() == 1) &&
-      !(firstChild->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
+      !(firstChild->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() && cg->comp()->target().isSMP()))
       {
       // Coming from memory, last use. Use flds to save the move
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(firstChild, 4, cg);
@@ -1935,7 +1941,7 @@ TR::Register *OMR::ARM::TreeEvaluator::i2dEvaluator(TR::Node *node, TR::CodeGene
       (firstChild->getOpCodeValue() == TR::iload || firstChild->getOpCodeValue() == TR::iloadi) &&
       (firstChild->getNumChildren() > 0) &&
       (firstChild->getFirstChild()->getNumChildren() == 1) &&
-      !(firstChild->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
+      !(firstChild->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() && cg->comp()->target().isSMP()))
       {
       // Coming from memory, last use
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(firstChild, 4, cg);
@@ -2007,7 +2013,7 @@ TR::Register *OMR::ARM::TreeEvaluator::f2dEvaluator(TR::Node *node, TR::CodeGene
       (firstChild->getOpCodeValue() == TR::fload || firstChild->getOpCodeValue() == TR::floadi) &&
       (firstChild->getNumChildren() > 0) &&
       (firstChild->getFirstChild()->getNumChildren() == 1) &&
-      !(firstChild->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
+      !(firstChild->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() && cg->comp()->target().isSMP()))
       {
       // Coming from memory, last use
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(firstChild, 4, cg);
@@ -2062,7 +2068,7 @@ TR::Register *OMR::ARM::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGene
       (firstChild->getOpCodeValue() == TR::fload || firstChild->getOpCodeValue() == TR::floadi) &&
       (firstChild->getNumChildren() > 0) &&
       (firstChild->getFirstChild()->getNumChildren() == 1) &&
-      !(firstChild->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
+      !(firstChild->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() && cg->comp()->target().isSMP()))
       {
       // Coming from memory, last use
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(firstChild, 4, cg);
@@ -2102,7 +2108,7 @@ TR::Register *OMR::ARM::TreeEvaluator::d2iEvaluator(TR::Node *node, TR::CodeGene
       (firstChild->getOpCodeValue() == TR::dload || firstChild->getOpCodeValue() == TR::dloadi) &&
       (firstChild->getNumChildren() > 0) &&
       (firstChild->getFirstChild()->getNumChildren() == 1) &&
-      !(firstChild->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
+      !(firstChild->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() && cg->comp()->target().isSMP()))
       {
       // Coming from memory, last use
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(firstChild, 4, cg);
@@ -2175,7 +2181,7 @@ TR::Register *OMR::ARM::TreeEvaluator::d2fEvaluator(TR::Node *node, TR::CodeGene
       (firstChild->getOpCodeValue() == TR::dload || firstChild->getOpCodeValue() == TR::dloadi) &&
       (firstChild->getNumChildren() > 0) &&
       (firstChild->getFirstChild()->getNumChildren() == 1) &&
-      !(firstChild->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
+      !(firstChild->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() && cg->comp()->target().isSMP()))
       {
       // Coming from memory, last use
       TR::Register *tempReg = cg->allocateRegister(TR_FPR);
@@ -3140,12 +3146,12 @@ TR::Register *OMR::ARM::TreeEvaluator::fRegStoreEvaluator(TR::Node *node, TR::Co
 
 TR::Register *OMR::ARM::TreeEvaluator::fmaxEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return NULL; 
+   return NULL;
    }
 
 TR::Register *OMR::ARM::TreeEvaluator::fminEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return NULL; 
+   return NULL;
    }
 
 #endif

--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -3221,7 +3221,7 @@ TR::Instruction *loadAddressConstant(TR::CodeGenerator *cg, TR::Node * node, int
 TR::Register *OMR::ARM::TreeEvaluator::iloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *tempReg;
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
+   bool needSync = node->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() && cg->comp()->target().isSMP();
 
    tempReg = cg->allocateRegister();
    if (node->getSymbolReference()->getSymbol()->isInternalPointer())
@@ -3326,7 +3326,7 @@ TR::Register *OMR::ARM::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGe
       }
 
    TR::Register *tempReg;
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
+   bool needSync = node->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() && cg->comp()->target().isSMP();
 
    if (!node->getSymbolReference()->getSymbol()->isInternalPointer())
       {
@@ -3370,7 +3370,7 @@ TR::Register *OMR::ARM::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::CodeGe
    TR::RegisterPair       *trgReg = cg->allocateRegisterPair(lowReg, highReg);
    TR::Compilation *comp = cg->comp();
    bool bigEndian = cg->comp()->target().cpu.isBigEndian();
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
+   bool needSync = (node->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() && cg->comp()->target().isSMP());
 
    if (needSync && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
@@ -3422,7 +3422,7 @@ TR::Register *OMR::ARM::TreeEvaluator::commonLoadEvaluator(TR::Node *node,  TR::
    {
    TR::Register *tempReg = node->setRegister(cg->allocateRegister());
    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, memSize, cg);
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
+   bool needSync = (node->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() && cg->comp()->target().isSMP());
    generateTrg1MemInstruction(cg, memToRegOp, node, tempReg, tempMR);
    if (needSync && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
@@ -3440,7 +3440,7 @@ TR::Register *OMR::ARM::TreeEvaluator::awrtbarEvaluator(TR::Node *node, TR::Code
    TR::Node                *firstChild = node->getFirstChild();
    TR::Register            *sourceRegister;
    bool killSource = false;
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
+   bool needSync = (node->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() && cg->comp()->target().isSMP());
 
    if (firstChild->getReferenceCount() > 1 && firstChild->getRegister() != NULL)
       {
@@ -3490,7 +3490,7 @@ TR::Register *OMR::ARM::TreeEvaluator::awrtbariEvaluator(TR::Node *node, TR::Cod
    TR::Node                *secondChild = node->getSecondChild();
    TR::Register            *sourceRegister;
    bool killSource = false;
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
+   bool needSync = (node->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() && cg->comp()->target().isSMP());
 
    /* comp->useCompressedPointers() is false for 32bit environment, leaving the compressed pointer support unimplemented. */
    if (secondChild->getReferenceCount() > 1 && secondChild->getRegister() != NULL)
@@ -3547,7 +3547,7 @@ TR::Register *OMR::ARM::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::CodeG
       valueChild = node->getFirstChild();
       }
    bool bigEndian = cg->comp()->target().cpu.isBigEndian();
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
+   bool needSync = (node->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() && cg->comp()->target().isSMP());
    TR::Register *valueReg = cg->evaluate(valueChild);
 
    if (needSync && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
@@ -3612,7 +3612,7 @@ TR::Register *OMR::ARM::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::CodeG
 TR::Register *OMR::ARM::TreeEvaluator::commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic memToRegOp, int32_t memSize, TR::CodeGenerator *cg)
    {
    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, memSize, cg);
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
+   const bool supportsDMB = (cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor);
    TR::Node *valueChild;
    if (node->getOpCode().isIndirect())
       {
@@ -3623,12 +3623,12 @@ TR::Register *OMR::ARM::TreeEvaluator::commonStoreEvaluator(TR::Node *node, TR::
       valueChild = node->getFirstChild();
       }
 
-   if (needSync && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
+   if (supportsDMB && node->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease())
       {
       generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? TR::InstOpCode::dmb_v6 : TR::InstOpCode::dmb_st, node);
       }
    generateMemSrc1Instruction(cg, memToRegOp, node, tempMR, cg->evaluate(valueChild));
-   if (needSync && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
+   if (supportsDMB && node->getSymbolReference()->getSymbol()->isVolatile())
       {
       generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? TR::InstOpCode::dmb_v6 : TR::InstOpCode::dmb, node);
       }

--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -102,8 +102,6 @@ OMR::SymbolReferenceTable::SymbolReferenceTable(size_t sizeHint, TR::Compilation
      _numInternalPointers(0),
      _ObjectNewInstanceImplSymRef(0),
      _knownObjectSymrefsByObjectIndex(comp->trMemory()),
-     _unsafeSymRefs(0),
-     _unsafeVolatileSymRefs(0),
      _availableAutos(comp->trMemory()),
      _vtableEntrySymbolRefs(comp->trMemory()),
      _classLoaderSymbolRefs(comp->trMemory()),
@@ -125,6 +123,8 @@ OMR::SymbolReferenceTable::SymbolReferenceTable(size_t sizeHint, TR::Compilation
       baseArray.element(i) = 0;
    _size_hint = sizeHint;
 
+   for (int i = 0; i < TR::Symbol::numberOfMemoryOrderings; i++)
+      _unsafeSymRefs[i] = NULL;
    }
 
 

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -948,8 +948,7 @@ class SymbolReferenceTable
 
    TR_Array<TR_BitVector *>            _knownObjectSymrefsByObjectIndex;
 
-   TR_Array<TR::SymbolReference *> *    _unsafeSymRefs;
-   TR_Array<TR::SymbolReference *> *    _unsafeVolatileSymRefs;
+   TR_Array<TR::SymbolReference *> *    _unsafeSymRefs[TR::Symbol::numberOfMemoryOrderings];
 
    List<TR::SymbolReference>            _availableAutos;
    List<TR::SymbolReference>            _vtableEntrySymbolRefs;

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -321,7 +321,7 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
             // (this is the same as before), or if we are unresolved and condy
             // (this is the extra condition added), we would return conservative aliases.
             if ((self()->isUnresolved() && (_symbol->isConstantDynamic() || !_symbol->isConstObjectRef())) ||
-	        _symbol->isVolatile() || self()->isLiteralPoolAddress() ||
+                !_symbol->isTransparent() || self()->isLiteralPoolAddress() ||
                 self()->isFromLiteralPool() || _symbol->isUnsafeShadowSymbol() ||
                 (_symbol->isArrayShadowSymbol() && comp->getMethodSymbol()->hasVeryRefinedAliasSets()))
                {
@@ -628,7 +628,7 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
          }
       case TR::Symbol::IsShadow:
          {
-         if ((self()->isUnresolved() && !_symbol->isConstObjectRef()) || _symbol->isVolatile() || self()->isLiteralPoolAddress() || self()->isFromLiteralPool() ||
+         if ((self()->isUnresolved() && !_symbol->isConstObjectRef()) || !_symbol->isTransparent() || self()->isLiteralPoolAddress() || self()->isFromLiteralPool() ||
              (_symbol->isUnsafeShadowSymbol() && !self()->reallySharesSymbol()))
             {
             return &comp->getSymRefTab()->aliasBuilder.defaultMethodDefAliasesWithoutImmutable();
@@ -781,7 +781,7 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
          // (this is the same as before), or if we are unresolved and condy
          // (this is the extra condition added), we would return conservative aliases.
          if ((self()->isUnresolved() && (_symbol->isConstantDynamic() || !_symbol->isConstObjectRef())) ||
-	     self()->isLiteralPoolAddress() || self()->isFromLiteralPool() || _symbol->isVolatile())
+             self()->isLiteralPoolAddress() || self()->isFromLiteralPool() || !_symbol->isTransparent())
             {
             return &comp->getSymRefTab()->aliasBuilder.defaultMethodDefAliases();
             }
@@ -851,7 +851,7 @@ OMR::SymbolReference::sharesSymbol(bool includingGCSafePoint)
          // (this is the same as before), or if we are unresolved and condy
          // (this is the extra condition added), we would return conservative aliases.
          if ((self()->isUnresolved() && (_symbol->isConstantDynamic() || !_symbol->isConstObjectRef())) ||
-	       _symbol->isVolatile() || self()->isLiteralPoolAddress() ||
+             !_symbol->isTransparent() || self()->isLiteralPoolAddress() ||
                self()->isFromLiteralPool() || _symbol->isUnsafeShadowSymbol() ||
                (_symbol->isArrayShadowSymbol() && c->getMethodSymbol()->hasVeryRefinedAliasSets()))
             {
@@ -1062,7 +1062,7 @@ OMR::SymbolReference::storeCanBeRemoved()
    TR::Compilation *comp = TR::comp();
    TR::Symbol * s = self()->getSymbol();
 
-   return !s->isVolatile() &&
+   return s->isTransparent() &&
      (((s->getDataType() != TR::Double) && (s->getDataType() != TR::Float)) ||
            comp->cg()->getSupportsJavaFloatSemantics() ||
            (self()->isTemporary(comp) && !s->behaveLikeNonTemp()));

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1955,13 +1955,13 @@ OMR::Node::hasUnresolvedSymbolReference()
    }
 
 /**
- * Does this node have a volatile symbol reference by any chance?
+ * Does this node have a non-transparent symbol reference by any chance?
  */
 bool
-OMR::Node::mightHaveVolatileSymbolReference()
+OMR::Node::mightHaveNonTransparentSymbolReference()
    {
    if (self()->getOpCode().hasSymbolReference())
-      return self()->getSymbolReference()->maybeVolatile();
+      return self()->getSymbolReference()->maybeNonTransparent();
 
    return false;
    }
@@ -2651,7 +2651,7 @@ OMR::Node::mayModifyValue(TR::SymbolReference * symRef)
    TR::Symbol * symbol = symRef->getSymbol();
    if (node->getOpCode().isCall() ||
        node->getOpCodeValue() == TR::monexit ||
-       (node->getOpCode().hasSymbolReference() && node->getSymbol()->isVolatile()) ||
+       (node->getOpCode().hasSymbolReference() && !node->getSymbol()->isTransparent()) ||
        symbolIsUnresolved)
       {
       // assume the call kills everything except for auto, parms and const statics
@@ -2712,27 +2712,27 @@ OMR::Node::mayModifyValue(TR::SymbolReference * symRef)
 
 
 bool
-OMR::Node::performsVolatileAccess(vcount_t visitCount)
+OMR::Node::performsNonTransparentAccess(vcount_t visitCount)
    {
-   bool foundVolatile=false;
+   bool foundNonTransparent=false;
 
    self()->setVisitCount(visitCount);
 
    if (self()->getOpCode().hasSymbolReference())
       {
       TR::Symbol *sym = self()->getSymbol();
-      if (sym != NULL && sym->isVolatile())
-         foundVolatile=true;
+      if (sym != NULL && !sym->isTransparent())
+         foundNonTransparent=true;
       }
 
    for (int32_t c = 0; c < self()->getNumChildren(); c++)
       {
       TR::Node * child = self()->getChild(c);
       if (child->getVisitCount() != visitCount)
-         foundVolatile |= child->performsVolatileAccess(visitCount);
+         foundNonTransparent |= child->performsNonTransparentAccess(visitCount);
       }
 
-   return foundVolatile;
+   return foundNonTransparent;
    }
 
 

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -411,8 +411,8 @@ public:
    /// Does this node have an unresolved symbol reference?
    bool                   hasUnresolvedSymbolReference();
 
-   /// Does this node have a volatile symbol reference?
-   bool                   mightHaveVolatileSymbolReference();
+   /// Does this node have a non-transparent symbol reference by any chance?
+   bool                   mightHaveNonTransparentSymbolReference();
 
    /// Is this node the 'this' pointer?
    bool                   isThisPointer();
@@ -506,7 +506,8 @@ public:
    /// Returns true if the node kills the symbol reference
    bool                   mayModifyValue(TR::SymbolReference *);
 
-   bool                   performsVolatileAccess(vcount_t visitCount);
+   /// Returns true if the node performs a memory access with non-transparent memory semantics
+   bool                   performsNonTransparentAccess(vcount_t visitCount);
 
    bool                   uses64BitGPRs();
 

--- a/compiler/il/OMRNode_inlines.hpp
+++ b/compiler/il/OMRNode_inlines.hpp
@@ -165,7 +165,7 @@ OMR::Node::mayUse()
       TR_UseOnlyAliasSetInterface aliasSetInterface(self()->getSymbolReference());
       return aliasSetInterface;
       }
-   else 
+   else
       {
       //if there is no symbolreference, then return an empty aliseset
        TR_UseOnlyAliasSetInterface aliasSetInterface(NULL);
@@ -176,7 +176,7 @@ OMR::Node::mayUse()
 TR_UseDefAliasSetInterface
 OMR::Node::mayKill(bool gcSafe)
    {
-   if (self()->getOpCode().hasSymbolReference() && (self()->getOpCode().isLikeDef() || self()->mightHaveVolatileSymbolReference())) //we want the old behavior in these cases
+   if (self()->getOpCode().hasSymbolReference() && (self()->getOpCode().isLikeDef() || self()->mightHaveNonTransparentSymbolReference())) //we want the old behavior in these cases
       {
       bool shares_symbol = self()->getSymbolReference()->sharesSymbol(gcSafe);
       TR_UseDefAliasSetInterface aliasSetInterface(shares_symbol, self()->getSymbolReference(), self()->getOpCode().isCallDirect(), gcSafe);

--- a/compiler/il/OMRSymbolReference.cpp
+++ b/compiler/il/OMRSymbolReference.cpp
@@ -183,9 +183,9 @@ OMR::SymbolReference::getOwningMethod(TR::Compilation * c)
    }
 
 bool
-OMR::SymbolReference::maybeVolatile()
+OMR::SymbolReference::maybeNonTransparent()
    {
-   if (_symbol->isVolatile())
+   if (!_symbol->isTransparent())
       return true;
 
    if (self()->isUnresolved()

--- a/compiler/il/OMRSymbolReference.hpp
+++ b/compiler/il/OMRSymbolReference.hpp
@@ -139,7 +139,7 @@ public:
    TR_ResolvedMethod *        getOwningMethod(TR::Compilation * c);
    TR::ResolvedMethodSymbol * getOwningMethodSymbol(TR::Compilation *c);
 
-   bool maybeVolatile();
+   bool maybeNonTransparent();
 
    // New CS2 Interface
    TR_UseOnlyAliasSetInterface getUseonlyAliases();

--- a/compiler/il/OMRSymbol_inlines.hpp
+++ b/compiler/il/OMRSymbol_inlines.hpp
@@ -491,6 +491,122 @@ OMR::Symbol::isMemoryTypeShadowSymbol()
    return self()->isShadow() && _flags.testAny(MemoryTypeShadow);
    }
 
+const char *
+OMR::Symbol::getMemoryOrderingName(OMR::Symbol::MemoryOrdering ordering)
+   {
+   switch (ordering)
+      {
+      case MemoryOrdering::Transparent: return "transparent";
+      case MemoryOrdering::Opaque: return "opaque";
+      case MemoryOrdering::AcquireRelease: return "acquire/release";
+      case MemoryOrdering::Volatile: return "volatile";
+
+      default:
+         TR_ASSERT_FATAL(false, "Unrecognized memory ordering type");
+         return NULL;
+      }
+   }
+
+void
+OMR::Symbol::setMemoryOrdering(OMR::Symbol::MemoryOrdering ordering)
+   {
+   switch (ordering)
+      {
+      case MemoryOrdering::Transparent:
+         _flags.setValue(MemoryOrderingMask, Transparent);
+         break;
+      case MemoryOrdering::Opaque:
+         _flags.setValue(MemoryOrderingMask, Opaque);
+         break;
+      case MemoryOrdering::AcquireRelease:
+         _flags.setValue(MemoryOrderingMask, AcquireRelease);
+         break;
+      case MemoryOrdering::Volatile:
+         _flags.setValue(MemoryOrderingMask, Volatile);
+         break;
+
+      default:
+         TR_ASSERT_FATAL(false, "Unrecognized memory access ordering type");
+         break;
+      }
+   }
+
+OMR::Symbol::MemoryOrdering
+OMR::Symbol::getMemoryOrdering()
+   {
+   switch (_flags.getValue(MemoryOrderingMask))
+      {
+      case Transparent: return MemoryOrdering::Transparent;
+      case Opaque: return MemoryOrdering::Opaque;
+      case AcquireRelease: return MemoryOrdering::AcquireRelease;
+      case Volatile: return MemoryOrdering::Volatile;
+
+      default:
+         TR_ASSERT_FATAL(false, "This should be unreachable");
+         return MemoryOrdering::Transparent;
+      }
+   }
+
+void
+OMR::Symbol::setTransparent()
+   {
+   _flags.setValue(MemoryOrderingMask, Transparent);
+   }
+
+bool
+OMR::Symbol::isTransparent()
+   {
+   return _flags.testValue(MemoryOrderingMask, Transparent);
+   }
+
+void
+OMR::Symbol::setOpaque()
+   {
+   _flags.setValue(MemoryOrderingMask, Opaque);
+   }
+
+bool
+OMR::Symbol::isOpaque()
+   {
+   return _flags.testValue(MemoryOrderingMask, Opaque);
+   }
+
+bool
+OMR::Symbol::isAtLeastOrStrongerThanOpaque()
+   {
+   return _flags.getValue(MemoryOrderingMask) >= Opaque;
+   }
+
+void
+OMR::Symbol::setAcquireRelease()
+   {
+   _flags.setValue(MemoryOrderingMask, AcquireRelease);
+   }
+
+bool
+OMR::Symbol::isAcquireRelease()
+   {
+   return _flags.testValue(MemoryOrderingMask, AcquireRelease);
+   }
+
+bool
+OMR::Symbol::isAtLeastOrStrongerThanAcquireRelease()
+   {
+   return _flags.getValue(MemoryOrderingMask) >= AcquireRelease;
+   }
+
+void
+OMR::Symbol::setVolatile()
+   {
+   _flags.setValue(MemoryOrderingMask, Volatile);
+   }
+
+bool
+OMR::Symbol::isVolatile()
+   {
+   return _flags.testValue(MemoryOrderingMask, Volatile);
+   }
+
 void
 OMR::Symbol::setStartOfColdInstructionStream()
    {
@@ -749,12 +865,6 @@ bool
 OMR::Symbol::isRegularShadow()
    {
    return self()->isShadow() && !self()->isAutoField() && !self()->isParmField();
-   }
-
-bool
-OMR::Symbol::isSyncVolatile()
-   {
-   return self()->isVolatile();
    }
 
 void

--- a/compiler/optimizer/FieldPrivatizer.cpp
+++ b/compiler/optimizer/FieldPrivatizer.cpp
@@ -659,7 +659,7 @@ void TR_FieldPrivatizer::detectFieldsThatCannotBePrivatized(TR::Node *node, vcou
 
          if (canPrivatize &&
              !sym->isArrayShadowSymbol() &&
-             !sym->isVolatile() &&
+             sym->isTransparent() &&
              comp()->cg()->considerTypeForGRA(symRef) &&
              !_neverWritten->get(symRef->getReferenceNumber()) &&
              (opCode.isIndirect() ? subtreeIsInvariantInLoop(node->getFirstChild()) : true)  &&

--- a/compiler/optimizer/IsolatedStoreElimination.cpp
+++ b/compiler/optimizer/IsolatedStoreElimination.cpp
@@ -312,7 +312,7 @@ bool TR_IsolatedStoreElimination::canRemoveStoreNode(TR::Node *node)
    // operation that we do not want to remove.
    //
 
-   if (node->getSymbolReference()->getSymbol()->isVolatile())
+   if (!node->getSymbolReference()->getSymbol()->isTransparent())
       return false;
 
    if (node->dontEliminateStores())
@@ -1463,10 +1463,10 @@ TR_IsolatedStoreElimination::markNodesAndLocateSideEffectIn(TR::Node *node, vcou
        node->getOpCode().isReturn() ||
        node->getOpCode().isLoadReg() ||
        node->getOpCode().isStoreReg() ||
-       (node->getOpCode().hasSymbolReference() && node->getSymbolReference()->getSymbol()->isVolatile()) ||
+       (node->getOpCode().hasSymbolReference() && !node->getSymbolReference()->getSymbol()->isTransparent()) ||
        ((node->getOpCode().isStore() ||
          (node->getOpCode().hasSymbolReference() &&
-          node->getSymbolReference()->getSymbol()->isVolatile())) &&
+          !node->getSymbolReference()->getSymbol()->isTransparent())) &&
         (node->getSymbolReference()->getSymbol()->isShadow() ||
          node->getSymbolReference()->getSymbol()->isStatic()))
       )

--- a/compiler/optimizer/LocalAnalysis.cpp
+++ b/compiler/optimizer/LocalAnalysis.cpp
@@ -709,7 +709,7 @@ bool TR_LocalAnalysisInfo::isCallLike(TR::Node *node) {
 
    if (node->getOpCode().hasSymbolReference())
       {
-      if (node->getSymbolReference()->getSymbol()->isVolatile() ||
+      if (!node->getSymbolReference()->getSymbol()->isTransparent() ||
           (node->getSymbolReference()->getSymbol()->isMethodMetaData() &&
            !node->getSymbolReference()->getSymbol()->isImmutableField()))
          return true;

--- a/compiler/optimizer/LocalAnticipatability.cpp
+++ b/compiler/optimizer/LocalAnticipatability.cpp
@@ -905,7 +905,7 @@ void TR_LocalAnticipatability::updateUsesAndDefs(TR::Node *node, TR::Block *bloc
          }
 
       if ((opCode.isLoadVar() || (loadaddrAsLoad() && opCode.getOpCodeValue() == TR::loadaddr)) &&
-           !node->mightHaveVolatileSymbolReference())
+           !node->mightHaveNonTransparentSymbolReference())
          {
 #if FLEX_PRE
          node->mayKill(false, true).getAliasesAndUnionWith(*temp);

--- a/compiler/optimizer/LocalDeadStoreElimination.cpp
+++ b/compiler/optimizer/LocalDeadStoreElimination.cpp
@@ -259,7 +259,7 @@ void TR::LocalDeadStoreElimination::transformBlock(TR::TreeTop * entryTree, TR::
             if (!nonRemovableStore &&
                 (seenIdentityStore ||                                 // 1)
                  (deadSymbolReferences.get(symRefNum) &&          // 2)
-                  !symRef->getSymbol()->isVolatile()  &&
+                  symRef->getSymbol()->isTransparent()  &&
                   ((_blockContainsReturn              &&              //   a)
                     (symRef->getSymbol()->isAuto() ||
                      symRef->getSymbol()->isParm())) ||
@@ -521,7 +521,7 @@ bool TR::LocalDeadStoreElimination::isIdentityStore(TR::Node *storeNode)
    if ((storeNode->getOpCode().isIndirect() && !storedValue->getOpCode().isIndirect()) ||
        (!storeNode->getOpCode().isIndirect() && storedValue->getOpCode().isIndirect()))
       return false;
-   if (storedValue->getSymbol()->isVolatile())
+   if (!storedValue->getSymbol()->isTransparent())
       return false;
    if (!storedValue->getOpCode().isLoadVar())
       return false;
@@ -611,7 +611,7 @@ void TR::LocalDeadStoreElimination::examineNode(TR::Node *parent, int32_t childN
        node->getOpCodeValue() == TR::instanceof ||
        node->getOpCodeValue() == TR::monent ||
        node->getOpCodeValue() == TR::monexit ||
-       node->mightHaveVolatileSymbolReference())
+       node->mightHaveNonTransparentSymbolReference())
       {
       int32_t symRefNum = symRef->getReferenceNumber();
       deadSymbolReferences.reset(symRefNum);
@@ -762,7 +762,7 @@ void TR::LocalDeadStoreElimination::adjustStoresInfo(TR::Node *node, TR_BitVecto
             node->getOpCodeValue() == TR::monent ||
             node->getOpCodeValue() == TR::monexit ||
             (node->isGCSafePointWithSymRef() && comp()->getOptions()->realTimeGC()) ||
-            node->mightHaveVolatileSymbolReference())
+            node->mightHaveNonTransparentSymbolReference())
       {
       bool isCallDirect = false;
       if (node->getOpCode().isCallDirect())

--- a/compiler/optimizer/LocalLiveRangeReducer.cpp
+++ b/compiler/optimizer/LocalLiveRangeReducer.cpp
@@ -351,7 +351,7 @@ void TR_LocalLiveRangeReduction::populatePotentialDeps(TR_TreeRefInfo *treeRefIn
 
       //set defSym - all symbols that might be written
 
-      if (opCode.isCall() || opCode.isResolveCheck()|| opCode.isStore() || node->mightHaveVolatileSymbolReference())
+      if (opCode.isCall() || opCode.isResolveCheck()|| opCode.isStore() || node->mightHaveNonTransparentSymbolReference())
          {
 
          bool isCallDirect = false;

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -5070,7 +5070,7 @@ bool TR_Rematerialization::examineNode(TR::TreeTop *treeTop, TR::Node *parent, T
         parent->getOpCode().isResolveCheck()) ||
        (node->getOpCodeValue() == TR::monent) ||
        (node->getOpCodeValue() == TR::monexit) ||
-       node->mightHaveVolatileSymbolReference())
+       node->mightHaveNonTransparentSymbolReference())
       isSimilarToCall = true;
 
    bool isCallDirect = false;

--- a/compiler/optimizer/LocalReordering.cpp
+++ b/compiler/optimizer/LocalReordering.cpp
@@ -693,7 +693,7 @@ bool TR_LocalReordering::isAnySymInDefinedBy(TR::Node *node, vcount_t visitCount
       int32_t symRefNum = symReference->getReferenceNumber();
 
       if ((!node->getOpCode().isLoadVar() ||
-           node->mightHaveVolatileSymbolReference()) &&
+           node->mightHaveNonTransparentSymbolReference()) &&
           !node->getOpCode().isCheck())
          {
          if (_seenSymbols->get(symRefNum))

--- a/compiler/optimizer/LocalTransparency.cpp
+++ b/compiler/optimizer/LocalTransparency.cpp
@@ -535,7 +535,7 @@ void TR_LocalTransparency::updateUsesAndDefs(TR::Node *node, ContainerType *glob
          isCallDirect = true;
 
       if ((opCode.isLoadVar() || (loadaddrAsLoad() && opCode.getOpCodeValue() == TR::loadaddr)) &&
-           !node->mightHaveVolatileSymbolReference())
+           !node->mightHaveNonTransparentSymbolReference())
          {
          if (seenDefinedSymbolReferences->get(symRefNum))
             {
@@ -640,7 +640,7 @@ void TR_LocalTransparency::updateUsesAndDefs(TR::Node *node, ContainerType *glob
                // when the volatile store is processed in local anticipatability, which causes
                // inconsistency between local transparency and local anticipatability.
                // This matches how a call node is processed earlier.
-               if (node->mightHaveVolatileSymbolReference())
+               if (node->mightHaveNonTransparentSymbolReference())
                   {
                   *tempContainer &= *seenStoredSymRefs;
                   *symRefsDefinedAfterStored |= *tempContainer;

--- a/compiler/optimizer/LoopCanonicalizer.cpp
+++ b/compiler/optimizer/LoopCanonicalizer.cpp
@@ -3554,8 +3554,8 @@ void TR_LoopTransformer::updateInfo(TR::Node *node, vcount_t visitCount, updateI
 
    uinfo.currentlyWrittenOnce |= defAliases;
 
-   // use def aliases for volatiles to update reads and writes
-   if (node->mightHaveVolatileSymbolReference())
+   // use def aliases for non-transparents to update reads and writes
+   if (node->mightHaveNonTransparentSymbolReference())
       {
       *_neverRead -= defAliases;
       _readExactlyOnce -= defAliases;
@@ -3732,7 +3732,7 @@ bool TR_LoopTransformer::isSymbolReferenceWrittenNumberOfTimesInStructure(TR_Str
    {
    if (structure->asBlock() != NULL)
       {
-      if (comp()->getSymRefTab()->getSymRef(symRefNum)->getSymbol()->isVolatile())
+      if (!comp()->getSymRefTab()->getSymRef(symRefNum)->getSymbol()->isTransparent())
          return false;
 
       TR_BlockStructure *blockStructure = structure->asBlock();
@@ -4508,7 +4508,7 @@ bool TR_LoopInverter::isInvertibleLoop(int32_t symRefNum, TR_Structure *structur
    {
    if (structure->asBlock() != NULL)
       {
-      if (comp()->getSymRefTab()->getSymRef(symRefNum)->getSymbol()->isVolatile())
+      if (!comp()->getSymRefTab()->getSymRef(symRefNum)->getSymbol()->isTransparent())
          return false;
 
       TR_BlockStructure *blockStructure = structure->asBlock();

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -3384,7 +3384,7 @@ void TR_LoopVersioner::updateDefinitionsAndCollectProfiledExprs(TR::Node *parent
       if (symReference->getSymbol()->isArrayShadowSymbol())
          _arrayAccesses->add(node);
 
-      if (node->mightHaveVolatileSymbolReference())
+      if (node->mightHaveNonTransparentSymbolReference())
          {
          if (symReference->sharesSymbol())
            {

--- a/compiler/optimizer/OMRLocalCSE.hpp
+++ b/compiler/optimizer/OMRLocalCSE.hpp
@@ -116,7 +116,7 @@ class LocalCSE : public TR::Optimization
    virtual bool canBeAvailable(TR::Node *, TR::Node *, TR_BitVector &, bool);
    bool isAvailableNullCheck(TR::Node *, TR_BitVector &);
    TR::Node *getAvailableExpression(TR::Node *parent, TR::Node *node);
-   bool killExpressionsIfVolatileLoad(TR::Node *node, TR_BitVector &seenAvailableLoadedSymbolReferences, TR_UseDefAliasSetInterface &UseDefAliases);
+   bool killExpressionsIfNonTransparentLoad(TR::Node *node, TR_BitVector &seenAvailableLoadedSymbolReferences, TR_UseDefAliasSetInterface &UseDefAliases);
    void killAvailableExpressionsAtGCSafePoints(TR::Node *, TR::Node *, TR_BitVector &);
    void killAllAvailableExpressions();
    void killAllDataStructures(TR_BitVector &);

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -5554,7 +5554,7 @@ TR::Node *indirectLoadSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
           (node->getSymbol()->getSize() == firstChild->getSymbol()->getSize()) &&
           (firstChild->getSymbolReference()->getSymbol()->isAutoOrParm() || localStatic) &&
           node->getSymbolReference()->getOffset() == 0 &&
-          (node->getSymbol()->isVolatile() == firstChild->getSymbol()->isVolatile()) &&
+          (node->getSymbol()->getMemoryOrdering() == firstChild->getSymbol()->getMemoryOrdering()) &&
           performTransformation(s->comp(), "%sReplace indirect load %s [" POINTER_PRINTF_FORMAT "] with ",
           s->optDetailString(), node->getOpCode().getName(),node))
          {
@@ -5678,7 +5678,7 @@ TR::Node *indirectStoreSimplifier(TR::Node * node, TR::Block * block, TR::Simpli
        if ((storeDataType == addrDataType && isSameType) &&
            (firstChild->getSymbolReference()->getSymbol()->isAutoOrParm()  || localStatic) &&
            node->getSymbolReference()->getOffset() == 0 &&
-           (node->getSymbol()->isVolatile() == firstChild->getSymbol()->isVolatile()) &&
+           (node->getSymbol()->getMemoryOrdering() == firstChild->getSymbol()->getMemoryOrdering()) &&
            performTransformation(s->comp(), "%sReplace indirect store %s [" POINTER_PRINTF_FORMAT "] with ",
             s->optDetailString(), node->getOpCode().getName(),node))
          {

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -6881,7 +6881,7 @@ void OMR::ValuePropagation::collectDefSymRefs(TR::Node *node, TR::Node *parent)
    if (opCode.hasSymbolReference())
       {
       TR::SymbolReference *symReference = node->getSymbolReference();
-      if (node->mightHaveVolatileSymbolReference())
+      if (node->mightHaveNonTransparentSymbolReference())
          {
          if (symReference->sharesSymbol())
             symReference->getUseDefAliases().getAliasesAndUnionWith(*_seenDefinedSymbolReferences);

--- a/compiler/optimizer/SinkStores.cpp
+++ b/compiler/optimizer/SinkStores.cpp
@@ -2111,13 +2111,13 @@ bool nodeContainsCall(TR::Node *node, vcount_t visitCount)
    // 3) a monexit
    // 4) a store to a static
    // 5) a symref that is unresolved
-   // 6) a symbol that is volatile
+   // 6) a symbol that is not transparent
    if (node->getOpCode().isCall() ||
          node->getOpCodeValue() == TR::monent ||
          node->getOpCodeValue() == TR::monexit ||
          (node->getOpCode().isStore() && node->getSymbolReference()->getSymbol()->isStatic()) ||
          (node->getOpCode().hasSymbolReference() && node->getSymbolReference()->isUnresolved()) ||
-         (node->getOpCode().hasSymbolReference() && node->getSymbol()->isVolatile()))
+         (node->getOpCode().hasSymbolReference() && !node->getSymbol()->isTransparent()))
       return true;
 
    int32_t i;

--- a/compiler/optimizer/Structure.cpp
+++ b/compiler/optimizer/Structure.cpp
@@ -3304,7 +3304,7 @@ void TR_RegionStructure::updateInvariantSymbols(TR::Node *node, vcount_t visitCo
       {
       TR::SymbolReference *symReference = node->getSymbolReference();
 
-      if (symReference->getSymbol()->isVolatile())
+      if (!symReference->getSymbol()->isTransparent())
          _invariantSymbols->reset(symReference->getReferenceNumber());
 
       if (opCode.isResolveCheck())

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -240,13 +240,6 @@ class TR_UseDefInfo
    bool    isTrivialUseDefNodeImpl(TR::Node *node, AuxiliaryData &aux);
    bool    isTrivialUseDefSymRef(TR::SymbolReference *symRef, AuxiliaryData &aux);
 
-   // For Languages where an auto can alias a volatile, extra care needs to be taken when setting up use-def
-   // The conservative answer is to not index autos that have volatile aliases.
-
-   bool shouldIndexVolatileSym(TR::SymbolReference *ref, AuxiliaryData &aux);
-
-
-
    public:
    int32_t getNumIrrelevantStores() { return _numIrrelevantStores; }
    int32_t getNumUseNodes() {return _numUseOnlyNodes+_numDefUseNodes;}

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -723,6 +723,9 @@ static bool refineUnsafeAccess(OMR::ValuePropagation *vp, TR::Node *node)
    if (disable)
       return refuseToConstrainUnsafe(vp, node, "unsafe shadow refinement is disabled");
 
+   if (!sym->isTransparent() && !sym->isVolatile())
+      return refuseToConstrainUnsafe(vp, node, "non-transparent non-volatile symbol");
+
    if (vp->trace())
       {
       traceMsg(
@@ -824,12 +827,12 @@ static bool refineUnsafeAccess(OMR::ValuePropagation *vp, TR::Node *node)
             return refuseToConstrainUnsafe(vp, node, "type-punned array access");
          }
 
-      if (sym->isVolatile())
+      if (!sym->isTransparent())
          {
-         // We don't have a representation for volatile array shadows, and it's
-         // not straightforward to add one because we'd have to move volatile
+         // We don't have a representation for non-transparent array shadows, and it's
+         // not straightforward to add one because we'd have to move non-transparent
          // status to SymbolReference from Symbol.
-         return refuseToConstrainUnsafe(vp, node, "volatile array access");
+         return refuseToConstrainUnsafe(vp, node, "non-transparent array access");
          }
 
       TR::SymbolReference *arrayShadow =

--- a/compiler/p/codegen/OMRLoadStoreHandler.cpp
+++ b/compiler/p/codegen/OMRLoadStoreHandler.cpp
@@ -282,7 +282,7 @@ StoreSyncRequirements getStoreSyncRequirements(TR::CodeGenerator *cg, TR::Node *
 
         return StoreSyncRequirements::Full;
         }
-    else if (node->getSymbol()->isShadow() && node->getSymbol()->isOrdered() && cg->comp()->target().isSMP())
+    else if (node->getSymbol()->isShadow() && node->getSymbol()->isAcquireRelease() && cg->comp()->target().isSMP())
         {
         return StoreSyncRequirements::LazySet;
         }

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -991,9 +991,6 @@ TR_Debug::nodePrintAllFlags(TR::Node *node, TR_PrettyPrinterString &output)
    FLAG(chkCannotTrackLocalStringUses, "cannotTrackLocalStringUses");
    FLAG(chkCharArrayTRT, "charArrayTRT");
    FLAG(chkEscapesInColdBlock, "escapesInColdBlock");
-#ifdef J9_PROJECT_SPECIFIC
-   FLAG(chkDontInlineUnsafePutOrderedCall, "dontInlineUnsafePutOrderedCall");
-#endif
    FLAG(chkHeapificationStore, "HeapificationStore");
    FLAG(chkHeapificationAlloc, "HeapificationAlloc");
    FLAG(chkIdentityless, "Identityless");

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1071,8 +1071,8 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
          }
       if (symRef->getSymbol()->isFinal())
          symRefKind.appends(" final");
-      if (symRef->getSymbol()->isVolatile())
-         symRefKind.appends(" volatile");
+      if (!symRef->getSymbol()->isTransparent())
+         symRefKind.appendf(" %s", TR::Symbol::getMemoryOrderingName(symRef->getSymbol()->getMemoryOrdering()));
       switch (sym->getKind())
          {
          case TR::Symbol::IsAutomatic:
@@ -1209,9 +1209,9 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
 
           output.appendf(")");
 
-          if (sym->isVolatile())
+          if (!sym->isTransparent())
              {
-             output.appends(" [volatile]");
+             output.appendf(" [%s]", TR::Symbol::getMemoryOrderingName(sym->getMemoryOrdering()));
              }
           }
       }


### PR DESCRIPTION
Expand the possible memory ordering semantics of symbols from volatile or non-volatile to volatile, acquire/release, opaque, or transparent. The memory ordering semantics are defined as follows:
## Transparent
Only guaranteed to be bitwise atomic for data 32 bits or smaller and addresses.
*This is the same as non-volatile semantics prior to this change.*

## Opaque
Accesses to opaque symbols are bitwise atomic.
The execution order of all opaque accesses to any given address in a single thread is the same as the program order of accesses to that address.

## Acquire/Release
Loads of acquire/release symbols are acquire loads; i.e., loads and stores after a given acquire load will not be reordered to before that load. This matches the semantics of C's [`memory_order_acquire`](https://en.cppreference.com/w/c/atomic/memory_order).
Stores to acquire/release symbols are release stores; i.e., loads and stores before a given release store wil not be reordered to after that store. This matches the semantics of C's [`memory_order_release`](https://en.cppreference.com/w/c/atomic/memory_order).
Acquire/release accesses have a [release-acquire ordering](https://en.cppreference.com/w/c/atomic/memory_order#Release-Acquire_ordering).
Acquire/release symbols also have all the same guarantees that opaque symbols have.

## Volatile
Volatile accesses have a [sequentially-consistent ordering](https://en.cppreference.com/w/c/atomic/memory_order#Sequentially-consistent_ordering). This matches the semantics of C's [`memory_order_seq_cst`](https://en.cppreference.com/w/c/atomic/memory_order)
Volatile symbols also have all the same guarantees that acquire/release symbols have.
*This is the same as volatile semantics prior to this change*

Additionally, see the notes on memory ordering semantics in the [documentation for Java's VarHandle](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/invoke/VarHandle.html)