### PR TITLE
Recognize POWER11 on Linux

### DIFF
--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -1142,6 +1142,8 @@ omrsysinfo_map_ppc_processor(const char *processorName)
 		rc = OMR_PROCESSOR_PPC_P9;
 	} else if (0 == strncasecmp(processorName, "power10", 7)) {
 		rc = OMR_PROCESSOR_PPC_P10;
+	} else if (0 == strncasecmp(processorName, "power11", 7)) {
+		rc = OMR_PROCESSOR_PPC_P11;
 	}
 
 	return rc;


### PR DESCRIPTION
"power11" patch for Linux kernel was upstreamed a couple months ago. the
recognition mechanism involves comparing it with AT_PLATFORM.