### PR TITLE
Implement mFirstTrue evaluator on Power for Byte type

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1851,7 +1851,12 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
       case TR::vreductionAdd:
          return true;
       case TR::mToLongBits:
-         if (et == TR::Int8 && cpu->isAtLeast(OMR_PROCESSOR_PPC_P10))
+        if (et == TR::Int8 && cpu->isAtLeast(OMR_PROCESSOR_PPC_P10))
+            return true;
+         else
+            return false;
+      case TR::mFirstTrue:
+         if (et == TR::Int8 && cpu->isAtLeast(OMR_PROCESSOR_PPC_P9))
             return true;
          else
             return false;

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -6813,15 +6813,15 @@
    },
 
    {
-   /* .mnemonic    = */   OMR::InstOpCode::vclzlsbb,
-   /* .name        = */   "vclzlsbb",
-   /* .description =    "vector count leading zero least-significant bits byte", */
-   /* .prefix      = */   0x00000000,
-   /* .opcode      = */   0x10000602,
-   /* .format      = */   FORMAT_RT_VRB,
+   /* .mnemonic    = */  OMR::InstOpCode::vclzlsbb,
+   /* .name        = */  "vclzlsbb",
+   /* .description =     "vector count leading zero least-significant bits byte", */
+   /* .prefix      = */  0x00000000,
+   /* .opcode      = */  0x10000602,
+   /* .format      = */  FORMAT_RT_VRB,
    /* .minimumALS  = */  OMR_PROCESSOR_PPC_P9,
-   /* .properties  = */   PPCOpProp_IsVMX |
-                          PPCOpProp_SyncSideEffectFree,
+   /* .properties  = */  PPCOpProp_IsVMX |
+                         PPCOpProp_SyncSideEffectFree,
    },
 
    {

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -919,7 +919,26 @@ OMR::Power::TreeEvaluator::mTrueCountEvaluator(TR::Node *node, TR::CodeGenerator
 TR::Register*
 OMR::Power::TreeEvaluator::mFirstTrueEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   TR::Node *firstChild = node->getFirstChild();
+
+   TR_ASSERT_FATAL_WITH_NODE(node, firstChild->getDataType().getVectorLength() == TR::VectorLength128,
+                             "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
+   TR_ASSERT_FATAL_WITH_NODE(node, firstChild->getDataType().getVectorNumLanes() == 16,
+                             "Unsupported vector type %s for mToLongBits\n", firstChild->getDataType().toString());
+
+
+   TR::Register *srcReg = cg->evaluate(firstChild);
+   TR::Register *tmpReg = cg->allocateRegister(TR_VRF);
+   TR::Register *resReg = cg->allocateRegister();
+
+   generateTrg1Src1Instruction(cg, OMR::InstOpCode::vclzlsbb, node, resReg, srcReg);
+
+   cg->stopUsingRegister(tmpReg);
+   node->setRegister(resReg);
+   cg->decReferenceCount(firstChild);
+
+   return resReg;
    }
 
 TR::Register*

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -925,16 +925,14 @@ OMR::Power::TreeEvaluator::mFirstTrueEvaluator(TR::Node *node, TR::CodeGenerator
                              "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
    TR_ASSERT_FATAL_WITH_NODE(node, firstChild->getDataType().getVectorNumLanes() == 16,
-                             "Unsupported vector type %s for mToLongBits\n", firstChild->getDataType().toString());
+                             "Unsupported vector type %s for mFirstTrue\n", firstChild->getDataType().toString());
 
 
    TR::Register *srcReg = cg->evaluate(firstChild);
-   TR::Register *tmpReg = cg->allocateRegister(TR_VRF);
-   TR::Register *resReg = cg->allocateRegister();
+   TR::Register *resReg = cg->allocateRegister(TR_GPR);
 
    generateTrg1Src1Instruction(cg, OMR::InstOpCode::vclzlsbb, node, resReg, srcReg);
 
-   cg->stopUsingRegister(tmpReg);
    node->setRegister(resReg);
    cg->decReferenceCount(firstChild);
 


### PR DESCRIPTION
- Returns the index of the first mask lane that is set.
- Returns vector length if none of them are set.