### PR TITLE
Add missing copyright headers to .md files

### DIFF
--- a/doc/compiler/memory/MemoryManager.md
+++ b/doc/compiler/memory/MemoryManager.md
@@ -1,18 +1,39 @@
+<!--
+Copyright IBM Corp. and others 2017
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution
+and is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the
+Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+version 2 with the GNU Classpath Exception [1] and GNU General Public
+License, version 2 with the OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
 # OMR Compiler Memory Manager
 
-The OMR Compiler doesn't necessarily operate in a vacuum, but rather 
-as one component of a Managed runtime. Additionally,  communications 
-between components could be using C linkage. Therefore, one can't simply 
+The OMR Compiler doesn't necessarily operate in a vacuum, but rather
+as one component of a Managed runtime. Additionally,  communications
+between components could be using C linkage. Therefore, one can't simply
 use something like `::operator new` since it can throw. Additionally,
-any generic common allocator would have poor interaction between 
+any generic common allocator would have poor interaction between
 components, with little to no insight into usage.
 
-Using an allocator specific to a Managed Runtime, such as 
-`omrmem_allocate_memory` in the Port Library, is expensive 
-(both in terms of memory footprint and execution time) 
-for many of the types of allocations performed 
-by the Compiler; there are too many participants for informal trust, 
-book-keeping is expensive, and optimizing for divergent component 
+Using an allocator specific to a Managed Runtime, such as
+`omrmem_allocate_memory` in the Port Library, is expensive
+(both in terms of memory footprint and execution time)
+for many of the types of allocations performed
+by the Compiler; there are too many participants for informal trust,
+book-keeping is expensive, and optimizing for divergent component
 use-cases is difficult to impossible.
 
 Therefore, the compiler manages memory its own memory.
@@ -20,8 +41,8 @@ Therefore, the compiler manages memory its own memory.
 ## Compiler Memory Manager Hierarchy
 
 ### Low Level Allocators
-Low Level Allocators cannot be used by STL containers. They are 
-generally used by High Level Allocators as the underlying 
+Low Level Allocators cannot be used by STL containers. They are
+generally used by High Level Allocators as the underlying
 provider of memory.
 
 ```
@@ -56,90 +77,90 @@ provider of memory.
 ```
 
 #### TR::SegmentProvider
-`TR::SegmentProvider` is the basest class in the hierarchy. It is a 
-pure virtual class. It provides APIs to 
+`TR::SegmentProvider` is the basest class in the hierarchy. It is a
+pure virtual class. It provides APIs to
 * Request Memory
 * Release Memory
 * Determine the amount of memory allocated
 
 #### TR::SegmentPool
-`TR::SegmentPool` implements `TR::SegmentProvider`. It maintains a pool 
+`TR::SegmentPool` implements `TR::SegmentProvider`. It maintains a pool
 of memory segments. It currently does not have any users.
 
 #### TR::SegmentAllocator
-`TR::SegmentAllocator` is a pure virtual class. It extends 
+`TR::SegmentAllocator` is a pure virtual class. It extends
 `TR::SegmentProvider`. It providers further APIs to
 * Determine system bytes allocated
 * Determine region bytes allocated
 * Set an allocation limit
 
-Generally, implementors of this class allocate big segments of memory 
+Generally, implementors of this class allocate big segments of memory
 and subdivide those segments into smaller chunks of memory. Therefore,
