### PR TITLE
Remove compiler ras address masking

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -2496,12 +2496,8 @@ void OMR::Compilation::diagnosticImplVA(const char *s, va_list ap)
    {
    if (self()->getOutFile() != NULL)
       {
-      va_list copy;
-      va_copy(copy, ap);
-      char buffer[256];
-      TR::IO::vfprintf(self()->getOutFile(), s, copy);
+      TR::IO::vfprintf(self()->getOutFile(), s, ap);
       trfflush(self()->getOutFile());
-      va_end(copy);
       }
    }
 

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -2499,8 +2499,7 @@ void OMR::Compilation::diagnosticImplVA(const char *s, va_list ap)
       va_list copy;
       va_copy(copy, ap);
       char buffer[256];
-      TR::IO::vfprintf(self()->getOutFile(), self()->getDebug()->getDiagnosticFormat(s, buffer, sizeof(buffer)/sizeof(char)),
-                 copy);
+      TR::IO::vfprintf(self()->getOutFile(), s, copy);
       trfflush(self()->getOutFile());
       va_end(copy);
       }

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -965,7 +965,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"lowerCountsForAotCold", "M\tLower counts for cold aot runs", SET_OPTION_BIT(TR_LowerCountsForAotCold), "F", NOT_IN_SUBSET},
    {"lowOpt",             "O\tdeprecated; equivalent to optLevel=cold",
         TR::Options::set32BitValue, offsetof(OMR::Options, _optLevel), cold},
-   {"maskAddresses",       "D\tremove addresses from trace file",                   SET_OPTION_BIT(TR_MaskAddresses), "F" },
    {"maxBytesToLeaveAllocatedInSharedPool=","R<nnn>\tnumber of memory segments to leave allocated",
                                          TR::Options::setStaticNumeric, (intptr_t)&OMR::Options::_maxBytesToLeaveAllocatedInSharedPool, 0, "F%d", NOT_IN_SUBSET},
    {"maxInlinedCalls=",    "O<nnn>\tmaximum number of calls to be inlined",

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -194,7 +194,7 @@ enum TR_CompilationOptions
    TR_DisableDynamicLoopTransfer          = 0x00200000 + 3,
    TR_TraceNodeFlags                      = 0x00400000 + 3,
    TR_DisableNewBVA                       = 0x00800000 + 3,
-   TR_MaskAddresses                       = 0x01000000 + 3,
+   // Available                           = 0x01000000 + 3,
    TR_BreakBBStart                        = 0x02000000 + 3,
    TR_DisableRXusage                      = 0x04000000 + 3,
    TR_EnableInliningOfUnsafeForArraylets  = 0x08000000 + 3,

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -594,8 +594,6 @@ public:
 
    virtual void         printInstruction(TR::Instruction*);
 
-   virtual const char * getDiagnosticFormat(const char *, char *, int32_t);
-
    virtual void         dumpGlobalRegisterTable();
    virtual void         dumpSimulatedNode(TR::Node *node, char tagChar);
 

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -243,8 +243,6 @@ TR_Debug::printLoadConst(TR::Node *node, TR_PrettyPrinterString& output)
       case TR::Address:
          if (node->getAddress() == 0)
             output.appends(" NULL");
-         else if (_comp->getOption(TR_MaskAddresses))
-            output.appends(" *Masked*");
          else
             output.appendf(" " UINT64_PRINTF_FORMAT_HEX, node->getAddress());
          if (node->isClassPointerConstant())
@@ -1571,11 +1569,9 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
          else
             output.appends(" Relative [");
 
-         if (!_comp->getOption(TR_MaskAddresses))
-            {
-            for (auto i = 0U; i < node->getNumRelocations(); ++i)
-               output.appendf(" " POINTER_PRINTF_FORMAT, node->getRelocationDestination(i));
-            }
+         for (auto i = 0U; i < node->getNumRelocations(); ++i)
+            output.appendf(" " POINTER_PRINTF_FORMAT, node->getRelocationDestination(i));
+
          output.appends(" ]");
          }
       }

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -621,11 +621,9 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86FenceInstruction  * instr)
       else
          trfprintf(pOutFile, " Relative [");
 
-      if (!_comp->getOption(TR_MaskAddresses))
-         {
-         for (auto i = 0U; i < instr->getFenceNode()->getNumRelocations(); ++i)
-            trfprintf(pOutFile," " POINTER_PRINTF_FORMAT, instr->getFenceNode()->getRelocationDestination(i));
-         }
+      for (auto i = 0U; i < instr->getFenceNode()->getNumRelocations(); ++i)
+         trfprintf(pOutFile," " POINTER_PRINTF_FORMAT, instr->getFenceNode()->getRelocationDestination(i));
+
       trfprintf(pOutFile, " ]");
       }
 

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -901,8 +901,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390PseudoInstruction * instr)
             }
          for (int32_t i = 0; i < instr->getFenceNode()->getNumRelocations(); ++i)
             {
-            if (!_comp->getOption(TR_MaskAddresses))
-               trfprintf(pOutFile, " %p", instr->getFenceNode()->getRelocationDestination(i));
+            trfprintf(pOutFile, " %p", instr->getFenceNode()->getRelocationDestination(i));
             }
          trfprintf(pOutFile, " ]");
 

--- a/doc/compiler/CompilerOptions.md
+++ b/doc/compiler/CompilerOptions.md
@@ -194,7 +194,6 @@ options, etc).
 | debugOnEntry                               | invoke the debugger at the entry of a method                                                                                              |
 | exclude=<em>xxx</em>                       | do not compile methods beginning with <em>xxx</em>                                                                                        |
 | limit=<em>xxx</em>                         | only compile methods beginning with <em>xxx</em>                                                                                          |
-| maskAddresses                              | remove addresses from trace file                                                                                                          |
 | noRecompile                                | do not recompile even when counts allow it                                                                                                |
 | stopOnFailure                              | stop compilation if exceed memory threshold                                                                                               |
 | tlhPrefetch                                | enable software prefetch on allocation for X86                                                                                            |


### PR DESCRIPTION
"Address masking" was an attempt to make compiler log files easier to compare by preventing addresses (that are likely to change between compilations) from being printed raw in a compilation log.  It worked by intercepting the "printf" family of IO functions and checking whether any addresses were being printed with the `%p` format specifier, and instead of printing the address a "Masked Address" string was substituted instead.

This feature was introduced at a time when text file comparison tools were not as robust as they are today and many addresses are output to the log without using `%p` making this feature less effective.  Since it adds overhead and complexity to the logging path, has incomplete coverage, and is not widely used (if at all), remove it from the code base.

Removing address masking was discussed briefly at the Oct 24 OMR Architecture Meeting with agreement to remove it.