### PR TITLE
Clean up references to old opcodes

### DIFF
--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -619,11 +619,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::l2aEvaluator(TR::Node *node, TR::CodeGe
    if (comp->useCompressedPointers())
       {
       // pattern match the sequence under the l2a
-      //    iaload f      l2a                       <- node
+      //    aloadi f      l2a                       <- node
       //       aload O       ladd
       //                       lshl
       //                          i2l
-      //                            iiload f        <- load
+      //                            iloadi f        <- load
       //                               aload O
       //                          iconst shftKonst
       //                       lconst HB
@@ -631,7 +631,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::l2aEvaluator(TR::Node *node, TR::CodeGe
       // -or- if the load is known to be null
       //  l2a
       //    i2l
-      //      iiload f
+      //      iloadi f
       //         aload O
       //
       TR::Node *firstChild = node->getFirstChild();

--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -3153,7 +3153,7 @@ TR::Instruction *loadAddressConstant(TR::CodeGenerator *cg, TR::Node * node, int
    return armLoadConstant(node, value, trgReg, cg, cursor);
    }
 
-// also handles iiload
+// also handles iloadi
 TR::Register *OMR::ARM::TreeEvaluator::iloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *tempReg;
@@ -3202,7 +3202,7 @@ static bool nodeIsNeeded(TR::Node *checkNode, TR::Node *node)
    return result;
    }
 
-// handles aload and iaload
+// handles aload and aloadi
 TR::Register *OMR::ARM::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
@@ -3298,7 +3298,7 @@ TR::Register *OMR::ARM::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGe
    return tempReg;
    }
 
-// also handles ilload
+// also handles lloadi
 TR::Register *OMR::ARM::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register           *lowReg  = cg->allocateRegister();
@@ -3342,7 +3342,7 @@ TR::Register *OMR::ARM::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::CodeGe
 // aloadEvaluator handled by iloadEvaluator
 
 
-// also handles ibload
+// also handles bloadi
 TR::Register *OMR::ARM::TreeEvaluator::bloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return commonLoadEvaluator(node, TR::InstOpCode::ldrsb, 1, cg);
@@ -3469,7 +3469,7 @@ TR::Register *OMR::ARM::TreeEvaluator::awrtbariEvaluator(TR::Node *node, TR::Cod
 #endif
    }
 
-// also handles ilstore
+// also handles lstorei
 TR::Register *OMR::ARM::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *valueChild;
@@ -3527,7 +3527,7 @@ TR::Register *OMR::ARM::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::CodeG
    return NULL;
    }
 
-// also handles ibstore
+// also handles bstorei
 TR::Register *OMR::ARM::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return commonStoreEvaluator(node, TR::InstOpCode::strb, 1, cg);
@@ -3539,7 +3539,7 @@ TR::Register *OMR::ARM::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::CodeG
    return commonStoreEvaluator(node, TR::InstOpCode::strh, 2, cg);
    }
 
-// also handles astore, iastore, iistore
+// also handles astore, astorei, istorei
 TR::Register *OMR::ARM::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return commonStoreEvaluator(node, TR::InstOpCode::str, 4, cg);

--- a/compiler/codegen/NodeEvaluation.cpp
+++ b/compiler/codegen/NodeEvaluation.cpp
@@ -121,10 +121,10 @@ OMR::CodeGenerator::evaluate(TR::Node * node)
       // As well, more insidious trees exist:
       //
       // ificmpeq
-      //    iiload
+      //    iloadi
       //       i2l
       //          x
-      //    iiload
+      //    iloadi
       //       ishl
       //          ==> i2l
       //          4
@@ -144,11 +144,11 @@ OMR::CodeGenerator::evaluate(TR::Node * node)
       // perform the function calls:
       //
       // ificmpeq
-      //    iiload
+      //    iloadi
       //       ishl
       //          ==> x
       //          7
