### PR TITLE
 Add zNext support

### DIFF
--- a/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
+++ b/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
@@ -424,7 +424,11 @@ bool TR_RedundantAsyncCheckRemoval::callDoesAnImplicitAsyncCheck(TR::Node *callN
        (symbol->getRecognizedMethod()==TR::java_lang_Integer_rotateLeft) ||
        (symbol->getRecognizedMethod()==TR::java_lang_Long_rotateLeft) ||
        (symbol->getRecognizedMethod()==TR::java_lang_Integer_rotateRight) ||
-       (symbol->getRecognizedMethod()==TR::java_lang_Long_rotateRight)
+       (symbol->getRecognizedMethod()==TR::java_lang_Long_rotateRight) ||
+       (symbol->getRecognizedMethod()==TR::java_lang_Integer_compress) ||
+       (symbol->getRecognizedMethod()==TR::java_lang_Long_compress) ||
+       (symbol->getRecognizedMethod()==TR::java_lang_Integer_expand) ||
+       (symbol->getRecognizedMethod()==TR::java_lang_Long_expand)
        )
        return false;
 

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -918,6 +918,7 @@ TR::Node * constrainLongBitCount(OMR::ValuePropagation *vp, TR::Node *node);
 #define pdModifyPrecisionVPHandler constrainChildren
 #define countDigitsVPHandler constrainChildren
 #define BCDCHKVPHandler constrainBCDCHK
+#define zdchkVPHandler constrainChildren
 #endif
 
 const ValuePropagationPointerTable constraintHandlers;

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -2343,6 +2343,12 @@ void OMR::Z::TreeEvaluator::createDAACondDeps(TR::Node * node, TR::RegisterDepen
          TR::TreeEvaluator::addToRegDep(daaDeps, daaInstr->getRegisterOperand(2), false);
          break;
          }
+      case TR::Instruction::IsVRIl: // VTZ
+         {
+         TR::TreeEvaluator::addToRegDep(daaDeps, daaInstr->getRegisterOperand(1), false);
+         TR::TreeEvaluator::addToRegDep(daaDeps, daaInstr->getRegisterOperand(2), false);
+         break;
+         }
       case TR::Instruction::IsVRRg: // VTP
          {
          TR::TreeEvaluator::addToRegDep(daaDeps, daaInstr->getRegisterOperand(1), false);

--- a/compiler/z/codegen/InstOpCode.cpp
+++ b/compiler/z/codegen/InstOpCode.cpp
@@ -130,6 +130,7 @@ OMR::Z::InstOpCode::copyBinaryToBufferWithoutClear(uint8_t *cursor, TR::InstOpCo
         case VRIg_FORMAT:
         case VRIh_FORMAT:
         case VRIi_FORMAT:
+        case VRIl_FORMAT:
         case VRRa_FORMAT:
         case VRRb_FORMAT:
         case VRRc_FORMAT:

--- a/compiler/z/codegen/InstOpCode.cpp
+++ b/compiler/z/codegen/InstOpCode.cpp
@@ -119,6 +119,7 @@ OMR::Z::InstOpCode::copyBinaryToBufferWithoutClear(uint8_t *cursor, TR::InstOpCo
         case RXF_FORMAT:
         case RXYa_FORMAT:
         case RXYb_FORMAT:
+        case RXYc_FORMAT:
         case SIY_FORMAT:
         case VRIa_FORMAT:
         case VRIb_FORMAT:

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -408,17 +408,12 @@ OMR::Z::CodeGenerator::lowerTreeIfNeeded(
          }
       }
 
-   static const bool canEmulateLXA = TR::InstOpCode(TR::InstOpCode::LXAB).canEmulate() &&
-                                     TR::InstOpCode(TR::InstOpCode::LXAH).canEmulate() &&
-                                     TR::InstOpCode(TR::InstOpCode::LXAF).canEmulate() &&
-                                     TR::InstOpCode(TR::InstOpCode::LXAG).canEmulate() &&
-                                     TR::InstOpCode(TR::InstOpCode::LXAQ).canEmulate();
    static bool disableLXAUncommoning = feGetEnv("TR_disableLXAUncommoning") != NULL;
 
    if (!disableLXAUncommoning &&
        (node->getOpCodeValue() == TR::aiadd || node->getOpCodeValue() == TR::aladd) &&
        !parent->getOpCode().isLoad() &&
-       (canEmulateLXA || self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_ZNEXT)))
+       self()->getUseLXAInstructions())
       {
       // To enable generating more LXAs, perform uncommoning on trees that look like this:
       // axadd
@@ -650,6 +645,15 @@ OMR::Z::CodeGenerator::initialize()
       comp->setOption(TR_DisableVectorBCD);
       }
 
+   static bool canEmulateLXA = TR::InstOpCode(TR::InstOpCode::LXAB).canEmulate() &&
+                                     TR::InstOpCode(TR::InstOpCode::LXAH).canEmulate() &&
+                                     TR::InstOpCode(TR::InstOpCode::LXAF).canEmulate() &&
+                                     TR::InstOpCode(TR::InstOpCode::LXAG).canEmulate() &&
+                                     TR::InstOpCode(TR::InstOpCode::LXAQ).canEmulate();
+   if (canEmulateLXA || comp->target().cpu.isAtLeast(OMR_PROCESSOR_S390_ZNEXT))
+      {
+      cg->setUseLXAInstructions(true);
+      }
    // Be pessimistic until we can prove we don't exit after doing code-generation
    cg->setExitPointsInMethod(true);
 

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -722,8 +722,13 @@ public:
 
    int32_t arrayTranslateAndTestMinimumNumberOfIterations() { return 4; }
 
-   /** Yank the scaling opp up a tree in lowerTrees */
-   bool yankIndexScalingOp() {return true;}
+   /**
+    * Yank the scaling op up a tree in lowerTrees
+    */
+   bool yankIndexScalingOp()
+      {
+      return false;
+      }
 
    bool excludeInvariantsFromGRAEnabled();
 

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -505,6 +505,9 @@ public:
    bool getCondCodeShouldBePreserved() { return _cgFlags.testAny(S390CG_condCodeShouldBePreserved); }
    void setCondCodeShouldBePreserved(bool b) { _cgFlags.set(S390CG_condCodeShouldBePreserved, b); }
 
+   bool getUseLXAInstructions() { return _cgFlags.testAny(S390CG_useLXAInstructions); }
+   void setUseLXAInstructions(bool b) { _cgFlags.set(S390CG_useLXAInstructions, b); }
+
    uint8_t getFCondMoveBranchOpCond() { return fCondMoveBranchOpCond; }
    void setFCondMoveBranchOpCond(TR::InstOpCode::S390BranchCondition b) { fCondMoveBranchOpCond = (getMaskForBranchCondition(b)) & 0xF; }
 
@@ -727,7 +730,7 @@ public:
     */
    bool yankIndexScalingOp()
       {
-      return false;
+      return !getUseLXAInstructions();
       }
 
    bool excludeInvariantsFromGRAEnabled();
@@ -836,7 +839,7 @@ protected:
       S390CG_condCodeShouldBePreserved   = 0x00004000,
       S390CG_enableBranchPreload         = 0x00008000,
       S390CG_globalStaticBaseRegisterOn  = 0x00010000,
-      // Available                       = 0x00020000,
+      S390CG_useLXAInstructions          = 0x00020000,
       S390CG_canExceptByTrap             = 0x00040000,
       S390CG_enableTLHPrefetching        = 0x00080000,
       S390CG_enableBranchPreloadForCalls = 0x00100000,

--- a/compiler/z/codegen/OMRInstOpCode.enum
+++ b/compiler/z/codegen/OMRInstOpCode.enum
@@ -1161,7 +1161,7 @@
    VLBRREP,             // vector load byte reversed element and replicate
    VLEBRF,              // vector load byte reversed element (32)
    VLEBRG,              // vector load byte reversed element (64)
-   VLEBRH,              // vector load byte reversed element (16)   
+   VLEBRH,              // vector load byte reversed element (16)
    VLER,                // vector load elements reversed
    VLLEBRZ,             // vector load byte reversed element and zero
    VSTBR,               // vector store byte reversed elements
@@ -1179,4 +1179,28 @@
    VUPKZL,              // VECTOR UNPACK ZONED LOW
    VUPKZH,              // VECTOR UNPACK ZONED HIGH
 
-   S390LastOp = VUPKZH,
+   /* zNext Instructions */
+   BDEPG,               // BIT DEPOSIT
+   BEXTG,               // BIT EXTRACT
+   CLZG,                // COUNT LEADING ZEROS
+   CTZG,                // COUNT TRAILING ZEROS
+   LLXAB,               // LOAD LOGICAL INDEXED ADDRESS (8)
+   LLXAF,               // LOAD LOGICAL INDEXED ADDRESS (32)
+   LLXAG,               // LOAD LOGICAL INDEXED ADDRESS (64)
+   LLXAH,               // LOAD LOGICAL INDEXED ADDRESS (16)
+   LLXAQ,               // LOAD LOGICAL INDEXED ADDRESS (128)
+   LXAB,                // LOAD INDEXED ADDRESS (8)
+   LXAF,                // LOAD INDEXED ADDRESS (32)
+   LXAG,                // LOAD INDEXED ADDRESS (64)
+   LXAH,                // LOAD INDEXED ADDRESS (16)
+   LXAQ,                // LOAD INDEXED ADDRESS (128)
+   VBLEND,              // VECTOR BLEND
+   VEVAL,               // VECTOR EVALUATE
+   VD,                  // VECTOR DIVIDE
+   VDL,                 // VECTOR DIVIDE LOGICAL
+   VGEM,                // VECTOR GENERATE ELEMENT MASKS
+   VR,                  // VECTOR REMAINDER
+   VRL,                 // VECTOR REMAINDER LOGICAL
+   VTZ,                 // VECTOR TEST ZONED
+
+   S390LastOp = VTZ,

