### PR TITLE
Aarch64: Fix isMethodPointerConstant call on wrong node

### DIFF
--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -158,7 +158,7 @@ static TR::Instruction *ificmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, 
    TR_ResolvedMethod *method = comp->getCurrentMethod();
    bool secondChildNeedsPicSite = (secondChild->getOpCodeValue() == TR::aconst) &&
                                     ((secondChild->isClassPointerConstant() && cg->fe()->isUnloadAssumptionRequired(reinterpret_cast<TR_OpaqueClassBlock *>(secondChild->getAddress()), method)) ||
-                                     (node->isMethodPointerConstant() && cg->fe()->isUnloadAssumptionRequired(
+                                     (secondChild->isMethodPointerConstant() && cg->fe()->isUnloadAssumptionRequired(
                                       cg->fe()->createResolvedMethod(cg->trMemory(), reinterpret_cast<TR_OpaqueMethodBlock *>(secondChild->getAddress()), method)->classOfMethod(), method)));
 
 #ifdef J9_PROJECT_SPECIFIC


### PR DESCRIPTION
While testing jb2 on my macbook, I ran into a crash in JIT asking an ifcmp node if it was a method pointer constant, which should only be asked of aconsts or loadaddrs. There was an obvious typo asking this question of "node" rather than "secondChild" so this fixes that typo.