### PR TITLE
Clean up references to old opcodes

### DIFF
--- a/compiler/arm/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.hpp
@@ -559,7 +559,6 @@ public:
    static TR::Register *dstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *bstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *ilstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *idstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *gotoEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -7047,18 +7047,18 @@ OMR::Node::chkMethodPointerConstant()
    }
 
 bool
-OMR::Node::isUnneededIALoad()
+OMR::Node::isUnneededAloadi()
    {
-   return (self()->getOpCodeValue() == TR::aloadi && _flags.testAny(unneededIALoad));
+   return (self()->getOpCodeValue() == TR::aloadi && _flags.testAny(unneededAloadi));
    }
 
 void
-OMR::Node::setUnneededIALoad(bool v)
+OMR::Node::setUnneededAloadi(bool v)
    {
    TR::Compilation * c = TR::comp();
    TR_ASSERT(self()->getOpCodeValue() == TR::aloadi, "Can only call this for aloadi");
-   if (performNodeTransformation2(c, "O^O NODE FLAGS: Setting unneededIALoad flag on node %p to %d\n", self(), v))
-      _flags.set(unneededIALoad, v);
+   if (performNodeTransformation2(c, "O^O NODE FLAGS: Setting unneededAloadi flag on node %p to %d\n", self(), v))
+      _flags.set(unneededAloadi, v);
    }
 
 

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1382,8 +1382,8 @@ public:
    void setIsMethodPointerConstant(bool b);
    bool chkMethodPointerConstant();
 
-   bool isUnneededIALoad();
-   void setUnneededIALoad(bool v);
+   bool isUnneededAloadi();
+   void setUnneededAloadi(bool v);
 
    // Flags used by TR::monent, TR::monexit, ad TR::tstart
    bool canSkipSync();
@@ -1942,7 +1942,7 @@ protected:
       //
       classPointerConstant                  = 0x00010000,
       methodPointerConstant                 = 0x00002000,
-      unneededIALoad                        = 0x00001000,
+      unneededAloadi                        = 0x00001000,
 
       // Flags used by TR::monent, TR::monexit, and TR::tstart
       //

--- a/compiler/infra/TreeServices.cpp
+++ b/compiler/infra/TreeServices.cpp
@@ -27,7 +27,7 @@
 #include "il/Node.hpp"
 
 bool