--- a/compiler/z/codegen/OMRInstOpCode.hpp
+++ b/compiler/z/codegen/OMRInstOpCode.hpp
@@ -628,6 +628,14 @@ class InstOpCode: public OMR::InstOpCode
    uint64_t isVectorStringOp() {return metadata[_mnemonic].properties & S390OpProp_VectorStringOp;}
    uint64_t isVectorFPOp() {return metadata[_mnemonic].properties & S390OpProp_VectorFPOp;}
    uint64_t isEmulatable() {return metadata[_mnemonic].properties & S390OpProp_IsEmulatable;}
+   bool canEmulate()
+   {
+#ifdef EMULATE_ZNEXT
+      return isEmulatable();
+#else
+      return false;
+#endif
+   }
 
    /* Static */
    static void copyBinaryToBufferWithoutClear(uint8_t *cursor, Mnemonic i_opCode);

--- a/compiler/z/codegen/OMRInstOpCode.hpp
+++ b/compiler/z/codegen/OMRInstOpCode.hpp
@@ -400,7 +400,7 @@ namespace Z
 #define S390OpProp_ImplicitlySetsGPR3     static_cast<uint64_t>(0x1000000000000000ull)
 #define S390OpProp_ImplicitlySetsGPR4     static_cast<uint64_t>(0x2000000000000000ull)
 #define S390OpProp_ImplicitlySetsGPR5     static_cast<uint64_t>(0x4000000000000000ull)
-// Available                              static_cast<uint64_t>(0x8000000000000000ull)
+#define S390OpProp_IsEmulatable           static_cast<uint64_t>(0x8000000000000000ull)
 
 class InstOpCode: public OMR::InstOpCode
    {
@@ -627,6 +627,7 @@ class InstOpCode: public OMR::InstOpCode
    uint64_t hasExtendedMnemonic() {return metadata[_mnemonic].properties & S390OpProp_HasExtendedMnemonic;}
    uint64_t isVectorStringOp() {return metadata[_mnemonic].properties & S390OpProp_VectorStringOp;}
    uint64_t isVectorFPOp() {return metadata[_mnemonic].properties & S390OpProp_VectorFPOp;}
+   uint64_t isEmulatable() {return metadata[_mnemonic].properties & S390OpProp_IsEmulatable;}
 
    /* Static */
    static void copyBinaryToBufferWithoutClear(uint8_t *cursor, Mnemonic i_opCode);

--- a/compiler/z/codegen/OMRInstOpCode.hpp
+++ b/compiler/z/codegen/OMRInstOpCode.hpp
@@ -282,7 +282,7 @@ namespace Z
 #define   RSa_FORMAT    36
 #define   RSb_FORMAT    37
 #define   RSI_FORMAT    38
-#define   RSLa_FORMAT   40 
+#define   RSLa_FORMAT   40
 #define   RSLb_FORMAT   41
 #define   RSYa_FORMAT   43
 #define   RSYb_FORMAT   44
@@ -292,45 +292,48 @@ namespace Z
 #define   RXF_FORMAT    49
 #define   RXYa_FORMAT   51
 #define   RXYb_FORMAT   52
-#define   S_FORMAT      53
-#define   SI_FORMAT     54
-#define   SIL_FORMAT    55
-#define   SIY_FORMAT    56
-#define   SMI_FORMAT    57
-#define   SSa_FORMAT    60
-#define   SSb_FORMAT    61
-#define   SSc_FORMAT    62
-#define   SSd_FORMAT    63
-#define   SSe_FORMAT    64
-#define   SSf_FORMAT    65
-#define   SSE_FORMAT    66
-#define   SSF_FORMAT    67
-#define   VRIa_FORMAT   68
-#define   VRIb_FORMAT   69
-#define   VRIc_FORMAT   70
-#define   VRId_FORMAT   71
-#define   VRIe_FORMAT   72
-#define   VRIf_FORMAT   73
-#define   VRIg_FORMAT   74
-#define   VRIh_FORMAT   75
-#define   VRIi_FORMAT   76
-#define   VRRa_FORMAT   77
-#define   VRRb_FORMAT   78
-#define   VRRc_FORMAT   79
-#define   VRRd_FORMAT   80
-#define   VRRe_FORMAT   81
-#define   VRRf_FORMAT   82
-#define   VRRg_FORMAT   83
-#define   VRRh_FORMAT   84
-#define   VRRi_FORMAT   85
-#define   VRRk_FORMAT   86
-#define   VRSa_FORMAT   87
-#define   VRSb_FORMAT   88
-#define   VRSc_FORMAT   89
-#define   VRSd_FORMAT   90
-#define   VRV_FORMAT    91
-#define   VRX_FORMAT    92
-#define   VSI_FORMAT    93
+#define   RXYc_FORMAT   53
+#define   S_FORMAT      54
+#define   SI_FORMAT     55
+#define   SIL_FORMAT    56
+#define   SIY_FORMAT    57
+#define   SMI_FORMAT    60
+#define   SSa_FORMAT    61
+#define   SSb_FORMAT    62
+#define   SSc_FORMAT    63
+#define   SSd_FORMAT    64
+#define   SSe_FORMAT    65
+#define   SSf_FORMAT    66
+#define   SSE_FORMAT    67
+#define   SSF_FORMAT    68
+#define   VRIa_FORMAT   69
+#define   VRIb_FORMAT   70
+#define   VRIc_FORMAT   71
+#define   VRId_FORMAT   72
+#define   VRIe_FORMAT   73
+#define   VRIf_FORMAT   74
+#define   VRIg_FORMAT   75
+#define   VRIh_FORMAT   76
+#define   VRIi_FORMAT   77
+#define   VRIk_FORMAT   78
+#define   VRIl_FORMAT   79
+#define   VRRa_FORMAT   80
+#define   VRRb_FORMAT   81
+#define   VRRc_FORMAT   82
+#define   VRRd_FORMAT   83
+#define   VRRe_FORMAT   84
+#define   VRRf_FORMAT   85
+#define   VRRg_FORMAT   86
+#define   VRRh_FORMAT   87
+#define   VRRi_FORMAT   88
+#define   VRRk_FORMAT   89
+#define   VRSa_FORMAT   90
+#define   VRSb_FORMAT   91
+#define   VRSc_FORMAT   92
+#define   VRSd_FORMAT   93
+#define   VRV_FORMAT    94
+#define   VRX_FORMAT    95
+#define   VSI_FORMAT    96
 
 /* Instruction Properties (One hot encoding) */
 #define S390OpProp_None                   static_cast<uint64_t>(0x0000000000000000ull)
@@ -414,54 +417,54 @@ class InstOpCode: public OMR::InstOpCode
                            ----------------------------------------- */
       COND_NOPR,        // Conditional Branch     No operation (RR)
       COND_NOP,         // Conditional Branch     No Operation (RX)
-      COND_VGNOP,       // Virtual Guard          No Operation 
-      COND_BRO,         // Relative Branch        Branch Relative on Overflow 
+      COND_VGNOP,       // Virtual Guard          No Operation
+      COND_BRO,         // Relative Branch        Branch Relative on Overflow
       COND_BRH,         // Relative Branch        Branch Relative on High
-      COND_BRP,         // Relative Branch        Branch Relative on Plus 
+      COND_BRP,         // Relative Branch        Branch Relative on Plus
       COND_BRL,         // Relative Branch        Branch Relative on A Low
       COND_BRM,         // Relative Branch        Branch Relative on Minus
       COND_BRNE,        // Relative Branch        Branch Relative on A Not Equal B
       COND_BRNZ,        // Relative Branch        Branch Relative on Not Zero
-      COND_BRE,         // Relative Branch        Branch Relative on A Equal B 
-      COND_BRZ,         // Relative Branch        Branch Relative on Zero 
-      COND_BRNH,        // Relative Branch        Branch Relative on A Not High 
+      COND_BRE,         // Relative Branch        Branch Relative on A Equal B
+      COND_BRZ,         // Relative Branch        Branch Relative on Zero
+      COND_BRNH,        // Relative Branch        Branch Relative on A Not High
       COND_BRNL,        // Relative Branch        Branch Relative on A Not Low
-      COND_BRNM,        // Relative Branch        Branch Relative on Not Minus 
+      COND_BRNM,        // Relative Branch        Branch Relative on Not Minus
       COND_BRNP,        // Relative Branch        Branch Relative on Not Plus
-      COND_BRNO,        // Relative Branch        Branch Relative on No Overflow 
+      COND_BRNO,        // Relative Branch        Branch Relative on No Overflow
       COND_B,           // Conditional Branch     Unconditional Branch (RX)
       COND_BR,          // Branch on Condition    Unconditional Branch (RR)
-      COND_BRU,         // Relative Branch        Unconditional Branch Relative 
+      COND_BRU,         // Relative Branch        Unconditional Branch Relative
       COND_BRUL,        // Relative Branch        Unconditional Branch Relative
-      COND_BC,          // Conditional Branch     Branch on Condition (RX)  
+      COND_BC,          // Conditional Branch     Branch on Condition (RX)
       COND_BCR,         // Conditional Branch     Branch on Condition (RR)
       COND_BE,          // Conditional Branch     Branch on A Equal B (RX)
-      COND_BER,         // Conditional Branch     Branch on A Equal B (RR) 
+      COND_BER,         // Conditional Branch     Branch on A Equal B (RR)
       COND_BH,          // Conditional Branch     Branch on A High (RX)
       COND_BHR,         // Conditional Branch     Branch on A High (RR)
       COND_BL,          // Conditional Branch     Branch on A Low (RX)
-      COND_BLR,         // Conditional Branch     Branch on A Low (RR) 
+      COND_BLR,         // Conditional Branch     Branch on A Low (RR)
       COND_BM,          // Conditional Branch     Branch on Minus (RX)
       COND_BMR,         // Conditional Branch     Branch on Minus (RR)
       COND_BNE,         // Conditional Branch     Branch on A Not Equal B (RX)
       COND_BNER,        // Conditional Branch     Branch on A Not Equal B (RR)
       COND_BNH,         // Conditional Branch     Branch on A Not High (RX)
-      COND_BNHR,        // Conditional Branch     Branch on A Not High (RR) 
+      COND_BNHR,        // Conditional Branch     Branch on A Not High (RR)
       COND_BNL,         // Conditional Branch     Branch on A Not Low (RX)
-      COND_BNLR,        // Conditional Branch     Branch on A Not Low (RR) 
+      COND_BNLR,        // Conditional Branch     Branch on A Not Low (RR)
       COND_BNM,         // Conditional Branch     Branch on Not Minus (RX)
       COND_BNMR,        // Conditional Branch     Branch on Not Minus (RR)
       COND_BNO,         // Conditional Branch     Branch on No Overflow (RX)
-      COND_BNOR,        // Conditional Branch     Branch on No Overflow (RR) 
-      COND_BNP,         // Conditional Branch     Branch on Not Plus (RX) 
+      COND_BNOR,        // Conditional Branch     Branch on No Overflow (RR)
+      COND_BNP,         // Conditional Branch     Branch on Not Plus (RX)
       COND_BNPR,        // Conditional Branch     Branch on Not Plus (RR)
       COND_BNZ,         // Conditional Branch     Branch on Not Zero (RX)
       COND_BNZR,        // Conditional Branch     Branch on Not Zero (RR)
-      COND_BO,          // Conditional Branch     Branch on Overflow (RX) 
+      COND_BO,          // Conditional Branch     Branch on Overflow (RX)
       COND_BOR,         // Conditional Branch     Branch on Overflow (RR)
       COND_BP,          // Conditional Branch     Branch on Plus (RX)
       COND_BPR,         // Conditional Branch     Branch on Plus (RR)
-      COND_BRC,         // Relative Branch        Branch Relative on Condition               
+      COND_BRC,         // Relative Branch        Branch Relative on Condition
       COND_BZ,          // Conditional Branch     Branch on Zero (RX)
       COND_BZR,         // Conditional Branch     Branch on Zero (RR)
       COND_MASK0,

--- a/compiler/z/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeProperties.hpp
@@ -16037,3 +16037,275 @@
    /* .properties  = */ S390OpProp_SetsOperand1 |
                         S390OpProp_UsesM3
    },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::BDEPG,
