### PR TITLE
Pass indent size rather than buffer to TR_Debug::printByteCodeStack

### DIFF
--- a/compiler/env/FEBase.cpp
+++ b/compiler/env/FEBase.cpp
@@ -174,4 +174,4 @@ void __cxa_pure_virtual()
 void TR_Debug::print(J9JITExceptionTable *, TR_ResolvedMethod *, bool) { }
 void TR_Debug::printAnnotationInfoEntry(J9AnnotationInfo *,J9AnnotationInfoEntry *,int32_t) { }
 void TR_Debug::printByteCodeAnnotations() { }
-void TR_Debug::printByteCodeStack(int32_t, uint16_t, char *) { }
+void TR_Debug::printByteCodeStack(int32_t, uint16_t, size_t *) { }

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -2568,8 +2568,8 @@ TR_Debug::dumpMixedModeDisassembly()
          n = inst->getNode();
 
          trfprintf(pOutFile, "\n\n");
-         char * indent = (char *)_comp->trMemory()->allocateHeapMemory(6 + 3*(_comp->getMaxInlineDepth()+1));
-         printByteCodeStack(n->getInlinedSiteIndex(), n->getByteCodeIndex(), indent);
+         size_t indentLen = 0;
+         printByteCodeStack(n->getInlinedSiteIndex(), n->getByteCodeIndex(), &indentLen);
          }
 
       print(pOutFile, inst);

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -778,7 +778,7 @@ public:
    void printVCGEdges(TR::FILE *, TR_StructureSubGraphNode * node);
    void printVCG(TR::FILE *, TR::Block * block, int32_t vorder = -1, int32_t horder = -1);
 
-   void printByteCodeStack(int32_t parentStackIndex, uint16_t byteCodeIndex, char * indent);
+   void printByteCodeStack(int32_t parentStackIndex, uint16_t byteCodeIndex, size_t *indentLen);
    void print(TR::FILE *, TR::GCRegisterMap *);
 
    void verifyTreesPass1(TR::Node *node);


### PR DESCRIPTION
Codependent on https://github.com/eclipse-openj9/openj9/pull/20667