-_system bytes_ refers to the total amount of big segments of memory 
-allocated, and _region bytes_ refers to the amount of memory carved 
-into smaller chunks. This process of allocating big segments of memory 
-in order to subdivide into smaller chunks is done to minimize the 
-number of times the allocator needs to request memory from *__its__* 
-backing provider (whether that be the Port Libary, or the OS, or 
+_system bytes_ refers to the total amount of big segments of memory
+allocated, and _region bytes_ refers to the amount of memory carved
+into smaller chunks. This process of allocating big segments of memory
+in order to subdivide into smaller chunks is done to minimize the
+number of times the allocator needs to request memory from *__its__*
+backing provider (whether that be the Port Libary, or the OS, or
 something else).
 
 #### OMR::SystemSegmentProvider
-`OMR::SystemSegmentProvider` implements `TR::SegmentAllocator`. 
-It uses `TR::RawAllocator` (see below) in order to allocate both 
-`TR::MemorySegment`s (see below) as well as memory for all its 
-internal memory management requirements. This is the default Low 
+`OMR::SystemSegmentProvider` implements `TR::SegmentAllocator`.
+It uses `TR::RawAllocator` (see below) in order to allocate both
+`TR::MemorySegment`s (see below) as well as memory for all its
+internal memory management requirements. This is the default Low
 Level Allocator used by the Compiler.
 
 #### OMR::DebugSegmentProvider
-`OMR::DebugSegmentProvider` implements `TR::SegmentAllocator`. 
-It uses `mmap` (or equivalent) to allocate `TR::MemorySegment`s. 
-It does not free memory when requested; instead it changes the 
-permission on the freed memory. The purpose of this is to help 
-debug memory corruption issues. It uses `TR::RawAllocator` for 
-all its internal memory mangement requirements. The compiler 
-will use this Low Level Allocator when the 
+`OMR::DebugSegmentProvider` implements `TR::SegmentAllocator`.
+It uses `mmap` (or equivalent) to allocate `TR::MemorySegment`s.
+It does not free memory when requested; instead it changes the
+permission on the freed memory. The purpose of this is to help
+debug memory corruption issues. It uses `TR::RawAllocator` for
+all its internal memory mangement requirements. The compiler
+will use this Low Level Allocator when the
 `TR_EnableScratchMemoryDebugging` option is enabled.
 
 ### High level Allocators
 High Level Allocators can be used by STL containers by wrapping them
-in a `TR::typed_allocator` (see below). They generally use a Low 
+in a `TR::typed_allocator` (see below). They generally use a Low
 Level Allocator as their underlying provider of memory.
 
 #### TR::Region
-`TR::Region` facilitates Region Semantics. It is used to allocate 
-memory that exists for its lifetime. It frees all of its memory when 
-it is destroyed. It uses `TR::SegmentProvider` as its backing provider 
-of memory. It also contains an automatic conversion (which wraps it 
+`TR::Region` facilitates Region Semantics. It is used to allocate
+memory that exists for its lifetime. It frees all of its memory when
+it is destroyed. It uses `TR::SegmentProvider` as its backing provider
+of memory. It also contains an automatic conversion (which wraps it
 in a `TR::typed_allocator`) for ease of use with STL containers.
 
 #### TR::StackMemoryRegion
-`TR::StackMemoryRegion` extends `TR::Region`. It is used to facilitate 
-Stack Mark / Stack Release semantics. A Stack Mark is implemented by 
-constructing the object, at which point it registers itself with the 
-`TR_Memory` object (see below), and saves the previous 
-`TR::StackMemoryRegion` object. A Stack Release is implemented by 
-destroying the object, at which point it unregisters itself with the 
-`TR_Memory` object, restoring the previous `TR::StackMemoryRegion` 
+`TR::StackMemoryRegion` extends `TR::Region`. It is used to facilitate
+Stack Mark / Stack Release semantics. A Stack Mark is implemented by
+constructing the object, at which point it registers itself with the
+`TR_Memory` object (see below), and saves the previous
+`TR::StackMemoryRegion` object. A Stack Release is implemented by
+destroying the object, at which point it unregisters itself with the
+`TR_Memory` object, restoring the previous `TR::StackMemoryRegion`
 object. `TR_Memory` is then used to allocate memory from the region.
-The use of this object **must** be consistent; it must either 
-be used for Stack Mark / Stack Release via `TR_Memory`, OR, it must 
-be used as a Region (though at that point, `TR::Region` should be used). 
-Interleaving Stack Mark / Stack Release and Region semantics **will** 
+The use of this object **must** be consistent; it must either
+be used for Stack Mark / Stack Release via `TR_Memory`, OR, it must
+be used as a Region (though at that point, `TR::Region` should be used).
+Interleaving Stack Mark / Stack Release and Region semantics **will**
 result in invalid data.
 
 #### TR::PersistentAllocator
-`TR::PersistentAllocator` is used to allocate memory that persists 
-for the lifetime of the Managed Runtime. It uses `TR::RawAllocator` 
-to allocate memory. It receives this allocator via the 
-`TR::PersistentAllocatorKit` (see below). It also contains 
-an automatic conversion (which wraps it in a `TR::typed_allocator`) 
+`TR::PersistentAllocator` is used to allocate memory that persists
+for the lifetime of the Managed Runtime. It uses `TR::RawAllocator`
+to allocate memory. It receives this allocator via the
+`TR::PersistentAllocatorKit` (see below). It also contains
+an automatic conversion (which wraps it in a `TR::typed_allocator`)
 for ease of use with STL containers.
 
 #### TR_TypedPersistentAllocator
 `TR_TypedPersistentAllocator` is a wrapper around `TR_PersistentMemory`.
-Its purpose is to allow the compiler to track memory per type (as 
+Its purpose is to allow the compiler to track memory per type (as
 defined in `TR_MemoryBase::ObjectType`) when using STL containers for
-persistent data types; it contains an automatic conversion (which 
+persistent data types; it contains an automatic conversion (which
 wraps it in a `TR::typed_allocator`) for ease of use with STL containers.
 
 For example, given:
@@ -156,15 +177,15 @@ public:
    uintptr_t _field2;
    };
 ```
-1. Add (or replace the existing `TR_ALLOC` with) `TR_ALLOC_SPECIALIZED` 
-with the appropriate `TR_MemoryBase::ObjectType` enum value to the 
+1. Add (or replace the existing `TR_ALLOC` with) `TR_ALLOC_SPECIALIZED`
+with the appropriate `TR_MemoryBase::ObjectType` enum value to the
 class definition
 2. Declare and use the container, eg:
 ```
 typedef TR::list<Test, Test::TrackedPersistentAllocator> TestList;
 TestList myList(getTypedAllocator<Test, Test::TrackedPersistentAllocator>(Test::getPersistentAllocator()));
 ```
-If the desire is to allocate the container using persistent memory 
+If the desire is to allocate the container using persistent memory
 (ie not a local on the stack), then:
 ```
 typedef TR::list<Test, Test::TrackedPersistentAllocator> TestList;
@@ -173,64 +194,64 @@ TestList *myList = new (storage) TestList(getTypedAllocator<Test, Test::TrackedP
 ```
 
 #### TR::RawAllocator
-`TR::RawAllocator` uses `malloc` (or equivalent) to allocate memory. 
-It contains an automatic conversion (which wraps it in a 
+`TR::RawAllocator` uses `malloc` (or equivalent) to allocate memory.
+It contains an automatic conversion (which wraps it in a
 `TR::typed_allocator`) for ease of use with STL containers.
 
 #### TR::Allocator
-`TR::Allocator` is an allocator provided by the CS2 library. 
-Use of `TR:Allocator` is strongly discouraged; it only exists for 
-legacy purposes. It will quite likley be removed in the 
-future. It contains an automatic conversion (which wraps it in a 
+`TR::Allocator` is an allocator provided by the CS2 library.
+Use of `TR:Allocator` is strongly discouraged; it only exists for
+legacy purposes. It will quite likley be removed in the
+future. It contains an automatic conversion (which wraps it in a
 `TR::typed_allocator`) for ease of use with STL containers.
 
 ## Other Compiler Memory Manager Related Concepts
 
 #### TR::typed_allocator
-`TR::typed_allocator` is used to wrap High Level 
-Allocators such as `TR::Region` in order to allow them to 
+`TR::typed_allocator` is used to wrap High Level
+Allocators such as `TR::Region` in order to allow them to
 be used by STL containers.
 
 #### TR::RegionProfiler
-`TR::RegionProfiler` is used to profile a `TR::Region`. 
+`TR::RegionProfiler` is used to profile a `TR::Region`.
 It does so via Debug Counters.
 
 #### TR::PersistentAllocatorKit
-`TR::PersistentAllocatorKit` contains data that is used 
+`TR::PersistentAllocatorKit` contains data that is used
 by the `TR::PersistentAllocator`.
 
 #### TR::MemorySegment
-`TR::MemorySegment` is used to describe a chunk, or segment, 
-of memory. It is also used to carve out that segment into smaller 
-pieces of memory. Both Low and High Level Allocators above describe and 
+`TR::MemorySegment` is used to describe a chunk, or segment,
+of memory. It is also used to carve out that segment into smaller
+pieces of memory. Both Low and High Level Allocators above describe and
 subdivide the memory they manage using `TR::MemorySegment`s.
 
 #### TR_PersistentMemory
-`TR_PersistentMemory` is an object that is used to allocate memory 
-that persists throughout the lifetime of the runtime. It uses 
-`TR::PersistentAllocator` to allocate memory. For the most part, 
-it is used in conjunction with `TR_ALLOC` (and related macros 
-described below). It is also used as a substitute for `malloc` in 
-legacy code where memory is still allocated and freed explicitly. 
-Generally, newer code should favour using `TR::PersistentAllocator` 
+`TR_PersistentMemory` is an object that is used to allocate memory
+that persists throughout the lifetime of the runtime. It uses
+`TR::PersistentAllocator` to allocate memory. For the most part,
+it is used in conjunction with `TR_ALLOC` (and related macros
+described below). It is also used as a substitute for `malloc` in
+legacy code where memory is still allocated and freed explicitly.
+Generally, newer code should favour using `TR::PersistentAllocator`
 instead of `jitPersistentAlloc`/`jitPersistentFree`.
 
 #### TR_Memory
-`TR_Memory` is a legacy object that was used as the interface by 
-which memory could be allocated. Each `TR::Compilation` contains 
-a `TR_Memory` object. `TR_Memory` is similar to `TR_PersistentMemory` 
-in that it is used in conjunction with `TR_ALLOC` (and related 
-macros described below), as well as is used as the means to allocate 
-and free memory explicity. Generally, newer code should favour 
+`TR_Memory` is a legacy object that was used as the interface by
+which memory could be allocated. Each `TR::Compilation` contains
+a `TR_Memory` object. `TR_Memory` is similar to `TR_PersistentMemory`
+in that it is used in conjunction with `TR_ALLOC` (and related
+macros described below), as well as is used as the means to allocate
+and free memory explicity. Generally, newer code should favour
 using `TR::Region`.
 
 #### TR_ALLOC, TR_PERSISTENT_ALLOC, TR_PERSISTENT_ALLOC_THROW, TR_ALLOC_WITHOUT_NEW
-These are macros that are placed inside a class' definition. 
-They are used to define a set of `new`/`delete` operators, as 
-well as to add the `jitPersistentAlloc`/`jitPersistentFree` methods 
-into the class. They exist to help keep track of the memory 
-allocated by various objects, as well as to ensure that the 
-`new`/`delete` operators are used in a manner that is consistent 
+These are macros that are placed inside a class' definition.
+They are used to define a set of `new`/`delete` operators, as
+well as to add the `jitPersistentAlloc`/`jitPersistentFree` methods
+into the class. They exist to help keep track of the memory
+allocated by various objects, as well as to ensure that the
+`new`/`delete` operators are used in a manner that is consistent
 with the Compiler memory management.
 
 ## How the Compiler Allocates Memory
@@ -240,27 +261,27 @@ The Compiler deals with two categories of allocations:
 2. Allocations that need to persist throughout the lifetime of the Managed Runtime
 
 ### Allocations only useful during a compilation
-The Compiler initializes a `OMR::SystemSegmentProvider` 
-(or `OMR::DebugSegmentProvider`) local object at the start of a 
-compilation. It then initializes a local `TR::Region` object, and a 
-local `TR_Memory` object which uses the `TR::Region` for general 
-allocations (and sub Regions), as well as for the first 
-`TR::StackMemoryRegion`. At the end of the compilation, the 
-`TR::Region` and `OMR::SystemtSegmentProvider` 
-(or `OMR::DebugSegmentProvider`) go out of scope, invoking their 
+The Compiler initializes a `OMR::SystemSegmentProvider`
+(or `OMR::DebugSegmentProvider`) local object at the start of a
+compilation. It then initializes a local `TR::Region` object, and a
+local `TR_Memory` object which uses the `TR::Region` for general
+allocations (and sub Regions), as well as for the first
+`TR::StackMemoryRegion`. At the end of the compilation, the
+`TR::Region` and `OMR::SystemtSegmentProvider`
+(or `OMR::DebugSegmentProvider`) go out of scope, invoking their
 destructors and freeing all the memory.
 
-There are a lot of places (thanks to `TR_ALLOC` and related macros) 
-where memory is explicity allocated. However, `TR::Region` 
+There are a lot of places (thanks to `TR_ALLOC` and related macros)
+where memory is explicity allocated. However, `TR::Region`
 should be the allocator used for all new code as much as possible.
 
 ### Allocations that persist for the lifetime of the Managed Runtime
-The Compiler initializes a `TR::PeristentAllocator` object when 
-it is first initialized (close to bootstrap time). For the most 
-part it allocates persistent memory either directly using the global 
-`jitPersistentAlloc`/`jitPersistentFree` or via the object methods 
-added through `TR_ALLOC` (and related macros). Again, 
-`TR::PersistentAllocator` or `TR_TypedPersistentAllocator` should 
+The Compiler initializes a `TR::PeristentAllocator` object when
+it is first initialized (close to bootstrap time). For the most
+part it allocates persistent memory either directly using the global
+`jitPersistentAlloc`/`jitPersistentFree` or via the object methods
+added through `TR_ALLOC` (and related macros). Again,
+`TR::PersistentAllocator` or `TR_TypedPersistentAllocator` should
 be the allocator used for all new code as much as possible.
 
 
@@ -276,7 +297,7 @@ copy-constructable. The objects die in LIFO order when the Region is destroyed.:
 to create a `TR::Region` that used `TR::PersistentAllocator` as its backing
 provider, they would simply need to extend `TR::SegmentProvider`, perhaps
 calling it `TR::PersistentSegmentProvider`, and have it use
-`TR::PersistentAllocator`. The `TR::Region` would then be provided this 
+`TR::PersistentAllocator`. The `TR::Region` would then be provided this
 `TR::PersistentSegmentProvider` object.
 
 

--- a/doc/compiler/optimizer/BenefitInliner.md
+++ b/doc/compiler/optimizer/BenefitInliner.md
@@ -1,16 +1,37 @@
+<!--
+Copyright IBM Corp. and others 2020
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution
+and is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the
+Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+version 2 with the GNU Classpath Exception [1] and GNU General Public
+License, version 2 with the OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
 # BenefitInliner
 
-BenefitInliner introduces a novel way of inlining. Compared to the traditional way of inlining relies on hard-coded heuristics, BenefitInliner provides a systematic way of evaluating inlining candidates that combines the dynamic and static benefits of inlining. 
+BenefitInliner introduces a novel way of inlining. Compared to the traditional way of inlining relies on hard-coded heuristics, BenefitInliner provides a systematic way of evaluating inlining candidates that combines the dynamic and static benefits of inlining.
 
 ## Overview of main phases of BenefitInliner
 1. Build the search space for candidate methods to be inlined.
     1. **TR::IDTBuilder** constructs an inlining dependency tree (**TR::IDT**).
     2. **TR::AbstractInterpreter** generates an **TR::InliningMethodSummary** stashing potential optimization opportunities and specifying the constraints for parameters to make optimizations happen.
-    3. **TR::AbstractInterpreter** computes abstract state values for each program point. 
+    3. **TR::AbstractInterpreter** computes abstract state values for each program point.
     4. At each call site, we calculate the benefit of inlining this method with its call frequency (direct benefit) and optimizations unlocked (indirect benefit) according to **TR::InliningMethodSummary**.
-2. Run the knapsack algorithm for choosing the best inlining plan.  
+2. Run the knapsack algorithm for choosing the best inlining plan.
 3. Commit the inlining plan and inline the methods.
-    
+
 ## Higher-Level Structure of the parts of BenfitInliner
 
 ### 1. BenefitInliner.cpp
@@ -26,23 +47,23 @@ Class hierarchy of the real inliner:
 
 * **TR::BenefitInlinerWrapper** is an adapter class which extends from **TR::Optimization**. `TR::BenefitInlinerWrapper::perform()` initializes a **TR::BenefitInliner** and controls how benefit inlining process is being done.
 
-* **TR::BenefitInliner** is the real Inliner that contains functionalities for selecting inlining candidates. When a **TR::BenefitInliner** is initialized, it comes with an inlining budget that constrains inlining by avoiding an uncontrollable increase in binary size. The inlining budget will be calculated based on the hotness and size of the method being JIT compiled. `TR::BenefitInliner::buildingInliningDependecyTree()` builds an **TR::IDT** that contains all the candidate methods to be inlined. `TR::BenefitInliner::inlinerPacking()` consumes the **TR::IDT** and selects the optimal set of methods to be inlined given the inlining budget and the cost and benefit of each method in the **TR::IDT**. 
+* **TR::BenefitInliner** is the real Inliner that contains functionalities for selecting inlining candidates. When a **TR::BenefitInliner** is initialized, it comes with an inlining budget that constrains inlining by avoiding an uncontrollable increase in binary size. The inlining budget will be calculated based on the hotness and size of the method being JIT compiled. `TR::BenefitInliner::buildingInliningDependecyTree()` builds an **TR::IDT** that contains all the candidate methods to be inlined. `TR::BenefitInliner::inlinerPacking()` consumes the **TR::IDT** and selects the optimal set of methods to be inlined given the inlining budget and the cost and benefit of each method in the **TR::IDT**.
 
-* **TR::BenefitInlinerBase** contains the functionalities of doing the actual inlining according to the inlining proposal proposed by `TR::BenefitInliner::inlinerPacking()`. 
+* **TR::BenefitInlinerBase** contains the functionalities of doing the actual inlining according to the inlining proposal proposed by `TR::BenefitInliner::inlinerPacking()`.
 
 ### 2. InliningProposal.cpp
 
-* **TR::InliningProposal** proposes an optimal set of methods that will be inlined. **TR::BenefitInlinerBase** takes **TR::InliningProposal** as a dependency. **TR::InliningProposal** will be set by the `TR::BenefitInliner::inlinerPacking()` and will be consulted during the inlining. 
+* **TR::InliningProposal** proposes an optimal set of methods that will be inlined. **TR::BenefitInlinerBase** takes **TR::InliningProposal** as a dependency. **TR::InliningProposal** will be set by the `TR::BenefitInliner::inlinerPacking()` and will be consulted during the inlining.
 
-* **TR::InliningProposalTable** is a 2D table of **TR::InliningProposal**. By the nature of `TR::BenefitInliner::inlinerPacking()` being a nested knapsack algorithm, a 2D table is required. 
+* **TR::InliningProposalTable** is a 2D table of **TR::InliningProposal**. By the nature of `TR::BenefitInliner::inlinerPacking()` being a nested knapsack algorithm, a 2D table is required.
 
 ### 3. IDTNode.cpp, IDT.cpp & IDTBuilder.cpp
 
-* **TR::IDTNode** is the building block of **TR::IDT**. It is the abstract representation of a candidate method. 
+* **TR::IDTNode** is the building block of **TR::IDT**. It is the abstract representation of a candidate method.
 
 A **TR::IDTNode** has the following important properties:
-- **call ratio** - Estimate of how many times this node is visited per the execution of its parent. 
-- **root call ratio** - Estimate of how many times this node is visited per the execution of the root node. 
+- **call ratio** - Estimate of how many times this node is visited per the execution of its parent.
+- **root call ratio** - Estimate of how many times this node is visited per the execution of the root node.
 - **Inlining method summary** - Captures potential optimization opportunities for inlining this method. (Refer to **InliningMethodSummary.cpp** for details)
 - **static benefit** - The indirect benefit (optimizations unlocked) of inlining this method.
 - **budget** - The remaining budget for the descendants of this node.
@@ -62,10 +83,10 @@ The **cost** and **benefit** will be used for solving the inliner packing proble
 **Process of building the IDT:**
 
 ```
-buildIDT() --> buildIDT2() --> generateControlFlowGraph() --> performAbstractInterpretation() --> addNodesToIDT() 
-             |                                                                                              |  
-             |______________________________________________________________________________________________| 
-``` 
+buildIDT() --> buildIDT2() --> generateControlFlowGraph() --> performAbstractInterpretation() --> addNodesToIDT()
+             |                                                                                              |
+             |______________________________________________________________________________________________|
+```
 
 Note: `generateControlFlowGraph()` and `performAbstractInterpretation()` need language-specific implementation.
 
@@ -81,7 +102,7 @@ The responsibilities of **abstract interpretation**:
 
 **TR::PotentialOptimizationPredicate** is the interface for the potential optimization predicates such as branch folding and null-check folding, etc.`TR::PotentialOptimizationPredicate::test` tests against an argument value to tell whether or not this abstract argument is a safe value to unlock the optimization.
 
-**TR::PotentialOptimizationVPPredicate** is the extention of **TR::PotentialOptimizationPredicate**. It takes **TR::VPConstraint** as a dependency to serve as the constraint (lattice). Those constraints specify the maximal safe values to make the optimizations happen. 
+**TR::PotentialOptimizationVPPredicate** is the extention of **TR::PotentialOptimizationPredicate**. It takes **TR::VPConstraint** as a dependency to serve as the constraint (lattice). Those constraints specify the maximal safe values to make the optimizations happen.
 
 **TR::InliningMethodSummary** captures potential optimization opportunities of inlining one particular method. `InliningMethodSummary::testArgument` tells the total optimizations that will be unlocked given the abstract argument value.
 
@@ -89,6 +110,6 @@ The responsibilities of **abstract interpretation**:
 
 **TR::AbsValue** is an interface for abstract values. A **top** abstract value is the least accurate abstract value, analogous to the unknown value. A NULL **TR::AbsValue** represents uninitialized abstract values (bottom). The core method `merge(TR::AbsValue* other)` along with other methods need to be implemented by extension classes. The implementation of the `merge(TR::AbsValue* other)` operation should be an in-place merge and should not modify `other`. Also, `self` should not store any mutable references from `other` during the merge but immutable references are allowed.
 
-**TR::AbsVPValue** extends from **TR::AbsValue**. It uses **TR::VPConstraint** as the lattice (constraint) to represent the value. `TR::AbsVPValue::merge` relies on `TR::VPConstraint::merge` for merging various type of values. 
+**TR::AbsVPValue** extends from **TR::AbsValue**. It uses **TR::VPConstraint** as the lattice (constraint) to represent the value. `TR::AbsVPValue::merge` relies on `TR::VPConstraint::merge` for merging various type of values.
 
 **TR::AbsOpStack** is an operand stack for abstract values. **TR::AbsOpArray** is an operand array for abstract values. The `merge` functions of **TR::AbsOpStack** and **TR::AbsOpArray** merge another state in place. The merge operation does not modify the state of another state or store any references of abstract values from another state to be merged with.

--- a/doc/compiler/optimizer/DataFlowEngine.md
+++ b/doc/compiler/optimizer/DataFlowEngine.md
@@ -1,3 +1,24 @@
+<!--
+Copyright IBM Corp. and others 2020
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution
+and is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the
+Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+version 2 with the GNU Classpath Exception [1] and GNU General Public
+License, version 2 with the OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
 # Data-Flow Engine
 
 To perform global optimizations on a compilation unit one of the primary utilities the OMR optimizer will make use of is the data-flow engine, which is the backbone for a variety of data-flow analyses that we support. The data-flow engine in OMR is not front and center to most developers. It is a piece of technology that has been battle tested for years and developers can expect it to _just work_. This document will walk us through some of the key concepts of the data-flow engine which will empower you, as a developer, to understand the inner workings of existing analyses and be able to write your own data-flow analyses with minimal effort.

--- a/doc/compiler/optimizer/IntroLoopOptimizations.md
+++ b/doc/compiler/optimizer/IntroLoopOptimizations.md
@@ -1,3 +1,24 @@
+<!--
+Copyright IBM Corp. and others 2017
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution
+and is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the
+Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+version 2 with the GNU Classpath Exception [1] and GNU General Public
+License, version 2 with the OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
 # Loop Canonicalizer, Loop Versioner, and Loop Specializer
 
 ## 1. Loop Canonicalizer

--- a/doc/compiler/optimizer/IntroReadLogFile.md
+++ b/doc/compiler/optimizer/IntroReadLogFile.md
@@ -1,3 +1,24 @@
+<!--
+Copyright IBM Corp. and others 2021
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution
+and is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the
+Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+version 2 with the GNU Classpath Exception [1] and GNU General Public
+License, version 2 with the OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
 # Introduction To JIT Compilation Logs
 
 1. How To Generate A Log File

--- a/doc/compiler/optimizer/ValuePropagation.md
+++ b/doc/compiler/optimizer/ValuePropagation.md
@@ -1,3 +1,24 @@
+<!--
+Copyright IBM Corp. and others 2020
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution
+and is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the
+Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+version 2 with the GNU Classpath Exception [1] and GNU General Public
+License, version 2 with the OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
 # Value Propagation
 
 Value propagation (VP) is one of the most powerful optimizations in the OMR compiler. It does several optimizations and analyses that one may typically find in literature, such as type propagation, constant propagation, range propagation, etc. The VP optimization combines these sorts of analyses all into one.
@@ -64,7 +85,7 @@ A `merge` of two constraints will weaken the constraint. For example consider th
 
 ```
 if (...) {
-    if (x != 10) 
+    if (x != 10)
         return;
     ...
 } else {

--- a/doc/compiler/riscv/Building.md
+++ b/doc/compiler/riscv/Building.md
@@ -1,3 +1,24 @@
+<!--
+Copyright IBM Corp. and others 2019
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution
+and is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the
+Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+version 2 with the GNU Classpath Exception [1] and GNU General Public
+License, version 2 with the OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
 # Building Compiler on RISC-V
 
 ## Native build

--- a/doc/port/sockets.md
+++ b/doc/port/sockets.md
@@ -1,3 +1,24 @@
+<!--
+Copyright IBM Corp. and others 2020
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution
+and is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the
+Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+version 2 with the GNU Classpath Exception [1] and GNU General Public
+License, version 2 with the OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
 # Linux to omrsock API mappings
 
 For implementation example, please refer to `omr/fvtest/porttest/omrsockTest.cpp`.


### PR DESCRIPTION
The copyright date was set to the date of the initial contribution.