+   /* .name        = */ "BDEPG",
+   /* .description = */ "BIT DEPOSIT",
+   /* .opcode[0]   = */ 0xB9,
+   /* .opcode[1]   = */ 0x6D,
+   /* .format      = */ RRFa_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsOperand1
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::BEXTG,
+   /* .name        = */ "BEXTG",
+   /* .description = */ "BIT EXTRACT",
+   /* .opcode[0]   = */ 0xB9,
+   /* .opcode[1]   = */ 0x6C,
+   /* .format      = */ RRFa_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsOperand1
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::CLZG,
+   /* .name        = */ "CLZG",
+   /* .description = */ "COUNT LEADING ZEROS",
+   /* .opcode[0]   = */ 0xB9,
+   /* .opcode[1]   = */ 0x68,
+   /* .format      = */ RRE_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsOperand1
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::CTZG,
+   /* .name        = */ "CTZG",
+   /* .description = */ "COUNT TRAILING ZEROS",
+   /* .opcode[0]   = */ 0xB9,
+   /* .opcode[1]   = */ 0x69,
+   /* .format      = */ RRE_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsOperand1
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::LLXAB,
+   /* .name        = */ "LLXAB",
+   /* .description = */ "LOAD LOGICAL INDEXED ADDRESS (8)",
+   /* .opcode[0]   = */ 0xE3,
+   /* .opcode[1]   = */ 0x61,
+   /* .format      = */ RXYc_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_LongDispSupported |
+                        S390OpProp_SetsOperand1
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::LLXAF,
+   /* .name        = */ "LLXAF",
+   /* .description = */ "LOAD LOGICAL INDEXED ADDRESS (32)",
+   /* .opcode[0]   = */ 0xE3,
+   /* .opcode[1]   = */ 0x65,
+   /* .format      = */ RXYc_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_LongDispSupported |
+                        S390OpProp_SetsOperand1
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::LLXAG,
+   /* .name        = */ "LLXAG",
+   /* .description = */ "LOAD LOGICAL INDEXED ADDRESS (64)",
+   /* .opcode[0]   = */ 0xE3,
+   /* .opcode[1]   = */ 0x67,
+   /* .format      = */ RXYc_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_LongDispSupported |
+                        S390OpProp_SetsOperand1
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::LLXAH,
+   /* .name        = */ "LLXAH",
+   /* .description = */ "LOAD LOGICAL INDEXED ADDRESS (16)",
+   /* .opcode[0]   = */ 0xE3,
+   /* .opcode[1]   = */ 0x63,
+   /* .format      = */ RXYc_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_LongDispSupported |
+                        S390OpProp_SetsOperand1
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::LLXAQ,
+   /* .name        = */ "LLXAQ",
+   /* .description = */ "LOAD LOGICAL INDEXED ADDRESS (128)",
+   /* .opcode[0]   = */ 0xE3,
+   /* .opcode[1]   = */ 0x69,
+   /* .format      = */ RXYc_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_LongDispSupported |
+                        S390OpProp_SetsOperand1
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::LXAB,
+   /* .name        = */ "LXAB",
+   /* .description = */ "LOAD INDEXED ADDRESS (8)",
+   /* .opcode[0]   = */ 0xE3,
+   /* .opcode[1]   = */ 0x60,
+   /* .format      = */ RXYc_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_LongDispSupported |
+                        S390OpProp_SetsOperand1
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::LXAF,
+   /* .name        = */ "LXAF",
+   /* .description = */ "LOAD INDEXED ADDRESS (32)",
+   /* .opcode[0]   = */ 0xE3,
+   /* .opcode[1]   = */ 0x64,
+   /* .format      = */ RXYc_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_LongDispSupported |
+                        S390OpProp_SetsOperand1
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::LXAG,
+   /* .name        = */ "LXAG",
+   /* .description = */ "LOAD INDEXED ADDRESS (64)",
+   /* .opcode[0]   = */ 0xE3,
+   /* .opcode[1]   = */ 0x66,
+   /* .format      = */ RXYc_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_LongDispSupported |
+                        S390OpProp_SetsOperand1
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::LXAH,
+   /* .name        = */ "LXAH",
+   /* .description = */ "LOAD INDEXED ADDRESS (16)",
+   /* .opcode[0]   = */ 0xE3,
+   /* .opcode[1]   = */ 0x62,
+   /* .format      = */ RXYc_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_LongDispSupported |
+                        S390OpProp_SetsOperand1
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::LXAQ,
+   /* .name        = */ "LXAQ",
+   /* .description = */ "LOAD INDEXED ADDRESS (128)",
+   /* .opcode[0]   = */ 0xE3,
+   /* .opcode[1]   = */ 0x68,
+   /* .format      = */ RXYc_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_LongDispSupported |
+                        S390OpProp_SetsOperand1
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::VBLEND,
+   /* .name        = */ "VBLEND",
+   /* .description = */ "VECTOR BLEND",
+   /* .opcode[0]   = */ 0xE7,
+   /* .opcode[1]   = */ 0x89,
+   /* .format      = */ VRRd_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_SetsOperand1 |
+                        S390OpProp_HasExtendedMnemonic |
+                        S390OpProp_UsesM5
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::VEVAL,
+   /* .name        = */ "VEVAL",
+   /* .description = */ "VECTOR EVALUATE",
+   /* .opcode[0]   = */ 0xE7,
+   /* .opcode[1]   = */ 0x88,
+   /* .format      = */ VRIk_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_SetsOperand1
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::VD,
+   /* .name        = */ "VD",
+   /* .description = */ "VECTOR DIVIDE",
+   /* .opcode[0]   = */ 0xE7,
+   /* .opcode[1]   = */ 0xB2,
+   /* .format      = */ VRRc_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_SetsOperand1 |
+                        S390OpProp_HasExtendedMnemonic |
+                        S390OpProp_UsesM4 |
+                        S390OpProp_UsesM5
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::VDL,
+   /* .name        = */ "VDL",
+   /* .description = */ "VECTOR DIVIDE LOGICAL",
+   /* .opcode[0]   = */ 0xE7,
+   /* .opcode[1]   = */ 0xB0,
+   /* .format      = */ VRRc_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_SetsOperand1 |
+                        S390OpProp_HasExtendedMnemonic |
+                        S390OpProp_UsesM4 |
+                        S390OpProp_UsesM5
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::VGEM,
+   /* .name        = */ "VGEM",
+   /* .description = */ "VECTOR GENERATE ELEMENT MASKS",
+   /* .opcode[0]   = */ 0xE7,
+   /* .opcode[1]   = */ 0x54,
+   /* .format      = */ VRRa_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_SetsOperand1 |
+                        S390OpProp_HasExtendedMnemonic |
+                        S390OpProp_UsesM3
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::VR,
+   /* .name        = */ "VR",
+   /* .description = */ "VECTOR REMAINDER",
+   /* .opcode[0]   = */ 0xE7,
+   /* .opcode[1]   = */ 0xB3,
+   /* .format      = */ VRRc_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_SetsOperand1 |
+                        S390OpProp_HasExtendedMnemonic |
+                        S390OpProp_UsesM4 |
+                        S390OpProp_UsesM5
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::VRL,
+   /* .name        = */ "VRL",
+   /* .description = */ "VECTOR REMAINDER LOGICAL",
+   /* .opcode[0]   = */ 0xE7,
+   /* .opcode[1]   = */ 0xB1,
+   /* .format      = */ VRRc_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_SetsOperand1 |
+                        S390OpProp_HasExtendedMnemonic |
+                        S390OpProp_UsesM4 |
+                        S390OpProp_UsesM5
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::VTZ,
+   /* .name        = */ "VTZ",
+   /* .description = */ "VECTOR TEST ZONED",
+   /* .opcode[0]   = */ 0xE6,
+   /* .opcode[1]   = */ 0x7F,
+   /* .format      = */ VRIl_FORMAT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .properties  = */ S390OpProp_SetsCC
+   },

