### PR TITLE
x86: Increase inline arraycopy threshold

### DIFF
--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1495,11 +1495,11 @@ public:
       _edoRecompSizeThreshold = 0;
       _edoRecompSizeThresholdInStartupMode = 0;
       _catchBlockCounterThreshold = 0;
-      _arraycopyRepMovsByteArrayThreshold = 32;
-      _arraycopyRepMovsCharArrayThreshold = 32;
-      _arraycopyRepMovsIntArrayThreshold = 32;
-      _arraycopyRepMovsLongArrayThreshold = 32;
-      _arraycopyRepMovsReferenceArrayThreshold = 32;
+      _arraycopyRepMovsByteArrayThreshold = 0;
+      _arraycopyRepMovsCharArrayThreshold = 0;
+      _arraycopyRepMovsIntArrayThreshold = 0;
+      _arraycopyRepMovsLongArrayThreshold = 0;
+      _arraycopyRepMovsReferenceArrayThreshold = 0;
 
       memset(_options, 0, sizeof(_options));
       memset(_disabledOptimizations, false, sizeof(_disabledOptimizations));

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -2743,7 +2743,7 @@ static bool enablePrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS(uint8_t elemen
 
    bool disableEnhancement = false;
 
-   threshold = 32;
+   threshold = 64;
 
    switch (elementSize)
       {
@@ -2752,8 +2752,10 @@ static bool enablePrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS(uint8_t elemen
          disableEnhancement = disable64BitPrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS
                               || cg->comp()->getOption(TR_Disable64BitPrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS);
 
+         threshold = cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F) ? 128 : 64;
+
          int32_t newThreshold = cg->comp()->getOptions()->getArraycopyRepMovsLongArrayThreshold();
-         if ((threshold < newThreshold) && ((newThreshold == 64) || (newThreshold == 128)))
+         if ((newThreshold == 32) || (newThreshold == 64) || (newThreshold == 128))
             {
             // If the CPU doesn't support AVX512, reduce the threshold to 64 bytes
             threshold = ((newThreshold == 128) && !cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F)) ? 64 : newThreshold;
@@ -2765,8 +2767,10 @@ static bool enablePrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS(uint8_t elemen
          disableEnhancement = disable32BitPrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS
                               || cg->comp()->getOption(TR_Disable32BitPrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS);
 
+         threshold = cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F) ? 128 : 64;
+
          int32_t newThreshold = cg->comp()->getOptions()->getArraycopyRepMovsIntArrayThreshold();
-         if ((threshold < newThreshold) && ((newThreshold == 64) || (newThreshold == 128)))
+         if ((newThreshold == 32) || (newThreshold == 64) || (newThreshold == 128))
             {
             // If the CPU doesn't support AVX512, reduce the threshold to 64 bytes
             threshold = ((newThreshold == 128) && !cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F)) ? 64 : newThreshold;
@@ -2781,7 +2785,7 @@ static bool enablePrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS(uint8_t elemen
          int32_t newThreshold = cg->comp()->getOptions()->getArraycopyRepMovsCharArrayThreshold();
 
          // Char array enhancement supports only 32 or 64 bytes
-         threshold = (newThreshold == 64) ? 64 : threshold;
+         threshold = (newThreshold == 32) ? 32 : threshold;
          }
          break;
       default: // 1 byte
@@ -2792,7 +2796,7 @@ static bool enablePrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS(uint8_t elemen
          int32_t newThreshold = cg->comp()->getOptions()->getArraycopyRepMovsByteArrayThreshold();
 
          // Byte array enhancement supports only 32 or 64 bytes
-         threshold = (newThreshold == 64) ? 64 : threshold;
+         threshold = (newThreshold == 32) ? 32 : threshold;
          }
          break;
       }


### PR DESCRIPTION
This commit increases arraycopyRepMovs*ArrayThreshold:
- Byte and char arraycopy: from 32 bytes to 64 bytes
- Int and long arraycopy: from 32 bytes to 64 bytes or 128 bytes if AVX-512 is supported