-      //    iiload
+      //    iloadi
       //       ishl
       //          ==> x
       //          4

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1929,9 +1929,9 @@ OMR::CodeGenerator::addressesMatch(TR::Node *addr1, TR::Node *addr2, bool addres
       if (self()->isSupportedAdd(addr1) && self()->isSupportedAdd(addr2) &&
           self()->nodeMatches(addr1->getSecondChild(), addr2->getSecondChild(), addressesUnderSameTreeTop))
          {
-         // for the case where the iaload itself is below an addition, match the additions first
+         // for the case where the aloadi itself is below an addition, match the additions first
          // aiadd
-         //    iaload
+         //    aloadi
          //       aload
          //    iconst
          addr1 = addr1->getFirstChild();
@@ -3430,10 +3430,10 @@ OMR::CodeGenerator::isInMemoryInstructionCandidate(TR::Node * node)
    //
    // Examples:
    //
-   // ibstore
+   // bstorei
    //   addr
    //   bor/band/bxor
-   //     ibload
+   //     bloadi
    //       =>addr
    //     bconst
    //

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -7004,7 +7004,7 @@ OMR::Node::chkUnsigned()
 bool
 OMR::Node::isClassPointerConstant()
    {
-   TR_ASSERT((self()->getOpCodeValue() == TR::aconst)||(self()->getOpCodeValue() == TR::aloadi), "Can only call this for aconst or iaload\n");
+   TR_ASSERT((self()->getOpCodeValue() == TR::aconst)||(self()->getOpCodeValue() == TR::aloadi), "Can only call this for aconst or aloadi\n");
    return _flags.testAny(classPointerConstant);
    }
 
@@ -7027,7 +7027,7 @@ OMR::Node::chkClassPointerConstant()
 bool
 OMR::Node::isMethodPointerConstant()
    {
-   TR_ASSERT((self()->getOpCodeValue() == TR::aconst)||(self()->getOpCodeValue() == TR::aloadi), "Can only call this for aconst or iaload\n");
+   TR_ASSERT((self()->getOpCodeValue() == TR::aconst)||(self()->getOpCodeValue() == TR::aloadi), "Can only call this for aconst or aloadi\n");
    return _flags.testAny(methodPointerConstant);
    }
 
@@ -7056,7 +7056,7 @@ void
 OMR::Node::setUnneededIALoad(bool v)
    {
    TR::Compilation * c = TR::comp();
-   TR_ASSERT(self()->getOpCodeValue() == TR::aloadi, "Can only call this for iaload");
+   TR_ASSERT(self()->getOpCodeValue() == TR::aloadi, "Can only call this for aloadi");
    if (performNodeTransformation2(c, "O^O NODE FLAGS: Setting unneededIALoad flag on node %p to %d\n", self(), v))
       _flags.set(unneededIALoad, v);
    }

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1373,7 +1373,7 @@ public:
    void setUnsigned(bool b);
    bool chkUnsigned();
 
-   // Flags used by aconst and iaload (on s390 iaload can be used after dynamic lit pool)
+   // Flags used by aconst and aloadi (on s390 aloadi can be used after dynamic lit pool)
    bool isClassPointerConstant();
    void setIsClassPointerConstant(bool b);
    bool chkClassPointerConstant();
@@ -1502,11 +1502,11 @@ public:
    void setReturnIsDummy();
    bool chkReturnIsDummy();
 
-   // Flag used by ilload nodes for DFP
+   // Flag used by lloadi nodes for DFP
    bool isBigDecimalLoad();
    void setIsBigDecimalLoad();
 
-   // Flag used by iload, iiload, lload, ilload, aload, iaload
+   // Flag used by iload, iloadi, lload, lloadi, aload, aloadi
    bool isLoadAndTest()          { return _flags.testAny(loadAndTest); }
    void setIsLoadAndTest(bool v) { _flags.set(loadAndTest, v); }
 
@@ -1938,7 +1938,7 @@ protected:
       // currently used for ldiv folding to idiv, when both children are with highWordZero
       Unsigned                              = 0x00004000,
 
-      // Flags used by TR::aconst and TR::iaload (on s390 iaload can be used after dynamic lit pool)
+      // Flags used by TR::aconst and TR::aloadi (on s390 aloadi can be used after dynamic lit pool)
       //
       classPointerConstant                  = 0x00010000,
       methodPointerConstant                 = 0x00002000,
@@ -2014,12 +2014,12 @@ protected:
       // Flag used by TR::Return
       returnIsDummy                         = 0x00001000,
 
-      // Flag used by ilload nodes for BigDecimal long field (DFP)
+      // Flag used by lloadi nodes for BigDecimal long field (DFP)
       // Active when disableDFP JIT option not specifiec, and running
       // on hardware Power or zSeries hardware that supports DFP
       bigDecimal_load                       = 0x00000002, // TODO: make J9_PROJECT_SPECIFIC
 
-      // Flag used by iload, iiload, lload, ilload, aload, iaload
+      // Flag used by iload, iloadi, lload, lloadi, aload, aloadi
       loadAndTest                           = 0x00008000,
 
       // Flag used by TR::New when the codegen supports

--- a/compiler/infra/TreeServices.cpp
+++ b/compiler/infra/TreeServices.cpp
@@ -168,7 +168,7 @@ TR_AddressTree::processMultiplyNode(TR::Node * multiplyNode)
 //       ixload
 //          aiadd <memory reference sub-tree>
 //    l2i
-//       ilload <DirectByteBuffer>
+//       lloadi <DirectByteBuffer>
 //          aload <Buffer>
 //
 // (64-bit)
@@ -176,7 +176,7 @@ TR_AddressTree::processMultiplyNode(TR::Node * multiplyNode)
 //    x2i
 //       ixload
 //          aladd <memory reference sub-tree>
-//    ilload <DirectByteBuffer>
+//    lloadi <DirectByteBuffer>
 //       aload <Buffer>
 bool
 TR_AddressTree::process(TR::Node * aiaddNode, bool onlyConsiderConstAiaddSecondChild)

--- a/compiler/optimizer/CopyPropagation.cpp
+++ b/compiler/optimizer/CopyPropagation.cpp
@@ -1088,11 +1088,11 @@ void TR_CopyPropagation::commonIndirectLoadsFromAutos()
       if (!currentTree->getNextTreeTop())
           break;
       TR::Node *nextNode = currentTree->getNextTreeTop()->getNode();
-      //   iistore M
+      //   istorei M
       //      loadaddr A
       //      X
       //   istore TMP              ==> istore TMP
-      //        iiload M                   X
+      //        iloadi M                   X
       //           loadaddr A
 
       if (node->getOpCode().isStoreIndirect() &&
@@ -2320,7 +2320,7 @@ TR::Node * TR_CopyPropagation::isCheapRematerializationCandidate(TR::Node * defN
 
    // 1) indirect loads where the base ptr is on the stack or a location pointer
    //
-   //  iaload <refined-array-shadow> [id=238:"PSALIT2"] [#1.64 Shadow] [flags 0x80000607 0x0 ]  [0x2B026BFC] bci=[-1,37,329] rc=2 vc=9438 vn=- sti=- udi=331 nc=1 addr=4
+   //  aloadi <refined-array-shadow> [id=238:"PSALIT2"] [#1.64 Shadow] [flags 0x80000607 0x0 ]  [0x2B026BFC] bci=[-1,37,329] rc=2 vc=9438 vn=- sti=- udi=331 nc=1 addr=4
    //    aiadd (internalPtr )                                                            [0x2B016B20] bci=[-1,37,329] rc=1 vc=9438 vn=- sti=- udi=- nc=2 addr=4 flg=0x8000
    //      loadaddr <auto slot 40> [id=152:"PSA"] [#1.63 Auto] [flags 0x4000008 0x0 ]    [0x2B016AD0] bci=[-1,37,329] rc=1 vc=9438 vn=- sti=- udi=- nc=0 addr=4
    //      iconst 1212 (X!=0 X>=0 )                                                      [0x2B016B70] bci=[-1,37,329] rc=1 vc=9438 vn=- sti=- udi=- nc=0 flg=0x104

--- a/compiler/optimizer/GeneralLoopUnroller.cpp
+++ b/compiler/optimizer/GeneralLoopUnroller.cpp
@@ -4240,13 +4240,13 @@ TR_GeneralLoopUnroller::canUnrollUnCountedLoop(TR_RegionStructure *loop,
    // Detect Small loops like:
    //   [0x37047e24] BBStart (block 133) (frequency 127) (is in loop 133)
    //   [0x37047f58]   astore #392[0x36e8c8e4]
-   //   [0x37047ef8]     iaload #549[0x37047c9c]+24
+   //   [0x37047ef8]     aloadi #549[0x37047c9c]+24
    //   [0x37047ed0]       aload #392[0x36e8c8e4]  Auto[<temp slot 8>]   <flags:"0x4" (X!=0 )/>
    //   [0x375191d4]   NULLCHK on [0x37047ef8] #18[0x36a24b1c]  Method[jitThrowNullPointerException]
-   //   [0x375191fc]     iaload #549[0x37047c9c]+24
-   //                      ==>iaload at [0x37047ef8]
+   //   [0x375191fc]     aloadi #549[0x37047c9c]+24
+   //                      ==>aloadi at [0x37047ef8]
    //   [0x3751925c]   ifacmpne --> block 133 BBStart at [0x37047e24]
-   //                    ==>iaload at [0x375191fc]
+   //                    ==>aloadi at [0x375191fc]
    //   [0x37519288]     aconst NULL   <flags:"0x2" (X==0 )/>
    //   [0x37519144]   BBEnd (block 133)
 

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -3612,7 +3612,7 @@ bool TR_TransformInlinedFunction::findCallNodeInTree(TR::Node * callNode, TR::No
 bool TR_TransformInlinedFunction::findReturnValueInTree(TR::Node * rvStoreNode, TR::Node * node, TR::Compilation *comp)
    {
    TR::SymbolReference *rvSymRef = rvStoreNode->getSymbolReference();
-   // ibload
+   // bloadi
    //    loadaddr rvSymRef
    if (node->getOpCode().isLoadIndirect() &&
        node->getFirstChild()->getOpCodeValue() == TR::loadaddr &&

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -2312,11 +2312,11 @@ bool TR_CompactNullChecks::replaceNullCheckIfPossible(TR::Node *cursorNode, TR::
             //    loadaddr
             // ...
             // NULLCHK #1
-            //    iaload
+            //    aloadi
             //      aload #1
             // ..
             // NULLCHK #2
-            //    iiload
+            //    iloadi
             //      aload #1
             if (!compactionDone)
                {
@@ -5118,7 +5118,7 @@ bool TR_Rematerialization::examineNode(TR::TreeTop *treeTop, TR::Node *parent, T
         state->_currentlyCommonedLoads.getListHead()->getData()->isBigDecimalLoad()))
        considerRegPressure = false;
 
-    // rematerialize to generate TM's. ibload's are not evaluated
+    // rematerialize to generate TM's. bloadi's are not evaluated
     if (NULL != regPress)
         {
         considerRegPressure = false;

--- a/compiler/optimizer/LoopReducer.cpp
+++ b/compiler/optimizer/LoopReducer.cpp
@@ -379,7 +379,7 @@ TR_ByteToCharArraycopy::checkArrayStore(TR::Node * storeNode)
 //    ior
 //      imul
 //       bu2i
-//          ibload #132[0x005f1c80] Shadow[<array-shadow>]
+//          bloadi #132[0x005f1c80] Shadow[<array-shadow>]
 //            aiadd
 //              aload #221[0x00703b50] Auto[<temp slot 11>]
 //              isub
@@ -387,7 +387,7 @@ TR_ByteToCharArraycopy::checkArrayStore(TR::Node * storeNode)
 //                ==>iconst -16 at [0x005f21f8]
 //       iconst 256
 //      bu2i
-//        ibload #132[0x005f1c80] Shadow[<array-shadow>]
+//        bloadi #132[0x005f1c80] Shadow[<array-shadow>]
 //          aiadd
 //            ==>aload at [0x005f1ac8]
 //            isub
@@ -430,12 +430,12 @@ TR_ByteToCharArraycopy::checkByteLoads(TR::Node * loadNodes)
 
    if (highByteNode->getFirstChild()->getOpCodeValue() != TR::bu2i || highByteNode->getFirstChild()->getFirstChild()->getOpCodeValue() != TR::bloadi)
       {
-      dumpOptDetails(comp(), "checkByteLoads: high byte load does not have bu2i/ibload\n");
+      dumpOptDetails(comp(), "checkByteLoads: high byte load does not have bu2i/bloadi\n");
       return false;
       }
    if (lowByteNode->getFirstChild()->getOpCodeValue() != TR::bloadi)
       {
-      dumpOptDetails(comp(), "checkByteLoads: low byte load does not have ibload\n");
+      dumpOptDetails(comp(), "checkByteLoads: low byte load does not have bloadi\n");
       return false;
       }
 
@@ -1525,7 +1525,7 @@ static void swapIfNecessary(TR::Node *&aiaddFirstChild, TR::Node *&aiaddSecondCh
 //        isub (add displacement to get to start of array with index into translation table)
 //          imul (multiply by stride of target - may not be present if byte-to-byte)
 //            bu2i (widen byte (unsigned) to int - could be
-//              ibload #byte (load the byte - could also be isload)
+//              bloadi #byte (load the byte - could also be isload)
 //                aiadd
 //                  aload #base (load base pointer)
 //                  isub (add displacement to get to relative index)
@@ -1537,7 +1537,7 @@ static void swapIfNecessary(TR::Node *&aiaddFirstChild, TR::Node *&aiaddSecondCh
 // -or- (in the case of an unsafe reference)
 //istore #transchar (store translated character)
 //  b2i
-//    ibload <translate-char> (load character)
+//    bloadi <translate-char> (load character)
 //      iadd
 //       c2i (widen byte (unsigned) to int - could be
 //         isload #byte (load the byte - could also be isload)
@@ -1549,13 +1549,13 @@ static void swapIfNecessary(TR::Node *&aiaddFirstChild, TR::Node *&aiaddSecondCh
 //                    iconst 2
 //                  iconst -16
 //        l2i
-//          ilload <DirectByteBuffer>
+//          lloadi <DirectByteBuffer>
 //            aload <ButeBuffer>
 //
 // -or (in the case of a compiler-generated table look-up)
 //istore #transchar (store byte)
 //  b2i
-//    ibload <translate-char> (load character)
+//    bloadi <translate-char> (load character)
 //      aiadd
 //        aload #base (load base pointer)
 //        isub (add displacement to get to relative index)
@@ -1598,7 +1598,7 @@ TR_Arraytranslate::checkLoad(TR::Node * loadNode)
 
    if (transLoadNode->getOpCodeValue() != TR::bloadi)
       {
-      dumpOptDetails(comp(), "...load tree does not have ibload - no arraytranslate reduction\n");
+      dumpOptDetails(comp(), "...load tree does not have bloadi - no arraytranslate reduction\n");
       return false;
       }
    _resultUnconvertedNode = transLoadNode;
@@ -1645,7 +1645,7 @@ TR_Arraytranslate::checkLoad(TR::Node * loadNode)
          }
       if (aiaddSecondChild->getOpCodeValue() != TR::lloadi && aiaddSecondChild->getOpCodeValue() != TR::lload)
          {
-         dumpOptDetails(comp(), "...iadd load tree does not have ilload - no arraytranslate reduction\n");
+         dumpOptDetails(comp(), "...iadd load tree does not have lloadi - no arraytranslate reduction\n");
          return false;
          }
       _usesRawStorage = true;
@@ -1696,7 +1696,7 @@ TR_Arraytranslate::checkStore(TR::Node * storeNode)
    {
    if (storeNode->getOpCodeValue() != TR::sstorei && storeNode->getOpCodeValue() != TR::bstorei)
       {
-      dumpOptDetails(comp(), "...store tree does not have isstore/ibstore - no arraytranslate reduction\n");
+      dumpOptDetails(comp(), "...store tree does not have isstore/bstorei - no arraytranslate reduction\n");
       return false;
       }
 
@@ -1969,14 +1969,14 @@ TR_LoopReducer::generateArraycmp(TR_RegionStructure * whileLoop, TR_InductionVar
    //BBStart (block #1)
    //ificmpne --> block #3 <break block>
    //  b2i
-   //    ibload <array #1 element>
+   //    bloadi <array #1 element>
    //      aiadd
    //        aload <array #1 base>
    //        isub (this could be variable based on internal pointers, striding, type being loaded) [common base offset]
    //          iload <induction variable>
    //          iconst -16
    //  b2i
-   //    ibload <array #2 element>
+   //    bloadi <array #2 element>
    //      aiadd
    //        aload <array #2 base>
    //        ==>isub at [common base offset]
@@ -2453,7 +2453,7 @@ TR_LoopReducer::generateArraytranslate(TR_RegionStructure * whileLoop, TR_Induct
    //        isub (add displacement to get to start of array with index into translation table)
    //          imul (multiply by stride of target - may not be present if byte-to-byte)
    //            bu2i (widen byte (unsigned) to int - could be
-   //              ibload #byte (load the byte - could also be isload)
+   //              bloadi #byte (load the byte - could also be isload)
    //                aiadd
    //                  aload #base (load base pointer)
    //                  isub (add displacement to get to relative index)
@@ -2503,7 +2503,7 @@ TR_LoopReducer::generateArraytranslate(TR_RegionStructure * whileLoop, TR_Induct
    //        isub (add displacement to get to start of array with index into translation table)
    //          imul (multiply by stride of target - may not be present if byte-to-byte)
    //            bu2i (widen byte (unsigned) to int - could be
-   //              ibload #byte (load the byte - could also be isload)
+   //              bloadi #byte (load the byte - could also be isload)
    //                aiadd
    //                  aload #base (load base pointer)
    //                  isub (add displacement to get to relative index)
@@ -2549,7 +2549,7 @@ TR_LoopReducer::generateArraytranslate(TR_RegionStructure * whileLoop, TR_Induct
    //BBStart <load-char>
    //istore #transchar (store translated character)
    //  b2i
-   //    ibload <byte>
+   //    bloadi <byte>
    //     aiadd
    //       aload #base (load base pointer)
    //         isub (add displacement to get to relative index)
@@ -2557,7 +2557,7 @@ TR_LoopReducer::generateArraytranslate(TR_RegionStructure * whileLoop, TR_Induct
    //            iconst -16
    //       iconst -16
    //ifbcmpXX --> block <no-stop>
-   //  ==>ibload <byte>
+   //  ==>bloadi <byte>
    //  bconst <termination char> [+/- 1]
    //BBEnd <load-char>
    //BBStart <escape>
@@ -2595,7 +2595,7 @@ TR_LoopReducer::generateArraytranslate(TR_RegionStructure * whileLoop, TR_Induct
    //         iload #i <induction variable>
    //         iconst 2
    //       iconst -16
-   //    ibload <byte>
+   //    bloadi <byte>
    //     aiadd
    //       aload #base (load base pointer)
    //         isub (add displacement to get to relative index)
@@ -2867,7 +2867,7 @@ TR_LoopReducer::generateArraytranslate(TR_RegionStructure * whileLoop, TR_Induct
    TR::Node *outputBase = arraytranslateLoop.getOutputNode();
    if (inputBase && outputBase)
       {
-      inputBase = inputBase->getFirstChild(); //returns iaload/aload base
+      inputBase = inputBase->getFirstChild(); //returns aloadi/aload base
       outputBase = outputBase->getFirstChild();
       if ((inputBase == outputBase) ||
             (inputBase->getOpCode().hasSymbolReference() && outputBase->getOpCode().hasSymbolReference() &&
@@ -3430,7 +3430,7 @@ TR_LoopReducer::generateArraytranslate(TR_RegionStructure * whileLoop, TR_Induct
 //
 // BBStart block 14
 //  ifbcmpeq --> block <after>
-//   ibload #146[0x03F1527C] Shadow[<array-shadow>]
+//   bloadi #146[0x03F1527C] Shadow[<array-shadow>]
 //     aiadd
 //       aload #176[0x03F08DC4] Static[Simple.data [B]
 //       isub
@@ -3468,7 +3468,7 @@ TR_ArraytranslateAndTest::checkLoad(TR::Block * loadBlock, TR::Node * loadNode)
 
    if (bLoadNode->getOpCodeValue() != TR::bloadi)
       {
-      dumpOptDetails(comp(), "...load tree does not have ibload - no arraytranslateAndTest reduction\n");
+      dumpOptDetails(comp(), "...load tree does not have bloadi - no arraytranslateAndTest reduction\n");
       return false;
       }
 
@@ -3518,7 +3518,7 @@ TR_ArraytranslateAndTest::checkFrequency(TR::CodeGenerator * cg, TR::Block * loa
 
 // BBStart block 14
 //  ifbcmpeq --> block <after>
-//   ibload #146[0x03F1527C] Shadow[<array-shadow>]
+//   bloadi #146[0x03F1527C] Shadow[<array-shadow>]
 //     aiadd
 //       aload #176[0x03F08DC4] Static[Simple.data [B]
 //       isub
@@ -3714,7 +3714,7 @@ TR_LoopReducer::generateArraytranslateAndTest(TR_RegionStructure * whileLoop, TR
 //    ior
 //      imul
 //       bu2i
-//          ibload #132[0x005f1c80] Shadow[<array-shadow>]
+//          bloadi #132[0x005f1c80] Shadow[<array-shadow>]
 //            aiadd
 //              aload #221[0x00703b50] Auto[<temp slot 11>]
 //              isub
@@ -3722,7 +3722,7 @@ TR_LoopReducer::generateArraytranslateAndTest(TR_RegionStructure * whileLoop, TR
 //                ==>iconst -16 at [0x005f21f8]
 //       iconst 256
 //      bu2i
-//        ibload #132[0x005f1c80] Shadow[<array-shadow>]
+//        bloadi #132[0x005f1c80] Shadow[<array-shadow>]
 //          aiadd
 //            ==>aload at [0x005f1ac8]
 //            isub
@@ -3937,7 +3937,7 @@ TR_LoopReducer::generateByteToCharArraycopy(TR_InductionVariable * byteIndVar, T
 //generates:
 //
 // BBStart (block 33) (frequency 0) (is in loop 33)
-// ibstore #154[0x019D11B0] Shadow[<array-shadow>]
+// bstorei #154[0x019D11B0] Shadow[<array-shadow>]
 //   aiadd
 //     aload #240[0x015D9D5C] Auto[<temp slot 7>]
 //     isub
@@ -3957,7 +3957,7 @@ TR_LoopReducer::generateByteToCharArraycopy(TR_InductionVariable * byteIndVar, T
 //                 ==>iconst -16 at [0x019D112C]
 //         iconst 65280
 //       iconst 8
-// ibstore #154[0x019D11B0] Shadow[<array-shadow>]
+// bstorei #154[0x019D11B0] Shadow[<array-shadow>]
 //   aiadd
 //     ==>aload at [0x019D0C58]
 //     isub

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -5616,7 +5616,7 @@ void TR_LoopVersioner::RemoveArrayStoreCheck::improveLoop()
    TR::TreeTop *firstNewTree = TR::TreeTop::create(comp(), TR::Node::create(TR::treetop, 1, arrayStoreCheckNode->getFirstChild()), NULL, NULL);
    TR::Node *child = arrayStoreCheckNode->getFirstChild();
    if (child->getOpCodeValue() == TR::awrtbari && TR::Compiler->om.writeBarrierType() == gc_modron_wrtbar_none &&
-      performTransformation(comp(), "%sChanging awrtbari node [%p] to an iastore\n", OPT_DETAILS_LOOP_VERSIONER, child))
+      performTransformation(comp(), "%sChanging awrtbari node [%p] to an astorei\n", OPT_DETAILS_LOOP_VERSIONER, child))
       {
       TR::Node::recreate(child, TR::astorei);
       child->getChild(2)->recursivelyDecReferenceCount();
@@ -5630,7 +5630,7 @@ void TR_LoopVersioner::RemoveArrayStoreCheck::improveLoop()
       secondNewTree = TR::TreeTop::create(comp(), TR::Node::create(TR::treetop, 1, arrayStoreCheckNode->getSecondChild()), NULL, NULL);
       child = arrayStoreCheckNode->getSecondChild();
       if (child->getOpCodeValue() == TR::awrtbari && TR::Compiler->om.writeBarrierType() == gc_modron_wrtbar_none &&
-          performTransformation(comp(), "%sChanging awrtbari node [%p] to an iastore\n", OPT_DETAILS_LOOP_VERSIONER, child))
+          performTransformation(comp(), "%sChanging awrtbari node [%p] to an astorei\n", OPT_DETAILS_LOOP_VERSIONER, child))
          {
          TR::Node::recreate(child, TR::astorei);
          child->getChild(2)->recursivelyDecReferenceCount();
@@ -6696,7 +6696,7 @@ void TR_LoopVersioner::RemoveSpineCheck::improveLoop()
 
    //fixup node to have arraylets.
    // aiadd
-   //   iaload
+   //   aloadi
    //       aiadd
    //          aload a
    //          iadd

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -5082,8 +5082,8 @@ static bool isDeletedLabelLoadaddr(TR::Node * node)
 // They are for testing if a particular bit is ON or OFF
 // ifbcmpne                           ifbcmpne
 //  band                               band
-//    bshl                              ibload
-//      ibload           ===>             loadaddr
+//    bshl                              bloadi
+//      bloadi           ===>             loadaddr
 //        loadaddr                      bconst N>>s
 //      iconst s                       bconst M>>s
 //    bconst N
@@ -5748,7 +5748,7 @@ TR::Node *indirectStoreSimplifier(TR::Node * node, TR::Block * block, TR::Simpli
             }
 
          if (removeWrtBar && !s->comp()->getOptions()->realTimeGC() &&
-             performTransformation(s->comp(), "%sFolded indirect write barrier to iastore because GC could not have occurred enough times to require iwrtbar [" POINTER_PRINTF_FORMAT "]\n", s->optDetailString(), node))
+             performTransformation(s->comp(), "%sFolded indirect write barrier to astorei because GC could not have occurred enough times to require iwrtbar [" POINTER_PRINTF_FORMAT "]\n", s->optDetailString(), node))
             {
             TR::Node::recreate(node, TR::astorei);
             node->getChild(2)->recursivelyDecReferenceCount();
@@ -11733,19 +11733,19 @@ TR::Node *borSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    // bor
    //   band
    //      bshl
-   //         ibload (1)
+   //         bloadi (1)
    //         iconst
    //      bconst (1)
    //   band
-   //      ibload (2)
+   //      bloadi (2)
    //      bconst (2)
    //
    // Will get transformed to:
    // icall
-   //    ibload (1)
+   //    bloadi (1)
    //    iconst
    //    bconst (1)
-   //    ibload (2)
+   //    bloadi (2)
 
    //check for pattern like
    // bor                                  bor

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -2032,8 +2032,8 @@ TR::VPConstraint *OMR::ValuePropagation::mergeDefConstraints(TR::Node *node, int
 
    if (node->getOpCodeValue() == TR::loadaddr)
       {
-      // A loadaddr (USE) can be defined by an iistore.  Merging those
-      // constraints (the ones on the iistore) in would be dangerous.
+      // A loadaddr (USE) can be defined by an istorei.  Merging those
+      // constraints (the ones on the istorei) in would be dangerous.
       // There's no real point in merging in constraints from other
       // loadaddr defs, so just return NULL.
       return NULL;

--- a/compiler/optimizer/StripMiner.cpp
+++ b/compiler/optimizer/StripMiner.cpp
@@ -1659,7 +1659,7 @@ void TR_StripMiner::examineNode(LoopInfo *li, TR::Node *parent, TR::Node *node,
          if ( node->getSymbol() && node->getSymbol()->isArrayletShadowSymbol())
             {
             /* Pattern match for array access offsets
-               iaload <arraylet>                                iaload <arraylet>
+               aloadi <arraylet>                                aloadi <arraylet>
                   aiadd                                            aladd
                      aload <array>                                    aload <array>
                      isub/iadd                                        lsub/ladd

--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -3079,13 +3079,13 @@ void TR::VPClass::typeIntersect(TR::VPClassPresence* &presence, TR::VPClassType*
             ///   dumpOptDetails(vp->comp(), "type is classobject: %d\n", TR_yes);
             //
             // the following cases are due to the fact that for loadaddrs
-            // and ialoads<vft-symbol> vp keeps track of the underlying type ;
+            // and aloadis<vft-symbol> vp keeps track of the underlying type ;
             // but these are actually of type java/lang/Class. when confronted
             // with the intersection between a loadaddr (whose underlying type is A)
             // and an aload (whose actual type is java/lang/Class), vp cannot intersect
             // types (when it should succeed) causing it to do wrong things
             // like fold branches etc. to detect this scenario, loadaddrs and
-            // iaload<vft-symbols> are primed with a ClassObject property.
+            // aloadi<vft-symbols> are primed with a ClassObject property.
             //
             // case 1: VPClass wrapper intersects with a VPClass wrapper (i)
             //e.g. <fixedClass, classObject> with <resolvedClass, non-null>
@@ -3855,7 +3855,7 @@ TR::VPConstraint *TR::VPObjectLocation::intersect1(TR::VPConstraint *other, OMR:
    VPObjectLocationKind result =
       (VPObjectLocationKind)(_kind & otherInfo->_kind);
 
-   //FIXME: since loadaddrs (or ialoads of vft-symbols) are primed
+   //FIXME: since loadaddrs (or aloadis of vft-symbols) are primed
    //with a ClassObject property, we could intersect ClassObject with a HeapObject
    //Leaving this here for now, in all cases where we previously would
    //have had ClassObject (and where we now have a subset of ClassObject).

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2077,7 +2077,7 @@ TR::Node *constrainIiload(OMR::ValuePropagation *vp, TR::Node *node)
             TR::Node *nullCheckNode = vp->getCurrentParent();
             nullCheckNode->setAndIncChild(0, passThroughNode);
 
-            // create a treetop containing the iiload following the current tree
+            // create a treetop containing the iloadi following the current tree
             TR::TreeTop *newTree = TR::TreeTop::create(vp->comp(), TR::Node::create(TR::treetop, 1, node));
             node->decReferenceCount();
             TR::TreeTop *prevTree = vp->_curTree;
@@ -2149,7 +2149,7 @@ TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node)
             node = transformedNode;
             }
 
-         // If it is no longer an iaload,
+         // If it is no longer an aloadi,
          // the rest of this handler may not be applicable anymore.
          //
          if (node->getOpCode().isLoadIndirect() && node->getDataType() == TR::Address)
@@ -2886,7 +2886,7 @@ TR::Node *constrainLongStore(OMR::ValuePropagation *vp, TR::Node *node)
    return node;
    }
 
-// Also handles iastore
+// Also handles astorei
 //
 TR::Node *constrainAstore(OMR::ValuePropagation *vp, TR::Node *node)
    {
@@ -2924,7 +2924,7 @@ void canRemoveWrtBar(OMR::ValuePropagation *vp, TR::Node *node)
          {
          if (node->getOpCode().isIndirect())
             {
-            if (performTransformation(vp->comp(), "%sChanging write barrier store into iastore [%p]\n", OPT_DETAILS, node))
+            if (performTransformation(vp->comp(), "%sChanging write barrier store into astorei [%p]\n", OPT_DETAILS, node))
                {
                bool invalidateInfo = false;
                if (node->getChild(2) != node->getFirstChild())
@@ -5638,7 +5638,7 @@ TR::Node *constrainCall(OMR::ValuePropagation *vp, TR::Node *node)
          /*
          n572n       vcall  sun/misc/Unsafe.ensureClassInitialized(Ljava/lang/Class;)V[#631  final native virtual Method -728]
             n577n         aload  java/lang/invoke/MethodHandle$UnsafeGetter.myUnsafe
-            n579n         iaload  java/lang/invoke/MethodHandle.defc
+            n579n         aloadi  java/lang/invoke/MethodHandle.defc
 
          Because Unsafe.ensureClassInitialized is JNI, can't use direct JNI, otherwise can't optimized it at compile time.
          */
@@ -12487,13 +12487,13 @@ TR::Node *constrainArrayStoreChk(OMR::ValuePropagation *vp, TR::Node *node)
    //
    if (!isStoreCheckNeeded)
       {
-      // Change the write barrier into iastore
+      // Change the write barrier into astorei
       //
       canRemoveWrtBar(vp, child);
 
       if (performTransformation(vp->comp(), "%sRemoving redundant arraystore check node [%p]\n", OPT_DETAILS, node))
          {
-         // Child is the iastore. Just change this node to a treetop
+         // Child is the astorei. Just change this node to a treetop
          //
          TR::Node::recreate(node, TR::treetop);
          //DemandLiteralPool can add extra aload to arraystore check node, but treetop can only have one child

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -1898,7 +1898,7 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
       else
          {
          //aiadd
-         //   iaload
+         //   aloadi
          //       aiadd
          //          aload a
          //          iadd

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -227,7 +227,7 @@ OMR::Power::MemoryReference::MemoryReference(TR::Node *rootLoadOrStore, uint32_t
             self()->setUnresolvedSnippet(new (cg->trHeapMemory()) TR::UnresolvedDataSnippet(cg, rootLoadOrStore, ref, isStore, false));
             cg->addSnippet(self()->getUnresolvedSnippet());
             }
-         // if an aconst feeds a iaload, we need to load the constant
+         // if an aconst feeds a aloadi, we need to load the constant
          if (base->getOpCode().isLoadConst())
             {
             cg->evaluate(base);

--- a/compiler/p/codegen/UnaryEvaluator.cpp
+++ b/compiler/p/codegen/UnaryEvaluator.cpp
@@ -542,11 +542,11 @@ TR::Register *OMR::Power::TreeEvaluator::l2aEvaluator(TR::Node *node, TR::CodeGe
       if (comp->useCompressedPointers())
          {
          // pattern match the sequence under the l2a
-         //    iaload f      l2a                       <- node
+         //    aloadi f      l2a                       <- node
          //       aload O       ladd
          //                       lshl
          //                          i2l
-         //                            iiload f        <- load
+         //                            iloadi f        <- load
          //                               aload O
          //                          iconst shftKonst
          //                       lconst HB
@@ -554,7 +554,7 @@ TR::Register *OMR::Power::TreeEvaluator::l2aEvaluator(TR::Node *node, TR::CodeGe
          // -or- if the load is known to be null
          //  l2a
          //    i2l
-         //      iiload f
+         //      iloadi f
          //         aload O
          //
          TR::Node *firstChild = node->getFirstChild();

--- a/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
@@ -2322,7 +2322,7 @@ TR::Register *OMR::X86::AMD64::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR
    return TR::TreeEvaluator::integerStoreEvaluator(node, cg);
    }
 
-// also handles ilload
+// also handles lloadi
 TR::Register *OMR::X86::AMD64::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::MemoryReference  *sourceMR = generateX86MemoryReference(node, cg);

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -577,7 +577,7 @@ TR::Register *OMR::X86::TreeEvaluator::performIload(TR::Node *node, TR::MemoryRe
    return reg;
    }
 
-// also handles iaload
+// also handles aloadi
 TR::Register *OMR::X86::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::MemoryReference  *sourceMR = generateX86MemoryReference(node, cg);
@@ -686,7 +686,7 @@ bool OMR::X86::TreeEvaluator::genNullTestSequence(TR::Node *node,
    }
 
 
-// also handles iiload
+// also handles iloadi
 TR::Register *OMR::X86::TreeEvaluator::iloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::MemoryReference  *sourceMR = generateX86MemoryReference(node, cg);
@@ -716,7 +716,7 @@ TR::Register *OMR::X86::TreeEvaluator::iloadEvaluator(TR::Node *node, TR::CodeGe
    return reg;
    }
 
-// also handles ibload
+// also handles bloadi
 TR::Register *OMR::X86::TreeEvaluator::bloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::MemoryReference  *sourceMR = generateX86MemoryReference(node, cg);
@@ -768,17 +768,17 @@ OMR::X86::TreeEvaluator::fwrtbariEvaluator(TR::Node *node, TR::CodeGenerator *cg
    return TR::TreeEvaluator::floatingPointStoreEvaluator(node, cg);
    }
 
-// iiload handled by iloadEvaluator
+// iloadi handled by iloadEvaluator
 
-// ilload handled by lloadEvaluator
+// lloadi handled by lloadEvaluator
 
-// ialoadEvaluator handled by iloadEvaluator
+// aloadiEvaluator handled by iloadEvaluator
 
-// ibloadEvaluator handled by bloadEvaluator
+// bloadiEvaluator handled by bloadEvaluator
 
 // isloadEvaluator handled by sloadEvaluator
 
-// also used for iistore, astore and iastore
+// also used for istorei, astore and astorei
 TR::Register *OMR::X86::TreeEvaluator::integerStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *valueChild = NULL;
@@ -939,7 +939,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerStoreEvaluator(TR::Node *node, TR:
          tempMR = generateX86MemoryReference(node, cg);
 
          // in comp->useCompressedPointers we should write 4 bytes
-         // since the iastore has been changed to an iistore, size will be 4
+         // since the astorei has been changed to an istorei, size will be 4
          //
          instr = generateMemRegInstruction(opCode, node, tempMR, valueReg, cg);
 
@@ -1090,7 +1090,7 @@ TR::Register *OMR::X86::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::CodeG
 
 // astoreEvaluator handled by istoreEvaluator
 
-// also handles ibstore
+// also handles bstorei
 TR::Register *OMR::X86::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return TR::TreeEvaluator::integerStoreEvaluator(node, cg);
@@ -1102,13 +1102,13 @@ TR::Register *OMR::X86::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::CodeG
    return TR::TreeEvaluator::integerStoreEvaluator(node, cg);
    }
 
-// iistore handled by istoreEvaluator
+// istorei handled by istoreEvaluator
 
-// ilstore handled by lstoreEvaluator
+// lstorei handled by lstoreEvaluator
 
-// iastoreEvaluator handled by istoreEvaluator
+// astoreiEvaluator handled by istoreEvaluator
 
-// ibstoreEvaluator handled by bstoreEvaluator
+// bstoreiEvaluator handled by bstoreEvaluator
 
 // isstoreEvaluator handled by sstoreEvaluator
 
@@ -4735,7 +4735,7 @@ TR::Register *OMR::X86::TreeEvaluator::conversionAnalyser(TR::Node          *nod
          {
          // we could have a sequence like
          // iu2l
-         //   iiload  <- where this node was materialized by lowering an iaload in compressedPointers mode
+         //   iloadi  <- where this node was materialized by lowering an aloadi in compressedPointers mode
          //
          if (node->getOpCodeValue() == TR::iu2l &&
                comp->useCompressedPointers() &&

--- a/compiler/x/codegen/UnaryEvaluator.cpp
+++ b/compiler/x/codegen/UnaryEvaluator.cpp
@@ -361,11 +361,11 @@ TR::Register *OMR::X86::TreeEvaluator::l2aEvaluator(TR::Node *node, TR::CodeGene
    // evaluator in use only for cg->comp()->useCompressedPointers
    //
    // pattern match the sequence under the l2a
-   //    iaload f      l2a                       <- node
+   //    aloadi f      l2a                       <- node
    //       aload O       ladd
    //                       lshl
    //                          i2l
-   //                            iiload f        <- load
+   //                            iloadi f        <- load
    //                               aload O
    //                          iconst shftKonst
    //                       lconst HB
@@ -373,7 +373,7 @@ TR::Register *OMR::X86::TreeEvaluator::l2aEvaluator(TR::Node *node, TR::CodeGene
    // -or- if the load is known to be null or usingLowMemHeap
    //  l2a
    //    i2l
-   //      iiload f
+   //      iloadi f
    //         aload O
    //
    TR::Node *firstChild = node->getFirstChild();

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -2407,7 +2407,7 @@ void OMR::X86::I386::TreeEvaluator::lStoreEvaluatorSetHighLowMRIfNeeded(TR::Node
                                                                         TR::MemoryReference *highMR,
                                                                         TR::CodeGenerator *cg) {}
 
-// also handles ilstore
+// also handles lstorei
 TR::Register *OMR::X86::I386::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
@@ -4791,7 +4791,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::dstoreEvaluator(TR::Node *node, TR:
       //
       cg->recursivelyDecReferenceCount(valueChild);
 
-      TR::TreeEvaluator::lstoreEvaluator(node, cg); // The IA32 version, handles ilstore as well
+      TR::TreeEvaluator::lstoreEvaluator(node, cg); // The IA32 version, handles lstorei as well
       return NULL;
       }
    else
@@ -5029,7 +5029,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::performLload(TR::Node *node, TR::Me
    return longRegister;
    }
 
-// also handles ilload
+// also handles lloadi
 TR::Register *OMR::X86::I386::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::MemoryReference  *sourceMR = generateX86MemoryReference(node, cg);

--- a/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
@@ -175,8 +175,8 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
    //
    //     (0)  BNDCHK
    //     (1)    l2i [node >= 0] (in GPR_0063)
-   //     (1)      ilload #155[00000000801188C8] Shadow[<array-size>]24
-   //     (2)        iaload #177[000000008012C5E0] Shadow[java/lang/ThreadGroup.childrenGroups
+   //     (1)      lloadi #155[00000000801188C8] Shadow[<array-size>]24
+   //     (2)        aloadi #177[000000008012C5E0] Shadow[java/lang/ThreadGroup.childrenGroups
    //     (1)          ==>aload at [000000008012DBE8] (in &GPR_0058)
    //     (1)    l2i (in GPR_0067)
    //     (2)      ==>i2l at [0000000080117A70]

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -206,7 +206,7 @@ OMR::Z::CodeGenerator::checkIsUnneededIALoad(TR::Node *parent, TR::Node *node, T
          }
       else // Not in list
          {
-         // We only need to track future references to this iaload if refcount  > 1
+         // We only need to track future references to this aloadi if refcount  > 1
          if (node->getReferenceCount() > 1)
             {
             uint32_t *temp ;

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -364,7 +364,7 @@ bool OMR::Z::MemoryReference::setForceFoldingIfAdvantageous(TR::CodeGenerator * 
    else // if (eventualNonConversion->getReferenceCount() == 1)
       {
       // aiadd
-      //    iaload
+      //    aloadi
       //       x
       //    iconst
       //
@@ -372,13 +372,13 @@ bool OMR::Z::MemoryReference::setForceFoldingIfAdvantageous(TR::CodeGenerator * 
       //
       // aiadd
       //    conv
-      //       iaload
+      //       aloadi
       //          x
       //    iconst
       if (cg->traceBCDCodeGen())
          {
          traceMsg(comp,
-                  " inside setForceFoldingIfAdvantageous, eventualNonConversion %s (%p) has no register and refCount==1 and is an iaload+const so eval(%s - %p) and setForceFolding=true\n",
+                  " inside setForceFoldingIfAdvantageous, eventualNonConversion %s (%p) has no register and refCount==1 and is an aloadi+const so eval(%s - %p) and setForceFolding=true\n",
                   eventualNonConversion->getOpCode().getName(),eventualNonConversion,
                   eventualNonConversion->getFirstChild()->getOpCode().getName(),eventualNonConversion->getFirstChild());
          }
@@ -1328,7 +1328,7 @@ OMR::Z::MemoryReference::populateAddTree(TR::Node * subTree, TR::CodeGenerator *
             (integerChild->getOpCodeValue() == TR::isub || integerChild->getOpCodeValue() == TR::lsub))
       {
       //
-      // catch the pattern of aiadd on iaload <base> / isub of <expression> and -<constant> and
+      // catch the pattern of aiadd on aloadi <base> / isub of <expression> and -<constant> and
       // convert it into LA Rx,<constant>(R<expression>,R<base>)
       //
       bool usingAladd = (cg->comp()->target().is64Bit()) ? true : false;
@@ -1595,7 +1595,7 @@ OMR::Z::MemoryReference::populateLoadAddrTree(TR::Node * subTree, TR::CodeGenera
    // Need to associate symref of loadaddr to the memory reference
    // so that the resolution of any offsets (in particular autos on stack)
    // can be resolved.
-   //  i.e.  iaload <o.f>+12
+   //  i.e.  aloadi <o.f>+12
    //           loadaddr <auto>
    // will generate
    //       L  +12+?(GPR5)  <-- <auto> symref will resolve the ? offset.

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -7062,7 +7062,7 @@ aloadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * tempM
    if (node->isUnneededIALoad() &&
            (node->getFirstChild()->getNumChildren() == 0 || node->getFirstChild()->getRegister() != NULL))
       {
-      traceMsg (comp, "This iaload is not needed: %p\n", node);
+      traceMsg (comp, "This aloadi is not needed: %p\n", node);
 
       tempReg= cg->allocateRegister();
       node->setRegister(tempReg);
@@ -7845,7 +7845,7 @@ astoreHelper(TR::Node * node, TR::CodeGenerator * cg)
 
 /**
  * aload Evaluator: load address
- *   - also handles aload and iaload
+ *   - also handles aload and aloadi
  */
 TR::Register *
 OMR::Z::TreeEvaluator::aloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
@@ -7913,14 +7913,14 @@ OMR::Z::TreeEvaluator::axaddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
 /**
  * Indirect Load Evaluators:
- *   iiload handled by iloadEvaluator
- *   ilload handled by lloadEvaluator
- *   ialoadEvaluator handled by aloadEvaluator
- *   ibloadEvaluator handled by bloadEvaluator
+ *   iloadi handled by iloadEvaluator
+ *   lloadi handled by lloadEvaluator
+ *   aloadiEvaluator handled by aloadEvaluator
+ *   bloadiEvaluator handled by bloadEvaluator
  *   isloadEvaluator handled by sloadEvaluator
  *
  * iload Evaluator: load integer
- *   - also handles iiload
+ *   - also handles iloadi
  */
 TR::Register *
 OMR::Z::TreeEvaluator::iloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
@@ -7931,7 +7931,7 @@ OMR::Z::TreeEvaluator::iloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
 /**
  * lload Evaluator: load long integer
- *   - also handles ilload
+ *   - also handles lloadi
  */
 TR::Register *
 OMR::Z::TreeEvaluator::lloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
@@ -7951,7 +7951,7 @@ OMR::Z::TreeEvaluator::sloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
 /**
  * bload Evaluator: load byte
- *   - also handles ibload
+ *   - also handles bloadi
  */
 TR::Register *
 OMR::Z::TreeEvaluator::bloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
@@ -7973,10 +7973,10 @@ OMR::Z::TreeEvaluator::bloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
 /**
  * Indirect Store Evaluators:
- *  ilstore handled by lstoreEvaluator
- *  iistore handled by istoreEvaluator
- *  iastoreEvaluator handled by istoreEvaluator
- *  ibstoreEvaluator handled by bstoreEvaluator
+ *  lstorei handled by lstoreEvaluator
+ *  istorei handled by istoreEvaluator
+ *  astoreiEvaluator handled by istoreEvaluator
+ *  bstoreiEvaluator handled by bstoreEvaluator
  *  isstoreEvaluator handled by sstoreEvaluator
  */
 /**
@@ -8022,7 +8022,7 @@ OMR::Z::TreeEvaluator::sstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
 /**
  * astoreEvaluator - store address
- *  - also used for iastore
+ *  - also used for astorei
  */
 TR::Register *
 OMR::Z::TreeEvaluator::astoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
@@ -8033,7 +8033,7 @@ OMR::Z::TreeEvaluator::astoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
 /**
  * bstoreEvaluator - load byte
- *  - also handles ibstore
+ *  - also handles bstorei
  */
 TR::Register *
 OMR::Z::TreeEvaluator::bstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
@@ -8073,10 +8073,10 @@ OMR::Z::TreeEvaluator::bstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       return NULL;
       }
    // Check for bit op pattern
-   // ibstore
+   // bstorei
    //   addr
    //   bor/band/bxor
-   //     ibload
+   //     bloadi
    //       =>addr
    //     bconst
    else if (((valueChild->getOpCodeValue() == TR::bor) ||
@@ -8386,7 +8386,7 @@ OMR::Z::TreeEvaluator::checkAndAllocateReferenceRegister(TR::Node * node,
       if (!symbol->isInternalPointer()  &&
           !symbol->isNotCollected()     &&
           !symbol->isAddressOfClassObject() &&
-          // LowerTrees transforms unloadable aconsts to iaload <gen. int shadow> / aconst NULL.  All aconsts are never collectable.
+          // LowerTrees transforms unloadable aconsts to aloadi <gen. int shadow> / aconst NULL.  All aconsts are never collectable.
           !(symRef->isLiteralPoolAddress() && (node->getOpCodeValue() == TR::aloadi) && constNode->isClassUnloadingConst()))
          {
          tempReg->setContainsCollectedReference();

--- a/compiler/z/codegen/UnaryEvaluator.cpp
+++ b/compiler/z/codegen/UnaryEvaluator.cpp
@@ -212,11 +212,11 @@ OMR::Z::TreeEvaluator::l2aEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    // if comp->useCompressedPointers
    //
    // pattern match the sequence under the l2a
-   //    iaload f      l2a                       <- node
+   //    aloadi f      l2a                       <- node
    //       aload O       ladd
    //                       lshl
    //                          i2l
-   //                            iiload f        <- load
+   //                            iloadi f        <- load
    //                               aload O
    //                          iconst shftKonst
    //                       lconst HB
@@ -224,7 +224,7 @@ OMR::Z::TreeEvaluator::l2aEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    // -or- if the load is known to be null
    //  l2a
    //    i2l
-   //      iiload f
+   //      iloadi f
    //         aload O
    //
    TR::Node *firstChild = node->getFirstChild();


### PR DESCRIPTION
The old opcodes had the letter i as a prefix if the operation was indirect. Those opcodes were renamed to use the letter as a suffix instead.

This commit cleans up the references to the old opcodes, iiload/iistore ilload/ilstore iaload/iastore ibload/ibstore, to iloadi/istorei lloadi/lstorei aloadi/astorei bloadi/bstorei in the code comments and trace messages.

Related: eclipse-openj9/openj9#19489