--- a/compiler/z/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeProperties.hpp
@@ -16047,7 +16047,8 @@
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
    /* .properties  = */ S390OpProp_Is64Bit |
-                        S390OpProp_SetsOperand1
+                        S390OpProp_SetsOperand1 |
+                        S390OpProp_IsEmulatable
    },
 
    {
@@ -16059,7 +16060,8 @@
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
    /* .properties  = */ S390OpProp_Is64Bit |
-                        S390OpProp_SetsOperand1
+                        S390OpProp_SetsOperand1 |
+                        S390OpProp_IsEmulatable
    },
 
    {
@@ -16095,7 +16097,8 @@
    /* .format      = */ RXYc_FORMAT,
    /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
    /* .properties  = */ S390OpProp_LongDispSupported |
-                        S390OpProp_SetsOperand1
+                        S390OpProp_SetsOperand1 |
+                        S390OpProp_IsEmulatable
    },
 
    {
@@ -16107,7 +16110,8 @@
    /* .format      = */ RXYc_FORMAT,
    /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
    /* .properties  = */ S390OpProp_LongDispSupported |
-                        S390OpProp_SetsOperand1
+                        S390OpProp_SetsOperand1 |
+                        S390OpProp_IsEmulatable
    },
 
    {
@@ -16119,7 +16123,8 @@
    /* .format      = */ RXYc_FORMAT,
    /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
    /* .properties  = */ S390OpProp_LongDispSupported |
-                        S390OpProp_SetsOperand1
+                        S390OpProp_SetsOperand1 |
+                        S390OpProp_IsEmulatable
    },
 
    {
@@ -16131,7 +16136,8 @@
    /* .format      = */ RXYc_FORMAT,
    /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
    /* .properties  = */ S390OpProp_LongDispSupported |
-                        S390OpProp_SetsOperand1
+                        S390OpProp_SetsOperand1 |
+                        S390OpProp_IsEmulatable
    },
 
    {
@@ -16143,7 +16149,8 @@
    /* .format      = */ RXYc_FORMAT,
    /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
    /* .properties  = */ S390OpProp_LongDispSupported |
-                        S390OpProp_SetsOperand1
+                        S390OpProp_SetsOperand1 |
+                        S390OpProp_IsEmulatable
    },
 
    {
@@ -16155,7 +16162,8 @@
    /* .format      = */ RXYc_FORMAT,
    /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
    /* .properties  = */ S390OpProp_LongDispSupported |
-                        S390OpProp_SetsOperand1
+                        S390OpProp_SetsOperand1 |
+                        S390OpProp_IsEmulatable
    },
 
    {
@@ -16167,7 +16175,8 @@
    /* .format      = */ RXYc_FORMAT,
    /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
    /* .properties  = */ S390OpProp_LongDispSupported |
-                        S390OpProp_SetsOperand1
+                        S390OpProp_SetsOperand1 |
+                        S390OpProp_IsEmulatable
    },
 
    {
@@ -16179,7 +16188,8 @@
    /* .format      = */ RXYc_FORMAT,
    /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
    /* .properties  = */ S390OpProp_LongDispSupported |
-                        S390OpProp_SetsOperand1
+                        S390OpProp_SetsOperand1 |
+                        S390OpProp_IsEmulatable
    },
 
    {
@@ -16191,7 +16201,8 @@
    /* .format      = */ RXYc_FORMAT,
    /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
    /* .properties  = */ S390OpProp_LongDispSupported |
-                        S390OpProp_SetsOperand1
+                        S390OpProp_SetsOperand1 |
+                        S390OpProp_IsEmulatable
    },
 
    {
@@ -16203,7 +16214,8 @@
    /* .format      = */ RXYc_FORMAT,
    /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
    /* .properties  = */ S390OpProp_LongDispSupported |
-                        S390OpProp_SetsOperand1
+                        S390OpProp_SetsOperand1 |
+                        S390OpProp_IsEmulatable
    },
 
    {

--- a/compiler/z/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeProperties.hpp
@@ -16073,7 +16073,8 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
    /* .properties  = */ S390OpProp_Is64Bit |
-                        S390OpProp_SetsOperand1
+                        S390OpProp_SetsOperand1 |
+                        S390OpProp_IsEmulatable
    },
 
    {
@@ -16085,7 +16086,8 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
    /* .properties  = */ S390OpProp_Is64Bit |
-                        S390OpProp_SetsOperand1
+                        S390OpProp_SetsOperand1 |
+                        S390OpProp_IsEmulatable
    },
 
    {

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -86,7 +86,7 @@ OMR::Z::Instruction::Instruction(TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic
    OMR::Instruction(cg, op, node),
    CTOR_INITIALIZER_LIST
    {
-   TR_ASSERT_FATAL(cg->comp()->target().cpu.isAtLeast(_opcode.getMinimumALS()), "Processor detected (%s) does not support instruction %s\n", cg->comp()->target().cpu.getProcessorName(), _opcode.getMnemonicName());
+   TR_ASSERT_FATAL(canEmulate() || cg->comp()->target().cpu.isAtLeast(_opcode.getMinimumALS()), "Processor detected (%s) does not support instruction %s\n", cg->comp()->target().cpu.getProcessorName(), _opcode.getMnemonicName());
 
    self()->initialize();
    }
@@ -96,7 +96,7 @@ OMR::Z::Instruction::Instruction(TR::CodeGenerator*cg, TR::Instruction* precedin
    OMR::Instruction(cg, precedingInstruction, op, node),
    CTOR_INITIALIZER_LIST
    {
-   TR_ASSERT_FATAL(cg->comp()->target().cpu.isAtLeast(_opcode.getMinimumALS()), "Processor detected (%s) does not support instruction %s\n", cg->comp()->target().cpu.getProcessorName(), _opcode.getMnemonicName());
+   TR_ASSERT_FATAL(canEmulate() || cg->comp()->target().cpu.isAtLeast(_opcode.getMinimumALS()), "Processor detected (%s) does not support instruction %s\n", cg->comp()->target().cpu.getProcessorName(), _opcode.getMnemonicName());
 
    self()->initialize(precedingInstruction, true);
    }

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -86,7 +86,7 @@ OMR::Z::Instruction::Instruction(TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic
    OMR::Instruction(cg, op, node),
    CTOR_INITIALIZER_LIST
    {
-   TR_ASSERT_FATAL(canEmulate() || cg->comp()->target().cpu.isAtLeast(_opcode.getMinimumALS()), "Processor detected (%s) does not support instruction %s\n", cg->comp()->target().cpu.getProcessorName(), _opcode.getMnemonicName());
+   TR_ASSERT_FATAL(getOpCode().canEmulate() || cg->comp()->target().cpu.isAtLeast(_opcode.getMinimumALS()), "Processor detected (%s) does not support instruction %s\n", cg->comp()->target().cpu.getProcessorName(), _opcode.getMnemonicName());
 
    self()->initialize();
    }
@@ -96,7 +96,7 @@ OMR::Z::Instruction::Instruction(TR::CodeGenerator*cg, TR::Instruction* precedin
    OMR::Instruction(cg, precedingInstruction, op, node),
    CTOR_INITIALIZER_LIST
    {
-   TR_ASSERT_FATAL(canEmulate() || cg->comp()->target().cpu.isAtLeast(_opcode.getMinimumALS()), "Processor detected (%s) does not support instruction %s\n", cg->comp()->target().cpu.getProcessorName(), _opcode.getMnemonicName());
+   TR_ASSERT_FATAL(getOpCode().canEmulate() || cg->comp()->target().cpu.isAtLeast(_opcode.getMinimumALS()), "Processor detected (%s) does not support instruction %s\n", cg->comp()->target().cpu.getProcessorName(), _opcode.getMnemonicName());
 
    self()->initialize(precedingInstruction, true);
    }

--- a/compiler/z/codegen/OMRInstruction.hpp
+++ b/compiler/z/codegen/OMRInstruction.hpp
@@ -246,6 +246,12 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
 
    private:
 
+#ifdef EMULATE_ZNEXT
+   bool canEmulate() { return getOpCode().isEmulatable(); }
+#else
+   bool canEmulate() { return false; }
+#endif
+
    TR::RegisterDependencyConditions *_conditions;
 
    enum // _flags

--- a/compiler/z/codegen/OMRInstruction.hpp
+++ b/compiler/z/codegen/OMRInstruction.hpp
@@ -243,14 +243,7 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
    void setWillBePatched() { _index |= WillBePatched; }
    virtual const char *description() { return "S390"; }
 
-
    private:
-
-#ifdef EMULATE_ZNEXT
-   bool canEmulate() { return getOpCode().isEmulatable(); }
-#else
-   bool canEmulate() { return false; }
-#endif
 
    TR::RegisterDependencyConditions *_conditions;
 

--- a/compiler/z/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/z/codegen/OMRInstructionKindEnum.hpp
@@ -69,6 +69,8 @@ IsReg,             ///< Target is register
    IsVRIg,
    IsVRIh,
    IsVRIi,
+   IsVRIk,
+   IsVRIl,
    IsVRRa,         ///< Is VRR (Vector Register-and-Register) Operation and extended opCode field
    IsVRRb,
    IsVRRc,

--- a/compiler/z/codegen/OMRMemoryReference.hpp
+++ b/compiler/z/codegen/OMRMemoryReference.hpp
@@ -291,7 +291,7 @@ bool isAligned();
  *    A return value of `false` does not imply long displacement is not required. This is because the displacement of
  *    this memory reference is not fully known until binary encoding. Only after the binary encoding of this memory
  *    reference will a return value of `false` indicate that long displacement is not required. The offset may increase
- *    by some amount during code generation, however it will never decrease. This is why a return value of `true` 
+ *    by some amount during code generation, however it will never decrease. This is why a return value of `true`
  *    always implies long displacement will be required.
  */
 const bool isLongDisplacementRequired();
@@ -386,7 +386,7 @@ TR::S390ConstantDataSnippet* createLiteralPoolSnippet(TR::Node *rootNode, TR::Co
 void populateLoadAddrTree(TR::Node* subTree, TR::CodeGenerator* cg);
 void populateAloadTree(TR::Node* subTree, TR::CodeGenerator* cg, bool privateArea = false);
 void populateShiftLeftTree(TR::Node* subTree, TR::CodeGenerator* cg);
-void populateAddTree(TR::Node* subTree, TR::CodeGenerator* cg);
+void populateAddTree(TR::Node* subTree, TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic *loadOp = NULL, bool allowLXA = false);
 
 void consolidateRegisters(TR::Node *subTree, TR::CodeGenerator *cg);
 
@@ -468,7 +468,7 @@ void setMemRefAndGetUnresolvedData(TR::Snippet *& snippet) {}
 
 /**
  * \brief
- *   Create a MemoryReference from a given node. 
+ *   Create a MemoryReference from a given node.
  *
  * \param[in] node
  *   The node which describes the memory reference.

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -7877,11 +7877,11 @@ OMR::Z::TreeEvaluator::axaddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::MemoryReference * axaddMR = generateS390MemoryReference(cg);
    TR::InstOpCode::Mnemonic loadOp;
    static const bool disableLXAaxaddZNext = feGetEnv("TR_disableLXAaxaddZNext") != NULL;
-   static const bool canEmulateLXA = TR::InstOpCode(TR::InstOpCode::LXAB).isEmulatable() &&
-                                     TR::InstOpCode(TR::InstOpCode::LXAH).isEmulatable() &&
-                                     TR::InstOpCode(TR::InstOpCode::LXAF).isEmulatable() &&
-                                     TR::InstOpCode(TR::InstOpCode::LXAG).isEmulatable() &&
-                                     TR::InstOpCode(TR::InstOpCode::LXAQ).isEmulatable();
+   static const bool canEmulateLXA = TR::InstOpCode(TR::InstOpCode::LXAB).canEmulate() &&
+                                     TR::InstOpCode(TR::InstOpCode::LXAH).canEmulate() &&
+                                     TR::InstOpCode(TR::InstOpCode::LXAF).canEmulate() &&
+                                     TR::InstOpCode(TR::InstOpCode::LXAG).canEmulate() &&
+                                     TR::InstOpCode(TR::InstOpCode::LXAQ).canEmulate();
 
    axaddMR->populateAddTree(node, cg, &loadOp, !disableLXAaxaddZNext && (cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_ZNEXT) || canEmulateLXA));
    axaddMR->eliminateNegativeDisplacement(node, cg);
@@ -8503,7 +8503,7 @@ OMR::Z::TreeEvaluator::inlineNumberOfTrailingZeros(TR::Node *node, TR::CodeGener
    TR::Register *returnReg = NULL;
    bool isLong = (subfconst == 64);
    static const bool disableTrailZeroZNext = feGetEnv("TR_disableTrailZeroZNext") != NULL;
-   static const bool canEmulateCTZG = TR::InstOpCode(TR::InstOpCode::CTZG).isEmulatable();
+   static const bool canEmulateCTZG = TR::InstOpCode(TR::InstOpCode::CTZG).canEmulate();
 
    if ((cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_ZNEXT) || canEmulateCTZG) && !disableTrailZeroZNext)
       {
@@ -8626,7 +8626,7 @@ OMR::Z::TreeEvaluator::inlineNumberOfLeadingZeros(TR::Node *node, TR::CodeGenera
    TR::Register *argReg = cg->gprClobberEvaluate(argNode);
    TR::Register *returnReg = NULL;
    static const bool disableLeadZeroZNext = feGetEnv("TR_disableLeadZeroZNext") != NULL;
-   static const bool canEmulateCLZG = TR::InstOpCode(TR::InstOpCode::CLZG).isEmulatable();
+   static const bool canEmulateCLZG = TR::InstOpCode(TR::InstOpCode::CLZG).canEmulate();
 
    if ((cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_ZNEXT) || canEmulateCLZG) && !disableLeadZeroZNext)
       {

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -7877,13 +7877,8 @@ OMR::Z::TreeEvaluator::axaddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::MemoryReference * axaddMR = generateS390MemoryReference(cg);
    TR::InstOpCode::Mnemonic loadOp;
    static const bool disableLXAaxaddZNext = feGetEnv("TR_disableLXAaxaddZNext") != NULL;
-   static const bool canEmulateLXA = TR::InstOpCode(TR::InstOpCode::LXAB).canEmulate() &&
-                                     TR::InstOpCode(TR::InstOpCode::LXAH).canEmulate() &&
-                                     TR::InstOpCode(TR::InstOpCode::LXAF).canEmulate() &&
-                                     TR::InstOpCode(TR::InstOpCode::LXAG).canEmulate() &&
-                                     TR::InstOpCode(TR::InstOpCode::LXAQ).canEmulate();
 
-   axaddMR->populateAddTree(node, cg, &loadOp, !disableLXAaxaddZNext && (cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_ZNEXT) || canEmulateLXA));
+   axaddMR->populateAddTree(node, cg, &loadOp, !disableLXAaxaddZNext && cg->getUseLXAInstructions());
    axaddMR->eliminateNegativeDisplacement(node, cg);
    axaddMR->enforceDisplacementLimit(node, cg, NULL);
 

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -552,6 +552,16 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
     */
    static TR::Register *inlineNumberOfTrailingZeros(TR::Node *node, TR::CodeGenerator *cg, int32_t subfconst);
 
+   /**
+    * Used when inlining Integer|Long.compress
+    */
+   static TR::Register *inlineBitCompress(TR::Node *node, TR::CodeGenerator * cg, bool isLong);
+
+   /**
+    * Used when inlining Integer|Long.expand
+    */
+   static TR::Register *inlineBitExpand(TR::Node *node, TR::CodeGenerator * cg, bool isLong);
+
    static TR::Register *aconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *iconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *lconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -324,6 +324,7 @@ TR_Debug::printz(TR::FILE *pOutFile, TR::Instruction * instr)
       case TR::Instruction::IsVRIg:
       case TR::Instruction::IsVRIh:
       case TR::Instruction::IsVRIi:
+      case TR::Instruction::IsVRIl:
             print(pOutFile, (TR::S390VRIInstruction *) instr);
          break;
       case TR::Instruction::IsVRRa:
@@ -2756,7 +2757,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390VRIInstruction * instr)
          break;
       case TR::Instruction::IsVRIl:
          trfprintf(pOutFile, ",0x%x",
-               maskHalf(static_cast<TR::S390VRIkInstruction*>(instr)->getImmediateField5()));
+               maskHalf(static_cast<TR::S390VRIlInstruction*>(instr)->getImmediateField3()));
          break;
       default:
          TR_ASSERT(false, "Unknown VRI type");

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -2750,6 +2750,14 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390VRIInstruction * instr)
          trfprintf(pOutFile, ",0x%x",
                maskHalf(static_cast<TR::S390VRIiInstruction*>(instr)->getImmediateField3()));
          break;
+      case TR::Instruction::IsVRIk:
+         trfprintf(pOutFile, ",0x%x",
+               maskHalf(static_cast<TR::S390VRIkInstruction*>(instr)->getImmediateField5()));
+         break;
+      case TR::Instruction::IsVRIl:
+         trfprintf(pOutFile, ",0x%x",
+               maskHalf(static_cast<TR::S390VRIkInstruction*>(instr)->getImmediateField5()));
+         break;
       default:
          TR_ASSERT(false, "Unknown VRI type");
       }

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -664,7 +664,7 @@ generateRXInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
       }
    else
       {
-      TR_ASSERT_FATAL(instructionFormat == RXYa_FORMAT, "Mnemonic (%s) is incorrectly used as an RXY instruction", TR::InstOpCode::metadata[op].name);
+      TR_ASSERT_FATAL(instructionFormat == RXYa_FORMAT || instructionFormat == RXYc_FORMAT, "Mnemonic (%s) is incorrectly used as an RXY instruction", TR::InstOpCode::metadata[op].name);
 
       result = preced != NULL ?
          new (INSN_HEAP) TR::S390RXYInstruction(op, n, treg, mf, preced, cg) :
@@ -1777,6 +1777,13 @@ generateVRIiInstruction(
 #endif
 
    return instr;
+   }
+
+TR::Instruction *
+generateVRIkInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * targetReg, TR::Register * sourceReg2,
+                        TR::Register * sourceReg3, TR::Register * sourceReg4, uint8_t constantImm5 /* 8 bit */)
+   {
+   return new (INSN_HEAP) TR::S390VRIkInstruction(cg, op, n, targetReg, sourceReg2, sourceReg3, sourceReg4, constantImm5);
    }
 
 /****** VRR ******/

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -1786,6 +1786,27 @@ generateVRIkInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR:
    return new (INSN_HEAP) TR::S390VRIkInstruction(cg, op, n, targetReg, sourceReg2, sourceReg3, sourceReg4, constantImm5);
    }
 
