### PR TITLE
Clean up references to old opcodes

### DIFF
--- a/compiler/arm/codegen/FPTreeEvaluator.cpp
+++ b/compiler/arm/codegen/FPTreeEvaluator.cpp
@@ -1385,7 +1385,7 @@ TR::Register *OMR::ARM::TreeEvaluator::dstoreEvaluator(TR::Node *node, TR::CodeG
    return NULL;
    }
 
-TR::Register *OMR::ARM::TreeEvaluator::ifstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+TR::Register *OMR::ARM::TreeEvaluator::fstoreiEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *secondChild = node->getSecondChild();
    TR::Register *sourceReg = cg->evaluate(secondChild);
@@ -1440,7 +1440,7 @@ TR::Register *OMR::ARM::TreeEvaluator::ifstoreEvaluator(TR::Node *node, TR::Code
    return NULL;
    }
 
-TR::Register *OMR::ARM::TreeEvaluator::idstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+TR::Register *OMR::ARM::TreeEvaluator::dstoreiEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *secondChild = node->getSecondChild();
    TR::Register *sourceReg = cg->evaluate(secondChild);
@@ -2811,12 +2811,12 @@ TR::Register *OMR::ARM::TreeEvaluator::dstoreEvaluator(TR::Node *node, TR::CodeG
    return NULL;
    }
 
-TR::Register *OMR::ARM::TreeEvaluator::ifstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+TR::Register *OMR::ARM::TreeEvaluator::fstoreiEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return NULL;
    }
 
-TR::Register *OMR::ARM::TreeEvaluator::idstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+TR::Register *OMR::ARM::TreeEvaluator::dstoreiEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return NULL;
    }

--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -230,18 +230,6 @@ OMR::ARM::TreeEvaluator::lstoreiEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    }
 
 TR::Register*
-OMR::ARM::TreeEvaluator::fstoreiEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return TR::TreeEvaluator::ifstoreEvaluator(node, cg);
-   }
-
-TR::Register*
-OMR::ARM::TreeEvaluator::dstoreiEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return TR::TreeEvaluator::idstoreEvaluator(node, cg);
-   }
-
-TR::Register*
 OMR::ARM::TreeEvaluator::astoreiEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return TR::TreeEvaluator::istoreEvaluator(node, cg);
@@ -3376,7 +3364,7 @@ TR::Register *OMR::ARM::TreeEvaluator::bloadEvaluator(TR::Node *node, TR::CodeGe
    return commonLoadEvaluator(node, TR::InstOpCode::ldrsb, 1, cg);
    }
 
-// also handles isload
+// also handles sloadi
 TR::Register *OMR::ARM::TreeEvaluator::sloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return commonLoadEvaluator(node, TR::InstOpCode::ldrsh, 2, cg);
@@ -3561,7 +3549,7 @@ TR::Register *OMR::ARM::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::CodeG
    return commonStoreEvaluator(node, TR::InstOpCode::strb, 1, cg);
    }
 
-// also handles isstore,isstore
+// also handles sstorei
 TR::Register *OMR::ARM::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return commonStoreEvaluator(node, TR::InstOpCode::strh, 2, cg);

--- a/compiler/arm/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.hpp
@@ -559,8 +559,6 @@ public:
    static TR::Register *dstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *bstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *ifstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *idstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *gotoEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ireturnEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *lreturnEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -1613,7 +1613,7 @@ TR::Node *constrainLload(OMR::ValuePropagation *vp, TR::Node *node)
    return node;
    }
 
-// Also handles ifload
+// Also handles floadi
 //
 TR::Node *constrainFload(OMR::ValuePropagation *vp, TR::Node *node)
    {
@@ -1633,7 +1633,7 @@ TR::Node *constrainFload(OMR::ValuePropagation *vp, TR::Node *node)
    return node;
    }
 
-// Also handles idload
+// Also handles dloadi
 //
 TR::Node *constrainDload(OMR::ValuePropagation *vp, TR::Node *node)
    {

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -3014,7 +3014,7 @@ TR::Register *OMR::Power::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::Cod
    return NULL;
    }
 
