### PR TITLE
Zero offheap on commit on OSX

### DIFF
--- a/gc/base/SparseVirtualMemory.cpp
+++ b/gc/base/SparseVirtualMemory.cpp
@@ -132,6 +132,11 @@ MM_SparseVirtualMemory::allocateSparseFreeEntryAndMapToHeapObject(void *proxyObj
 	void *sparseHeapAddr = _sparseDataPool->findFreeListEntry(adjustedSize);
 	bool success = MM_VirtualMemory::commitMemory(sparseHeapAddr, adjustedSize);
 
+#if defined(OSX) || defined(OMRZTPF)
+	/* Most platforms will perform an implicit zero through the preceding commit. */
+	OMRZeroMemory(sparseHeapAddr, adjustedSize);
+#endif /* defined(OSX) || defined(OMRZTPF)) */
+
 	if (NULL != sparseHeapAddr) {
 		_sparseDataPool->mapSparseDataPtrToHeapProxyObjectPtr(sparseHeapAddr, proxyObjPtr, adjustedSize);
 	} else {


### PR DESCRIPTION
For some reason OSX does not seem to zero memory on commit, unless it's
the first commit. For now, till we understand if there is a way to force
zero on subsequent re-commits, we will zero it explicitly.

Including zPTF as well, since we don't know how it will behave, even
if/when it adds support for commit/decommit/virtual-memory.