+TR::Instruction *
+generateVRIlInstruction(
+                      TR::CodeGenerator        * cg,
+                      TR::InstOpCode::Mnemonic   op,
+                      TR::Node                 * n,
+                      TR::Register             * sourceReg1,
+                      TR::Register             * sourceReg2,
+                      uint16_t                   constantImm3)  /* 16 bits  */
+   {
+   TR::Instruction* instr =  new (INSN_HEAP) TR::S390VRIlInstruction(cg, op, n, sourceReg1, sourceReg2, constantImm3);
+
+#ifdef J9_PROJECT_SPECIFIC
+   if (op == TR::InstOpCode::VTZ)
+      {
+      generateS390DAAExceptionRestoreSnippet(cg, n, instr, op, false);
+      }
+#endif
+
+   return instr;
+   }
+
 /****** VRR ******/
 TR::Instruction *
 generateVRRaInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * targetReg, TR::Register * sourceReg2,

--- a/compiler/z/codegen/S390GenerateInstructions.hpp
+++ b/compiler/z/codegen/S390GenerateInstructions.hpp
@@ -352,11 +352,11 @@ TR::Instruction * generateRXInstruction(
                    TR::Instruction         *preced = 0);
 
 TR::Instruction * generateRXInstruction(
-                   TR::CodeGenerator* cg, 
-                   TR::InstOpCode::Mnemonic op, 
-                   TR::Node* n, 
-                   uint8_t mask, 
-                   TR::MemoryReference* mf, 
+                   TR::CodeGenerator* cg,
+                   TR::InstOpCode::Mnemonic op,
+                   TR::Node* n,
+                   uint8_t mask,
+                   TR::MemoryReference* mf,
                    TR::Instruction* preced = 0);
 
 TR::Instruction * generateRXEInstruction(
@@ -1059,6 +1059,16 @@ TR::Instruction * generateVRIiInstruction(
                       uint8_t                constantImm3,   /* 8 bits  */
                       uint8_t                 mask4);        /* 4 bits  */
 
+TR::Instruction * generateVRIkInstruction(
+                      TR::CodeGenerator    * cg,
+                      TR::InstOpCode::Mnemonic          op,
+                      TR::Node             * n,
+                      TR::Register           * targetReg,
+                      TR::Register           * sourceReg2,
+                      TR::Register           * sourceReg3,
+                      TR::Register           * sourceReg4,
+                      uint8_t                 constantImm5); /* 8 bits  */
+
 /****** VRR ******/
 TR::Instruction * generateVRRaInstruction(
                       TR::CodeGenerator     * cg         ,
@@ -1524,56 +1534,56 @@ generateReplicateNodeInVectorReg(TR::Node * node, TR::CodeGenerator *cg, TR::Reg
  *
  * \param cg
  *    The code generator used to generate the instructions.
- * 
+ *
  * \param targetRegister
- *    The register where the specific shifted bits from sourceRegister will be placed to the corresponding 
+ *    The register where the specific shifted bits from sourceRegister will be placed to the corresponding
  *    location. The remaining bits will be zeroed out.
- * 
+ *
  * \param sourceRegister
- *    The register which will be shifted. The selected shifted bits in sourceRegister will be placed to 
- *    targetRegister, and the sourceRegister itself will stay unchanged. 
- * 
+ *    The register which will be shifted. The selected shifted bits in sourceRegister will be placed to
+ *    targetRegister, and the sourceRegister itself will stay unchanged.
+ *
  * \param fromBit
- *    Indicates the starting bit position of the selected range of bits in targetRegister and in sourceRegister after shifting. 
- * 
+ *    Indicates the starting bit position of the selected range of bits in targetRegister and in sourceRegister after shifting.
+ *
  * \param toBit
- *    Indicates the ending bit position of the selected range of bits in targetRegister and in sourceRegister after shifting. 
- * 
+ *    Indicates the ending bit position of the selected range of bits in targetRegister and in sourceRegister after shifting.
+ *
  * \param shiftAmount
- *    Indicates the amount of bits that sourceRegister is shifted to the left. 
- * 
+ *    Indicates the amount of bits that sourceRegister is shifted to the left.
+ *
  * \example
  *    fromBit = 10;   toBit = 20;   shiftAmount = 15;
- * 
+ *
  *                              Bit 10    Bit 20
  *    Before:                     |          |
  *                     0          V          V                                               63
- *                    +--------+--------+--------+--------+--------+--------+--------+--------+     
+ *                    +--------+--------+--------+--------+--------+--------+--------+--------+
  *    sourceRegister: |10010000 00100011 01001000 11000100 00011010 00111000 00101011 00010000|
  *                    +--------+--------+--------+--------+--------+--------+--------+--------+
- *      
+ *
  *                     0                                                                     63
- *                    +--------+--------+--------+--------+--------+--------+--------+--------+     
+ *                    +--------+--------+--------+--------+--------+--------+--------+--------+
  *    targetRegister: |10000110 01101010 00111000 11011110 11000011 01111000 00100011 00000000|
  *                    +--------+--------+--------+--------+--------+--------+--------+--------+
- *    
+ *
  *    The function first makes a copy of sourceRegister into the targetRegister and then shifts the targetRegister left
  *    by the shiftAmount (15 bits):
- * 
+ *
  *                              Bit 10    Bit 20
  *                                |          |
  *                     0          V          V                                               63
- *                    +--------+--------+--------+--------+--------+--------+--------+--------+     
+ *                    +--------+--------+--------+--------+--------+--------+--------+--------+
  *    targetRegister: |10100100 01100010 00001101 00011100 00010101 10001000 00000000 00000000|
  *                    +--------+--------+--------+--------+--------+--------+--------+--------+
- * 
+ *
  *    The function then selects the bits in rage [fromBit, toBit] inclusive of the shifted value and all other non-
  *    selected bits are zeroed out:
- * 
+ *
  *                              Bit 10    Bit 20
  *    After:                      |          |
  *                     0          V          V                                               63
- *                    +--------+--------+--------+--------+--------+--------+--------+--------+     
+ *                    +--------+--------+--------+--------+--------+--------+--------+--------+
  *    targetRegister: |00000000 00100010 00001000 00000000 00000000 00000000 00000000 00000000|
  *                    +--------+--------+--------+--------+--------+--------+--------+--------+
  *

--- a/compiler/z/codegen/S390GenerateInstructions.hpp
+++ b/compiler/z/codegen/S390GenerateInstructions.hpp
@@ -1069,6 +1069,14 @@ TR::Instruction * generateVRIkInstruction(
                       TR::Register           * sourceReg4,
                       uint8_t                 constantImm5); /* 8 bits  */
 
+TR::Instruction * generateVRIlInstruction(
+                      TR::CodeGenerator    * cg,
+                      TR::InstOpCode::Mnemonic   op,
+                      TR::Node               * n,
+                      TR::Register           * sourceReg1,
+                      TR::Register           * sourceReg2,
+                      uint16_t                constantImm3);   /* 16 bits  */
+
 /****** VRR ******/
 TR::Instruction * generateVRRaInstruction(
                       TR::CodeGenerator     * cg         ,

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -3774,6 +3774,59 @@ TR::S390VRIiInstruction::generateBinaryEncoding()
 
 /** \details
  *
+ * VRI-k generate binary encoding for VRI-k instruction format
+ */
+uint8_t *
+TR::S390VRIkInstruction::generateBinaryEncoding()
+   {
+   // Error Checking
+   TR_ASSERT(getRegisterOperand(1) != NULL, "First Operand should not be NULL!");
+   TR_ASSERT(getRegisterOperand(2) != NULL, "2nd Operand should not be NULL!");
+   TR_ASSERT(getRegisterOperand(3) != NULL, "3rd Operand should not be NULL!");
+   TR_ASSERT(getRegisterOperand(4) != NULL, "4th Operand should not be NULL!");
+
+   // Generate Binary Encoding
+   uint8_t* cursor = preGenerateBinaryEncoding();
+
+   // The Immediate field
+   *(cursor + 3) |= getImmediateField5();
+
+   // Operands
+   toRealRegister(getRegisterOperand(1))->setRegister1Field(reinterpret_cast<uint32_t*>(cursor));
+   toRealRegister(getRegisterOperand(2))->setRegister2Field(reinterpret_cast<uint32_t*>(cursor));
+   toRealRegister(getRegisterOperand(3))->setRegister3Field(reinterpret_cast<uint32_t*>(cursor));
+   toRealRegister(getRegisterOperand(4))->setRegister4Field(reinterpret_cast<uint32_t*>(cursor));
+
+   return postGenerateBinaryEncoding(cursor);
+   }
+
+/** \details
+ *
+ * VRI-l generate binary encoding for VRI-l instruction format
+ */
+uint8_t *
+TR::S390VRIlInstruction::generateBinaryEncoding()
+   {
+   // Error Checking
+   TR_ASSERT(getRegisterOperand(1) != NULL, "First Operand should not be NULL!");
+   TR_ASSERT(getRegisterOperand(2) != NULL, "2nd Operand should not be NULL!");
+
+   // Generate Binary Encoding
+   uint8_t* cursor = preGenerateBinaryEncoding();
+
+   // The Immediate field
+   *(reinterpret_cast<uint32_t*>(cursor + 2)) |= static_cast<uint32_t>(getImmediateField3()) << 4;
+
+   // Operands
+   // First and second register operands for VRI-l map to second and third register fields
+   toRealRegister(getRegisterOperand(1))->setRegister2Field(reinterpret_cast<uint32_t*>(cursor));
+   toRealRegister(getRegisterOperand(2))->setRegister3Field(reinterpret_cast<uint32_t*>(cursor));
+
+   return postGenerateBinaryEncoding(cursor);
+   }
+
+/** \details
+ *
  * VRR instruction format get extended mnemonic name returns a charactor array that contains
  * the extended mnemonic names
  */

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -3815,7 +3815,7 @@ TR::S390VRIlInstruction::generateBinaryEncoding()
    uint8_t* cursor = preGenerateBinaryEncoding();
 
    // The Immediate field
-   *(reinterpret_cast<uint32_t*>(cursor + 2)) |= static_cast<uint32_t>(getImmediateField3()) << 4;
+   *(reinterpret_cast<uint32_t*>(cursor + 2)) |= static_cast<uint32_t>(getImmediateField3()) << 12;
 
    // Operands
    // First and second register operands for VRI-l map to second and third register fields

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -4829,7 +4829,7 @@ class S390VInstruction : public S390RegInstruction
  * S390VRIInstruction Class Definition
  *
  * Vector register-and-immediate operation with extended op-code field
- * Nine subtypes: VRI-a to VRI-i
+ * Eleven subtypes: VRI-a to VRI-l (VRI-j is not implemented)
  */
 class S390VRIInstruction : public S390VInstruction
    {
@@ -5214,6 +5214,79 @@ class S390VRIiInstruction : public S390VRIInstruction
    uint8_t * generateBinaryEncoding();
    };
 
+/**
+ * VRI-k Class
+ *    ________________________________________________________
+ *   |Op Code | V1 | V2 | V3 | // |    I5   | V4 |RXB |Op Code|
+ *   |________|____|____|____|____|_________|____|____|_______|
+ *   0        8    12   16   20   24        32   36   40      47
+ */
+class S390VRIkInstruction : public S390VRIInstruction
+   {
+   public:
+   S390VRIkInstruction(
+                          TR::CodeGenerator      * cg               = NULL,
+                          TR::InstOpCode::Mnemonic          op      = TR::InstOpCode::bad,
+                          TR::Node               * n                = NULL,
+                          TR::Register           * targetReg        = NULL,
+                          TR::Register           * sourceReg2       = NULL,
+                          TR::Register           * sourceReg3       = NULL,
+                          TR::Register           * sourceReg4       = NULL,
+                          uint8_t                 constantImm4      = 0)    /* 8 bits */
+   : S390VRIInstruction(cg, op, n, targetReg, 0, constantImm4, 0, 0, 0)
+      {
+      if (getOpCode().setsOperand2())
+         useTargetRegister(sourceReg2);
+      else
+         useSourceRegister(sourceReg2);
+
+      if (getOpCode().setsOperand3())
+         useTargetRegister(sourceReg3);
+      else
+         useSourceRegister(sourceReg3);
+
+      if (getOpCode().setsOperand4())
+         useTargetRegister(sourceReg4);
+      else
+         useSourceRegister(sourceReg4);
+      }
+
+   uint8_t getImmediateField5() { return getImmediateField8(); }
+   virtual const char *description() { return "S390VRIkInstruction"; }
+   virtual Kind getKind() { return IsVRIk; }
+   uint8_t * generateBinaryEncoding();
+   };
+
+/**
+ * VRI-l Class
+ *    ________________________________________________________
+ *   |Op Code | // | V1 | V2 |        I3         |RXB |Op Code|
+ *   |________|____|____|____|___________________|____|_______|
+ *   0        8    12   16   20                  36   40      47
+ */
+class S390VRIlInstruction : public S390VRIInstruction
+   {
+   public:
+   S390VRIlInstruction(
+                          TR::CodeGenerator      * cg               = NULL,
+                          TR::InstOpCode::Mnemonic          op      = TR::InstOpCode::bad,
+                          TR::Node               * n                = NULL,
+                          TR::Register           * targetReg        = NULL,
+                          TR::Register           * sourceReg        = NULL,
+                          uint16_t                 constantImm3     = 0)    /* 16 bits */
+   : S390VRIInstruction(cg, op, n, targetReg, constantImm3, 0, 0, 0, 0)
+      {
+      if (getOpCode().setsOperand2())
+         useTargetRegister(sourceReg);
+      else
+         useSourceRegister(sourceReg);
+      }
+
+   uint16_t getImmediateField3() { return getImmediateField16(); }
+   virtual const char *description() { return "S390VRIlInstruction"; }
+   virtual Kind getKind() { return IsVRIl; }
+   uint8_t * generateBinaryEncoding();
+   };
 
 /**
  * S390VRRInstruction Class Definition

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -5271,15 +5271,12 @@ class S390VRIlInstruction : public S390VRIInstruction
                           TR::CodeGenerator      * cg               = NULL,
                           TR::InstOpCode::Mnemonic          op      = TR::InstOpCode::bad,
                           TR::Node               * n                = NULL,
-                          TR::Register           * targetReg        = NULL,
-                          TR::Register           * sourceReg        = NULL,
+                          TR::Register           * sourceReg1        = NULL,
+                          TR::Register           * sourceReg2        = NULL,
                           uint16_t                 constantImm3     = 0)    /* 16 bits */
-   : S390VRIInstruction(cg, op, n, targetReg, constantImm3, 0, 0, 0, 0)
+   : S390VRIInstruction(cg, op, n, sourceReg1, constantImm3, 0, 0, 0, 0)
       {
-      if (getOpCode().setsOperand2())
-         useTargetRegister(sourceReg);
-      else
-         useSourceRegister(sourceReg);
+      useSourceRegister(sourceReg2);
       }
 
    uint16_t getImmediateField3() { return getImmediateField16(); }

--- a/compiler/z/env/OMRCPU.cpp
+++ b/compiler/z/env/OMRCPU.cpp
@@ -81,6 +81,14 @@ OMR::Z::CPU::detect(OMRPortLibrary * const omrPortLib)
       omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY_2, FALSE);
       }
 
+   if (processorDescription.processor < OMR_PROCESSOR_S390_ZNEXT)
+      {
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_3, FALSE);
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_3, FALSE);
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_PLO_EXTENSION, FALSE);
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY_3, FALSE);
+      }
+
    return TR::CPU(processorDescription);
    }
 