-TR_AddressTree::isILLoad(TR::Node * node)
+TR_AddressTree::isLloadi(TR::Node * node)
    {
    if (node->getOpCodeValue() != TR::iload  && node->getOpCodeValue() != TR::lload &&
        node->getOpCodeValue() != TR::iloadi && node->getOpCodeValue() != TR::lloadi)
@@ -47,7 +47,7 @@ TR_AddressTree::findComplexAddressGenerationTree(TR::Node *node, vcount_t visitC
       return false;
    node->setVisitCount(visitCount);
 
-   if (isILLoad(node))
+   if (isLloadi(node))
       {
       int32_t childNumber;
       for (childNumber = 0; childNumber < parent->getNumChildren(); childNumber++)
@@ -68,16 +68,16 @@ TR_AddressTree::processBaseAndIndex(TR::Node* parent)
    TR::Node * lhs = parent->getFirstChild();
    TR::Node * rhs = parent->getSecondChild();
    bool isValid = true;
-   if (isILLoad(lhs) && isILLoad(rhs))
+   if (isLloadi(lhs) && isLloadi(rhs))
       {
       isValid = false; // exactly one child should be a variable
       }
-   else if (isILLoad(lhs))
+   else if (isLloadi(lhs))
       {
       _indexBaseNode.setParentAndChildNumber(lhs, 0);
       _indVarNode.setParentAndChildNumber(parent, 0);
       }
-   else if (isILLoad(rhs))
+   else if (isLloadi(rhs))
       {
       _indexBaseNode.setParentAndChildNumber(rhs, 0);
       _indVarNode.setParentAndChildNumber(parent, 1);
@@ -135,7 +135,7 @@ TR_AddressTree::processMultiplyNode(TR::Node * multiplyNode)
          return false;
          }
       }
-   else if (isILLoad(firstMulChild))
+   else if (isLloadi(firstMulChild))
       {
       _indexBaseNode.setParentAndChildNumber(firstMulChild, 0);
       _indVarNode.setParentAndChildNumber(multiplyNode, 0);
@@ -262,7 +262,7 @@ TR_AddressTree::process(TR::Node * aiaddNode, bool onlyConsiderConstAiaddSecondC
                      }
                   }
                }
-            else if (isILLoad(isubFirstChild))
+            else if (isLloadi(isubFirstChild))
                {
                _multiplyNode.setParentAndChildNumber(aiaddSecondChild, 0);
                _indVarNode.setParentAndChildNumber(aiaddSecondChild, 0);

--- a/compiler/infra/TreeServices.hpp
+++ b/compiler/infra/TreeServices.hpp
@@ -83,7 +83,7 @@ public:
       return _rootNode;
       }
 
-   bool static isILLoad(TR::Node * node);
+   bool static isLloadi(TR::Node * node);
 
 protected:
    int64_t _offset;

--- a/compiler/optimizer/LoopReducer.cpp
+++ b/compiler/optimizer/LoopReducer.cpp
@@ -172,18 +172,18 @@ TR_LRAddressTree::processBaseAndIndex(TR::Node* parent)
    TR::Node * rhs = parent->getSecondChild();
 
    TR::RegisterMappedSymbol * indSym = _indVar->getLocal();
-   if (isILLoad(lhs) && (lhs->getSymbol()->getRegisterMappedSymbol() == indSym))
+   if (isLloadi(lhs) && (lhs->getSymbol()->getRegisterMappedSymbol() == indSym))
       {
       _indVarNode.setParentAndChildNumber(parent, 0);
-      if (isILLoad(rhs))
+      if (isLloadi(rhs))
          {
          _baseVarNode.setParentAndChildNumber(parent, 1);
          }
       }
-   else if (isILLoad(rhs) && (rhs->getSymbol()->getRegisterMappedSymbol() == indSym))
+   else if (isLloadi(rhs) && (rhs->getSymbol()->getRegisterMappedSymbol() == indSym))
       {
       _indVarNode.setParentAndChildNumber(parent, 1);
-      if (isILLoad(lhs))
+      if (isLloadi(lhs))
          {
          _baseVarNode.setParentAndChildNumber(parent, 0);
          }

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2046,7 +2046,7 @@ TR::Node *constrainAddressRef(OMR::ValuePropagation *vp, TR::Node *node)
    }
 
 
-TR::Node *constrainIiload(OMR::ValuePropagation *vp, TR::Node *node)
+TR::Node *constrainIloadi(OMR::ValuePropagation *vp, TR::Node *node)
    {
    if (findConstant(vp, node))
       return node;
@@ -2116,7 +2116,7 @@ TR::Node *constrainIiload(OMR::ValuePropagation *vp, TR::Node *node)
    return node;
    }
 
-TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node)
+TR::Node *constrainAloadi(OMR::ValuePropagation *vp, TR::Node *node)
    {
    if (findConstant(vp, node))
       return node;
@@ -2237,9 +2237,9 @@ TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node)
          // Base is known object, and field is recognized known object shadow,
          // hence can be treated as known object.
          {
-         TR::VMAccessCriticalSection constrainIaloadCriticalSection(vp->comp(),
+         TR::VMAccessCriticalSection constrainAloadiCriticalSection(vp->comp(),
                TR::VMAccessCriticalSection::tryToAcquireVMAccess);
-         if (constrainIaloadCriticalSection.hasVMAccess())
+         if (constrainAloadiCriticalSection.hasVMAccess())
             {
             TR::KnownObjectTable *knot = vp->comp()->getOrCreateKnownObjectTable();
             uintptr_t baseObject = knot->getPointer(base->getKnownObject()->getIndex());
@@ -2296,10 +2296,10 @@ TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node)
             TR_ASSERT(knot, "Can not have a TR::VPKnownObject without a known-object table");
 
                {
-               TR::VMAccessCriticalSection constrainIaloadCriticalSection(vp->comp(),
+               TR::VMAccessCriticalSection constrainAloadiCriticalSection(vp->comp(),
                                                                            TR::VMAccessCriticalSection::tryToAcquireVMAccess);
 
-               if (constrainIaloadCriticalSection.hasVMAccess())
+               if (constrainAloadiCriticalSection.hasVMAccess())
                   {
                   uintptr_t jlclazz = knot->getPointer(base->getKnownObject()->getIndex());
                   TR_OpaqueClassBlock *clazz = TR::Compiler->cls.classFromJavaLangClass(vp->comp(), jlclazz);
@@ -2445,9 +2445,9 @@ TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node)
                      uintptr_t *bypassLocation = NULL;
 
                         {
-                        TR::VMAccessCriticalSection constrainIaloadCriticalSection(vp->comp(),
+                        TR::VMAccessCriticalSection constrainAloadiCriticalSection(vp->comp(),
                                                                                     TR::VMAccessCriticalSection::tryToAcquireVMAccess);
-                        if (constrainIaloadCriticalSection.hasVMAccess())
+                        if (constrainAloadiCriticalSection.hasVMAccess())
                            {
                            uintptr_t *siteLocation = vp->comp()->getKnownObjectTable()->getPointerLocation(callSiteKOI);
                            bypassLocation = vp->comp()->fej9()->mutableCallSite_bypassLocation(*siteLocation);

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -67,7 +67,7 @@ TR::Node *constrainFload(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainFloatCmp(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainGoto(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainI2l(OMR::ValuePropagation *vp, TR::Node *node);
-TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node);
+TR::Node *constrainAloadi(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainIand(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainIdiv(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainIfcmpeq(OMR::ValuePropagation *vp, TR::Node *node);
@@ -76,7 +76,7 @@ TR::Node *constrainIfcmpgt(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainIfcmple(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainIfcmplt(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainIfcmpne(OMR::ValuePropagation *vp, TR::Node *node);
-TR::Node *constrainIiload(OMR::ValuePropagation *vp, TR::Node *node);
+TR::Node *constrainIloadi(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainImul(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainIneg(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainIabs(OMR::ValuePropagation *vp, TR::Node *node);
@@ -187,17 +187,17 @@ TR::Node * constrainLongBitCount(OMR::ValuePropagation *vp, TR::Node *node);
 #define brdbarVPHandler constrainIntLoad
 #define srdbarVPHandler constrainShortLoad
 #define lrdbarVPHandler constrainLload
-#define iloadiVPHandler constrainIiload
+#define iloadiVPHandler constrainIloadi
 #define floadiVPHandler constrainFload
 #define dloadiVPHandler constrainDload
-#define aloadiVPHandler constrainIaload
+#define aloadiVPHandler constrainAloadi
 #define bloadiVPHandler constrainIntLoad
 #define sloadiVPHandler constrainShortLoad
 #define lloadiVPHandler constrainLload
-#define irdbariVPHandler constrainIiload
+#define irdbariVPHandler constrainIloadi
 #define frdbariVPHandler constrainFload
 #define drdbariVPHandler constrainDload
-#define ardbariVPHandler constrainIaload
+#define ardbariVPHandler constrainAloadi
 #define brdbariVPHandler constrainIntLoad
 #define srdbariVPHandler constrainShortLoad
 #define lrdbariVPHandler constrainLload

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -481,7 +481,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *dstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *bstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *ilstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *astoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);  // ibm@59591
    static TR::Register *dwrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *awrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -81,7 +81,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *istoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *bstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *ilstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *gotoEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *lookupEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *tableEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -146,7 +146,7 @@ OMR::Z::CodeGenerator::preLowerTrees()
    {
    OMR::CodeGenerator::preLowerTrees();
 
-   _ialoadUnneeded.init();
+   _aloadiUnneeded.init();
 
    }
 
@@ -173,7 +173,7 @@ OMR::Z::CodeGenerator::lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, 
          self()->lowerTreeIfNeeded(child, childCount, parent, treeTop);
          }
 
-      self()->checkIsUnneededIALoad(parent, child, treeTop);
+      self()->checkIsUnneededAloadi(parent, child, treeTop);
       }
 
    self()->lowerTreesPostChildrenVisit(parent, treeTop, visitCount);
@@ -181,10 +181,10 @@ OMR::Z::CodeGenerator::lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, 
    }
 
 void
-OMR::Z::CodeGenerator::checkIsUnneededIALoad(TR::Node *parent, TR::Node *node, TR::TreeTop *tt)
+OMR::Z::CodeGenerator::checkIsUnneededAloadi(TR::Node *parent, TR::Node *node, TR::TreeTop *tt)
    {
 
-   ListIterator<TR_Pair<TR::Node, int32_t> > listIter(&_ialoadUnneeded);
+   ListIterator<TR_Pair<TR::Node, int32_t> > listIter(&_aloadiUnneeded);
    bool inList = false;
 
    if (node->getOpCodeValue() == TR::aloadi)
@@ -211,13 +211,13 @@ OMR::Z::CodeGenerator::checkIsUnneededIALoad(TR::Node *parent, TR::Node *node, T
             {
             uint32_t *temp ;
             TR_Pair<TR::Node, int32_t> *newEntry = new (self()->trStackMemory()) TR_Pair<TR::Node, int32_t> (node, (int32_t *)1);
-            _ialoadUnneeded.add(newEntry);
+            _aloadiUnneeded.add(newEntry);
             }
-         node->setUnneededIALoad (true);
+         node->setUnneededAloadi (true);
          }
       }
 
-   if (node->isUnneededIALoad())
+   if (node->isUnneededAloadi())
       {
       if (parent->getOpCodeValue() == TR::ifacmpne
          || parent->getOpCodeValue() == TR::ificmpeq
@@ -226,7 +226,7 @@ OMR::Z::CodeGenerator::checkIsUnneededIALoad(TR::Node *parent, TR::Node *node, T
          {
          if (!parent->isNopableInlineGuard() || !self()->getSupportsVirtualGuardNOPing())
             {
-            node->setUnneededIALoad(false);
+            node->setUnneededAloadi(false);
             }
          else
             {
@@ -235,7 +235,7 @@ OMR::Z::CodeGenerator::checkIsUnneededIALoad(TR::Node *parent, TR::Node *node, T
                      && self()->comp()->isVirtualGuardNOPingRequired(virtualGuard))
                && virtualGuard->canBeRemoved())
                {
-               node->setUnneededIALoad(false);
+               node->setUnneededAloadi(false);
                }
             }
          }
@@ -245,11 +245,11 @@ OMR::Z::CodeGenerator::checkIsUnneededIALoad(TR::Node *parent, TR::Node *node, T
          }
       else if (node->getOpCodeValue() == TR::aloadi && !(node->isClassPointerConstant() || node->isMethodPointerConstant()) || parent->getOpCode().isNullCheck())
          {
-         node->setUnneededIALoad(false);
+         node->setUnneededAloadi(false);
          }
       else if ((parent->getOpCodeValue() != TR::ifacmpne || tt->getNode()->getOpCodeValue() != TR::ifacmpne))
          {
-         node->setUnneededIALoad(false);
+         node->setUnneededAloadi(false);
          }
       }
    }
@@ -447,7 +447,7 @@ OMR::Z::CodeGenerator::CodeGenerator(TR::Compilation *comp)
      _previouslyAssignedTo(comp->allocator("LocalRA")),
      _methodBegin(NULL),
      _methodEnd(NULL),
-     _ialoadUnneeded(comp->trMemory())
+     _aloadiUnneeded(comp->trMemory())
    {
    }
 

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -243,7 +243,7 @@ public:
    void beginInstructionSelection();
    void endInstructionSelection();
 
-   void checkIsUnneededIALoad(TR::Node *parent, TR::Node* node, TR::TreeTop *tt);
+   void checkIsUnneededAloadi(TR::Node *parent, TR::Node* node, TR::TreeTop *tt);
    void lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount);
 
 
@@ -767,7 +767,7 @@ public:
 protected:
    TR::list<TR::S390ConstantDataSnippet*>  _constantList;
    TR::list<TR::S390ConstantDataSnippet*>  _snippetDataList;
-   List<TR_Pair<TR::Node, int32_t> > _ialoadUnneeded;
+   List<TR_Pair<TR::Node, int32_t> > _aloadiUnneeded;
 
 private:
 

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -550,7 +550,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
 
          if (symRef->isUnresolved())
             {
-            self()->createUnresolvedDataSnippetForiaload(rootLoadOrStore, cg, symRef, tempReg, isStore);
+            self()->createUnresolvedDataSnippetForAloadi(rootLoadOrStore, cg, symRef, tempReg, isStore);
             }
          else
             {

--- a/compiler/z/codegen/OMRMemoryReference.hpp
+++ b/compiler/z/codegen/OMRMemoryReference.hpp
@@ -457,7 +457,7 @@ void tryForceFolding(TR::Node * rootLoadOrStore, TR::CodeGenerator * cg, TR_Stor
                      List<TR::Node>& nodesAlreadyEvaluatedBeforeFoldingList) {}
 
 TR::UnresolvedDataSnippet * createUnresolvedDataSnippet(TR::Node * node, TR::CodeGenerator * cg, TR::SymbolReference * symRef, TR::Register * tempReg, bool isStore) {return NULL;}
-TR::UnresolvedDataSnippet * createUnresolvedDataSnippetForiaload(TR::Node * node, TR::CodeGenerator * cg, TR::SymbolReference * symRef, TR::Register * tempReg, bool & isStore) {return NULL;}
+TR::UnresolvedDataSnippet * createUnresolvedDataSnippetForAloadi(TR::Node * node, TR::CodeGenerator * cg, TR::SymbolReference * symRef, TR::Register * tempReg, bool & isStore) {return NULL;}
 void createUnresolvedSnippetWithNodeRegister(TR::Node * node, TR::CodeGenerator * cg, TR::SymbolReference * symRef, TR::Register *& writableLiteralPoolRegister) {}
 void createUnresolvedDataSnippetForBaseNode(TR::CodeGenerator * cg, TR::Register * writableLiteralPoolRegister) {}
 

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -7059,7 +7059,7 @@ aloadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * tempM
    // Evaluation of aloadi cannot be skipped if any unevaluated node in its subtree contains a symbol reference
    // TODO: Currently we exclude aloadi nodes from the skipping list conservatively. The logic should be modified
    // to skip evaluation of unneeded aloadi nodes which do not contain any symbol reference.
-   if (node->isUnneededIALoad() &&
+   if (node->isUnneededAloadi() &&
            (node->getFirstChild()->getNumChildren() == 0 || node->getFirstChild()->getRegister() != NULL))
       {
       traceMsg (comp, "This aloadi is not needed: %p\n", node);


### PR DESCRIPTION
The old opcodes had the letter i as a prefix if the operation was indirect. Those opcodes were renamed to use the letter i as a suffix instead.

This commit cleans up the references to the old opcodes, iiload/iistore ilload/ilstore iaload/iastore ibload/ibstore, to iloadi/istorei lloadi/lstorei aloadi/astorei bloadi/bstorei in the code.

**Depends on** 
- [ ] https://github.com/eclipse-openj9/openj9/pull/20521

Related: eclipse-openj9/openj9#19489