-// also handles isstore
+// also handles sstorei
 TR::Register *OMR::Power::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *valueChild;

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -732,7 +732,7 @@ TR::Register *OMR::X86::TreeEvaluator::bloadEvaluator(TR::Node *node, TR::CodeGe
    return reg;
    }
 
-// also handles isload
+// also handles sloadi
 TR::Register *OMR::X86::TreeEvaluator::sloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::MemoryReference  *sourceMR = generateX86MemoryReference(node, cg);
@@ -776,7 +776,7 @@ OMR::X86::TreeEvaluator::fwrtbariEvaluator(TR::Node *node, TR::CodeGenerator *cg
 
 // bloadiEvaluator handled by bloadEvaluator
 
-// isloadEvaluator handled by sloadEvaluator
+// sloadiEvaluator handled by sloadEvaluator
 
 // also used for istorei, astore and astorei
 TR::Register *OMR::X86::TreeEvaluator::integerStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -1096,7 +1096,7 @@ TR::Register *OMR::X86::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::CodeG
    return TR::TreeEvaluator::integerStoreEvaluator(node, cg);
    }
 
-// also handles isstore
+// also handles sstorei
 TR::Register *OMR::X86::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return TR::TreeEvaluator::integerStoreEvaluator(node, cg);
@@ -1110,7 +1110,7 @@ TR::Register *OMR::X86::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::CodeG
 
 // bstoreiEvaluator handled by bstoreEvaluator
 
-// isstoreEvaluator handled by sstoreEvaluator
+// sstoreiEvaluator handled by sstoreEvaluator
 
 TR::Register *
 OMR::X86::TreeEvaluator::arraycmpEvaluator(

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -5161,9 +5161,9 @@ generateS390CompareAndBranchOpsHelper(TR::Node * node, TR::CodeGenerator * cg, T
 
    // ificmpyy
    //   s2i        ; refcnt-1, unevaluated
-   //     isload   ; evaluated
+   //     sloadi   ; evaluated
    //   s2i        ; refcnt-1, unevaluated
-   //     isload   ; evaluated
+   //     sloadi   ; evaluated
    //
    // Try to generate a CR.
    // FIXME: can't the binary commutative analyser handle this? that's where this should be done
@@ -7920,7 +7920,7 @@ OMR::Z::TreeEvaluator::axaddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
  *   lloadi handled by lloadEvaluator
  *   aloadiEvaluator handled by aloadEvaluator
  *   bloadiEvaluator handled by bloadEvaluator
- *   isloadEvaluator handled by sloadEvaluator
+ *   sloadiEvaluator handled by sloadEvaluator
  *
  * iload Evaluator: load integer
  *   - also handles iloadi
@@ -7944,7 +7944,7 @@ OMR::Z::TreeEvaluator::lloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
 /**
  * sload Evaluator: load short integer
- *   - also handles isload
+ *   - also handles sloadi
  */
 TR::Register *
 OMR::Z::TreeEvaluator::sloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
@@ -7980,7 +7980,7 @@ OMR::Z::TreeEvaluator::bloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
  *  istorei handled by istoreEvaluator
  *  astoreiEvaluator handled by istoreEvaluator
  *  bstoreiEvaluator handled by bstoreEvaluator
- *  isstoreEvaluator handled by sstoreEvaluator
+ *  sstoreiEvaluator handled by sstoreEvaluator
  */
 /**
  * istoreEvaluator - store integer
@@ -8014,7 +8014,7 @@ OMR::Z::TreeEvaluator::lstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
 /**
  * sstoreEvaluator - store short integer
- *  - also handles isstore
+ *  - also handles sstorei
  */
 TR::Register *
 OMR::Z::TreeEvaluator::sstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -580,8 +580,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *dstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *bstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *ifstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *idstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *gotoEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *igotoEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *returnEvaluator(TR::Node *node, TR::CodeGenerator *cg);


### PR DESCRIPTION
The old opcodes had the letter i as a prefix if the operation was indirect. Those opcodes were renamed to use the letter i as a suffix instead.

This commit cleans up the references to the old opcodes, isload/isstore ifload/ifstore idload/idstore to
sloadi/sstorei floadi/fstorei dloadi/dstorei

Related: eclipse-openj9/openj9#19489