@@ -203,6 +211,18 @@ OMR::Z::CPU::supportsFeatureOldAPI(uint32_t feature)
          break;
       case OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY_2:
          supported = self()->getSupportsVectorPackedDecimalEnhancementFacility2();
+         break;
+      case OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_4:
+         supported = self()->getSupportsMiscellaneousInstructionExtensionsFacility4();
+         break;
+      case OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_3:
+         supported = self()->getSupportsVectorFacilityEnhancement3();
+         break;
+      case OMR_FEATURE_S390_PLO_EXTENSION:
+         supported = self()->getSupportsPLOExtensionFacility();
+         break;
+      case OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY_3:
+         supported = self()->getSupportsVectorPackedDecimalEnhancementFacility3();
          break;
       default:
          TR_ASSERT_FATAL(false, "Unknown processor feature: %d!\n", feature);
@@ -577,3 +597,78 @@ OMR::Z::CPU::setSupportsVectorPackedDecimalEnhancementFacility2(bool value)
       }
    }
 
+bool
+OMR::Z::CPU::getSupportsMiscellaneousInstructionExtensionsFacility4()
+   {
+   return _flags.testAny(S390SupportsMIE4);
+   }
+
+void
+OMR::Z::CPU::setSupportsMiscellaneousInstructionExtensionsFacility4(bool value)
+   {
+   if (value)
+      {
+      _flags.set(S390SupportsMIE4);
+      }
+   else
+      {
+      _flags.reset(S390SupportsMIE4);
+      }
+   }
+
+bool
+OMR::Z::CPU::getSupportsVectorFacilityEnhancement3()
+   {
+   return _flags.testAny(S390SupportsVectorFacilityEnhancement3);
+   }
+
+void
+OMR::Z::CPU::setSupportsVectorFacilityEnhancement3(bool value)
+   {
+   if (value)
+      {
+      _flags.set(S390SupportsVectorFacilityEnhancement3);
+      }
+   else
+      {
+      _flags.reset(S390SupportsVectorFacilityEnhancement3);
+      }
+   }
+
+bool
+OMR::Z::CPU::getSupportsPLOExtensionFacility()
+   {
+   return _flags.testAny(S390SupportsPLO);
+   }
+
+void
+OMR::Z::CPU::setSupportsPLOExtensionFacility(bool value)
+   {
+   if (value)
+      {
+      _flags.set(S390SupportsPLO);
+      }
+   else
+      {
+      _flags.reset(S390SupportsPLO);
+      }
+   }
+
+bool
+OMR::Z::CPU::getSupportsVectorPackedDecimalEnhancementFacility3()
+   {
+   return _flags.testAny(S390SupportsVectorPDEnhancementFacility3);
+   }
+
+void
+OMR::Z::CPU::setSupportsVectorPackedDecimalEnhancementFacility3(bool value)
+   {
+   if (value)
+      {
+      _flags.set(S390SupportsVectorPDEnhancementFacility3);
+      }
+   else
+      {
+      _flags.reset(S390SupportsVectorPDEnhancementFacility3);
+      }
+   }

