### PR TITLE
Avoid shifting negative signed value

### DIFF
--- a/compiler/x/codegen/DataSnippet.cpp
+++ b/compiler/x/codegen/DataSnippet.cpp
@@ -103,7 +103,7 @@ uint8_t *TR::X86DataSnippet::emitSnippetBody()
    // align to 16 bytes
    if (getDataSize() % 16 == 0)
       {
-      cursor = (uint8_t *)(((intptr_t)(cursor + 15)) & ((intptr_t)(-1)<<4));
+      cursor = (uint8_t *)(((intptr_t)(cursor + 15)) & -(1<<4));
       }
 
    getSnippetLabel()->setCodeLocation(cursor);


### PR DESCRIPTION
Shifting a negative signed value as was done here produces a clang warning about undefined behaviour.