### PR TITLE
Implement mToLongBits evaluator on Power for Byte type

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1850,6 +1850,11 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
             return false;
       case TR::vreductionAdd:
          return true;
+      case TR::mToLongBits:
+         if (et == TR::Int8 && cpu->isAtLeast(OMR_PROCESSOR_PPC_P10))
+            return true;
+         else
+            return false;
       case TR::vload:
       case TR::vloadi:
       case TR::vstore:

--- a/compiler/p/codegen/OMRInstOpCode.enum
+++ b/compiler/p/codegen/OMRInstOpCode.enum
@@ -637,7 +637,7 @@
 // vpermr,           // vector permute right-indexed
 // vbpermd,          // vector bit permute DWord
    vbpermq,          // Vector Bit Permute Qword
-// vextractbm,       // Vector Extract Byte Mask
+   vextractbm,       // Vector Extract Byte Mask
    vrld,             // Vector Rotate Left Dword
 // vsbox,            // Vector AES SubBytes
    vsel,             // vector conditional select
@@ -962,7 +962,7 @@
 // xxbrd,            // VSX Vector Byte-Reverse Dword
 // xxbrh,            // VSX Vector Byte-Reverse Hword
 // xxbrw,            // VSX Vector Byte-Reverse Word
-// xxbrq,            // VSX Vector Byte-Reverse Qword
+   xxbrq,            // VSX Vector Byte-Reverse Qword
    fmrgew,           // Merge Even Word
    fmrgow,           // Merge Odd Word
    lxsiwax,          // VSX Scalar as Integer Word Algebraic Indexed

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -7462,17 +7462,17 @@
                         PPCOpProp_SyncSideEffectFree,
    },
 
-  /* { */
-   /* .mnemonic    =    OMR::InstOpCode::vextractbm, */
-   /* .name        =    "vextractbm", */
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::vextractbm,
+   /* .name        = */ "vextractbm",
    /* .description =    "Vector Extract Byte Mask", */
-   /* .prefix      =    0x00000000, */
-   /* .opcode      =    0x10080642, */
-   /* .format      =    FORMAT_RT_VRB, */
-   /* .minimumALS  =    OMR_PROCESSOR_PPC_P10, */
-   /* .properties  =    PPCOpProp_IsVMX |  */
-   /*                   PPCOpProp_SyncSideEffectFree, */
-   /* }, */
+   /* .prefix      = */ 0x00000000,
+   /* .opcode      = */ 0x10080642,
+   /* .format      = */ FORMAT_RT_VRB,
+   /* .minimumALS  = */ OMR_PROCESSOR_PPC_P10,
+   /* .properties  = */ PPCOpProp_IsVMX |
+                        PPCOpProp_SyncSideEffectFree,
+   },
 
    {
    /* .mnemonic    = */ OMR::InstOpCode::vrld,
@@ -11494,17 +11494,17 @@
    /*                   PPCOpProp_SyncSideEffectFree, */
    /* }, */
 
-   /* { */
-   /* .mnemonic    =    OMR::InstOpCode::xxbrq, */
-   /* .name        =    "xxbrq", */
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::xxbrq,
+   /*  .name       = */ "xxbrq",
    /* .description =    "VSX Vector Byte-Reverse Qword", */
-   /* .prefix      =    0x00000000, */
-   /* .opcode      =    0xF01F076C, */
-   /* .format      =    FORMAT_UNKNOWN, */
-   /* .minimumALS  =    OMR_PROCESSOR_PPC_P9, */
-   /* .properties  =    PPCOpProp_IsVSX | */
-   /*                   PPCOpProp_SyncSideEffectFree, */
-   /* }, */
+   /* .prefix      = */ 0x00000000,
+   /* .opcode      = */ 0xF01F076C,
+   /* .format      = */ FORMAT_XT_XB,
+   /* .minimumALS  = */ OMR_PROCESSOR_PPC_P9,
+   /* .properties  = */ PPCOpProp_IsVSX |
+                        PPCOpProp_SyncSideEffectFree,
+   },
 
    {
    /* .mnemonic    = */ OMR::InstOpCode::fmrgew,

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -931,7 +931,26 @@ OMR::Power::TreeEvaluator::mLastTrueEvaluator(TR::Node *node, TR::CodeGenerator 
 TR::Register*
 OMR::Power::TreeEvaluator::mToLongBitsEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   TR::Node *firstChild = node->getFirstChild();
+
+   TR_ASSERT_FATAL_WITH_NODE(node, firstChild->getDataType().getVectorLength() == TR::VectorLength128,
+                             "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
+   TR_ASSERT_FATAL_WITH_NODE(node, firstChild->getDataType().getVectorNumLanes() == 16,
+                             "Unsupported vector type %s for mToLongBits\n", firstChild->getDataType().toString());
+
+   TR::Register *srcReg = cg->evaluate(firstChild);
+   TR::Register *tmpReg = cg->allocateRegister(TR_VRF);
+   TR::Register *resReg = cg->allocateRegister(TR_GPR);
+
+   generateTrg1Src1Instruction(cg, OMR::InstOpCode::xxbrq, node, tmpReg, srcReg);
+   generateTrg1Src1Instruction(cg, OMR::InstOpCode::vextractbm, node, resReg, tmpReg);
+
+   cg->stopUsingRegister(tmpReg);
+   node->setRegister(resReg);
+   cg->decReferenceCount(firstChild);
+
+   return resReg;
    }
 
 TR::Register*


### PR DESCRIPTION
- pack Mask into a long
- at least in the current VectorAPI implementation, bits are packed
  in reverse order
- for a mask [true, false, false, .... false] returns 0x01
- for a mask  [false, false, ... false,  true] returns 0x8000