--- a/compiler/z/env/OMRCPU.hpp
+++ b/compiler/z/env/OMRCPU.hpp
@@ -323,9 +323,61 @@ public:
     *     Sets Vector Packed Decimal facility 2 flag.
     *
     *  \param value
-    *     \c true if the Vector Packed Decimal facility is available, and \c false otherwise.
+    *     \c true if the Vector Packed Decimal facility 2 is available, and \c false otherwise.
     */
    void setSupportsVectorPackedDecimalEnhancementFacility2(bool value);
+
+   /** \brief
+    *     Determines whether the Miscellaneous Instruction Extensions facility 4 is available on the current processor.
+    */
+   bool getSupportsMiscellaneousInstructionExtensionsFacility4();
+
+   /** \brief
+    *     Sets Miscellaneous Instruction Extensions facility 4 flag.
+    *
+    *  \param value
+    *     \c true if the Miscellaneous Instruction Extensions facility 4 is available, and \c false otherwise.
+    */
+   void setSupportsMiscellaneousInstructionExtensionsFacility4(bool value);
+
+   /** \brief
+    *     Determines whether the Vector Enhancement 3 facility is available on the current processor.
+    */
+   bool getSupportsVectorFacilityEnhancement3();
+
+   /** \brief
+    *     Determines whether the Vector Enhancement 3 facility is available on the current processor.
+    *
+    *  \param value
+    *     Determines whether the Vector Enhancement 3 facility is available (if \c true) or not (if \c false).
+    */
+   void setSupportsVectorFacilityEnhancement3(bool value);
+
+   /** \brief
+    *     Determines whether the PLO Extension facility is available on the current processor.
+    */
+   bool getSupportsPLOExtensionFacility();
+
+   /** \brief
+    *     Sets Vector PLO Extension facility flag.
+    *
+    *  \param value
+    *     \c true if the PLO Extension facility is available, and \c false otherwise.
+    */
+   void setSupportsPLOExtensionFacility(bool value);
+
+   /** \brief
+    *     Determines whether the Vector Packed Decimal facility 3 is available on the current processor.
+    */
+   bool getSupportsVectorPackedDecimalEnhancementFacility3();
+
+   /** \brief
+    *     Sets Vector Packed Decimal facility 3 flag.
+    *
+    *  \param value
+    *     \c true if the Vector Packed Decimal 3 facility is available, and \c false otherwise.
+    */
+   void setSupportsVectorPackedDecimalEnhancementFacility3(bool value);
 
 private:
 
