### PR TITLE
Add missing parameter to method comment

### DIFF
--- a/compiler/optimizer/OMRTransformUtil.hpp
+++ b/compiler/optimizer/OMRTransformUtil.hpp
@@ -219,6 +219,9 @@ class OMR_EXTENSIBLE TransformUtil
     * \param offsetNode
     *    The offset node (in bytes)
     *
+    * \param originatingByteCodeNode
+    *    The originating byte code node
+    *
     * \return
     *    IL to access array element at offset provided by offsetNode or
     *    first array element if no offset node is provided


### PR DESCRIPTION
The parameter was added in https://github.com/eclipse-omr/omr/pull/7509/files but I forgot to add it to the Doxygen method comment.