@@ -345,25 +397,29 @@ protected:
 
    enum
       {
-      S390SupportsVectorPDEnhancementFacility2 = 0x00000001,
-      HasResumableTrapHandler                  = 0x00000002,
-      HasFixedFrameC_CallingConvention         = 0x00000004,
-      SupportsScaledIndexAddressing            = 0x00000080,
-      S390SupportsDFP                          = 0x00000100,
-      S390SupportsFPE                          = 0x00000200,
-      S390SupportsHPR                          = 0x00001000,
-      IsInZOSSupervisorState                   = 0x00008000,
-      S390SupportsTM                           = 0x00010000,
-      S390SupportsRI                           = 0x00020000,
-      S390SupportsVectorFacility               = 0x00040000,
-      S390SupportsVectorPackedDecimalFacility  = 0x00080000,
-      S390SupportsGuardedStorageFacility       = 0x00100000,
-      S390SupportsSideEffectAccessFacility     = 0x00200000,
-      S390SupportsMIE2                         = 0x00400000,
-      S390SupportsMIE3                         = 0x00800000,
-      S390SupportsVectorFacilityEnhancement2   = 0x01000000,
-      S390SupportsVectorPDEnhancementFacility  = 0x02000000,
-      S390SupportsVectorFacilityEnhancement1   = 0x04000000,
+      S390SupportsVectorPDEnhancementFacility2  = 0x00000001,
+      HasResumableTrapHandler                   = 0x00000002,
+      HasFixedFrameC_CallingConvention          = 0x00000004,
+      SupportsScaledIndexAddressing             = 0x00000080,
+      S390SupportsDFP                           = 0x00000100,
+      S390SupportsFPE                           = 0x00000200,
+      S390SupportsHPR                           = 0x00001000,
+      IsInZOSSupervisorState                    = 0x00008000,
+      S390SupportsTM                            = 0x00010000,
+      S390SupportsRI                            = 0x00020000,
+      S390SupportsVectorFacility                = 0x00040000,
+      S390SupportsVectorPackedDecimalFacility   = 0x00080000,
+      S390SupportsGuardedStorageFacility        = 0x00100000,
+      S390SupportsSideEffectAccessFacility      = 0x00200000,
+      S390SupportsMIE2                          = 0x00400000,
+      S390SupportsMIE3                          = 0x00800000,
+      S390SupportsVectorFacilityEnhancement2    = 0x01000000,
+      S390SupportsVectorPDEnhancementFacility   = 0x02000000,
+      S390SupportsVectorFacilityEnhancement1    = 0x04000000,
+      S390SupportsMIE4                          = 0x08000000,
+      S390SupportsVectorFacilityEnhancement3    = 0x10000000,
+      S390SupportsPLO                           = 0x20000000,
+      S390SupportsVectorPDEnhancementFacility3  = 0x40000000,
       };
 
    Architecture _supportedArch;

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1652,6 +1652,23 @@ typedef struct OMRProcessorDesc {
 /* STFLE bit 192 - Vector-Packed-Decimal-Enhancement Facility 2 */
 #define OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY_2 192
 
+/* zNext facilities */
+
+/* STFLE bit 84 - Miscellaneous-instruction-extensions facility 4 */
+#define OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_4 84
+
+/* STFLE bit 198 - Vector enhancements facility 3 */
+#define OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_3 198
+
+/* STFLE bit 87 - PLO-extension facility */
+#define OMR_FEATURE_S390_PLO_EXTENSION 87
+
+/* STFLE bit 199 - Vector-Packed-Decimal-Enhancement Facility 3 */
+#define OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY_3 199
+
+/* STFLE bit 170 - Ineffective-nonconstrained-transaction facility */
+#define OMR_FEATURE_S390_INEFFECTIVE_NONCONSTRAINED_TRANSACTION_FACILITY 170
+
 /*  Linux on Z features
  *  Auxiliary Vector Hardware Capability (AT_HWCAP) features for Linux on Z.
  *  Obtained from: https://github.com/torvalds/linux/blob/050cdc6c9501abcd64720b8cc3e7941efee9547d/arch/s390/include/asm/elf.h#L94-L109.

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -1631,7 +1631,10 @@ omrsysinfo_get_s390_description(struct OMRPortLibrary *portLibrary, OMRProcessor
 		if (OMR_ARE_ALL_BITS_SET(auxvFeatures, OMR_HWCAP_S390_TE))
 #endif /* defined(J9ZOS390) */
 		{
-			omrsysinfo_set_feature(desc, OMR_FEATURE_S390_TRANSACTIONAL_EXECUTION_FACILITY);
+			if (!omrsysinfo_test_stfle(portLibrary, OMR_FEATURE_S390_INEFFECTIVE_NONCONSTRAINED_TRANSACTION_FACILITY))
+			{
+				omrsysinfo_set_feature(desc, OMR_FEATURE_S390_TRANSACTIONAL_EXECUTION_FACILITY);
+			}
 
 			if (omrsysinfo_test_stfle(portLibrary, OMR_FEATURE_S390_CONSTRAINED_TRANSACTIONAL_EXECUTION_FACILITY)) {
 #if defined(J9ZOS390)
@@ -1801,6 +1804,46 @@ omrsysinfo_get_s390_description(struct OMRPortLibrary *portLibrary, OMRProcessor
 		}
 	}
 
+   /* zNext facility and processor detection */
+
+	if (omrsysinfo_test_stfle(portLibrary, OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_4)) {
+		omrsysinfo_set_feature(desc, OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_4);
+
+		desc->processor = OMR_PROCESSOR_S390_ZNEXT;
+	}
+
+	if (omrsysinfo_test_stfle(portLibrary, OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_3)) {
+#if defined(J9ZOS390)
+		if (omrsysinfo_get_s390_zos_supports_vector_extension_facility())
+#elif defined(LINUX) && !defined(J9ZTPF) /* defined(J9ZOS390) */
+		if (OMR_ARE_ALL_BITS_SET(auxvFeatures, OMR_HWCAP_S390_VXRS))
+#endif /* defined(LINUX) && !defined(J9ZTPF) */
+		{
+			omrsysinfo_set_feature(desc, OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_3);
+
+			desc->processor = OMR_PROCESSOR_S390_ZNEXT;
+		}
+	}
+
+	if (omrsysinfo_test_stfle(portLibrary, OMR_FEATURE_S390_PLO_EXTENSION)) {
+		omrsysinfo_set_feature(desc, OMR_FEATURE_S390_PLO_EXTENSION);
+
+		desc->processor = OMR_PROCESSOR_S390_ZNEXT;
+	}
+
+	if (omrsysinfo_test_stfle(portLibrary, OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY_3)) {
+#if defined(J9ZOS390)
+		if (omrsysinfo_get_s390_zos_supports_vector_extension_facility())
+#elif defined(LINUX) && !defined(J9ZTPF) /* defined(J9ZOS390) */
+		if (OMR_ARE_ALL_BITS_SET(auxvFeatures, OMR_HWCAP_S390_VXRS))
+#endif /* defined(LINUX) && !defined(J9ZTPF) */
+		{
+			omrsysinfo_set_feature(desc, OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY_3);
+
+			desc->processor = OMR_PROCESSOR_S390_ZNEXT;
+		}
+	}
+
 	/* Set Side Effect Facility without setting GP12. This is because
 	 * this GP12-only STFLE bit can also be enabled on zEC12 (GP10)
 	 */
@@ -1889,6 +1932,14 @@ omrsysinfo_get_s390_processor_feature_name(uint32_t feature)
 		return "vec_pde";
 	case OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY_2:
 		return "vec_pde2";
+	case OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_4:
+		return "mi_e4";
+	case OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_3:
+		return "vec_e4";
+	case OMR_FEATURE_S390_PLO_EXTENSION:
+		return "plo";
+	case OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY_3:
+		return "vec_pde3";
 	default:
 		return "null";
 	}


### PR DESCRIPTION
Changes in this PR adds following supporting changes for zNext processor and its
exploitation.

1. Add processor recognition and facility checks for zNext
2. Add zNext instructions
3. Supporting changes for emulating zNext instructions on older IBM Z hardware.
4. Use load indexed address instructions on zNext for aladd and aiadd
	-Adds support for generating load indexed address instructions for the
	 add tree in axaddEvaluator when the tree has the correct shape.
5. Add use of Count leading and trailing zeros instruction on zNext
	- For inotz/lnotz/inolz/lnolz nodes, use these new zNext instruction.
6. Supporting changes to accelerate ExternalDecimal.checkExternalDecimal in
OpenJ9.