### PR TITLE
Offheap LoopStrider Fix and disable storing dataAddr in temps

### DIFF
--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -3404,6 +3404,8 @@ bool TR_LoopStrider::reassociateAndHoistComputations(TR::Block *loopInvariantBlo
                index
                header_size/-header_size
 
+      OffHeap reassociation and hoisting is temporarily disabled
+      TODO enable storing dataAddrPtr in temps
       off-heap mode:
          aladd (internal pointer)
             contiguousArrayDataAddrFieldSymbol (dataAddrPointer, internal pointer)
@@ -3462,6 +3464,7 @@ bool TR_LoopStrider::reassociateAndHoistComputations(TR::Block *loopInvariantBlo
             //node->getSymbolReference()->getSymbol()->isAuto() &&
             node->getSymbolReference()->getSymbol()->isAutoOrParm() &&
             _neverWritten->get(node->getSymbolReference()->getReferenceNumber()))) &&
+           !originalNode->getFirstChild()->isDataAddrPointer() && // TODO enable storing dataAddrPtr in temps
            (!_registersScarce || (originalNode->getReferenceCount() > 1)) &&
            (comp()->getSymRefTab()->getNumInternalPointers() < maxInternalPointers()) &&
            (!comp()->cg()->canBeAffectedByStoreTagStalls() ||
@@ -3672,7 +3675,8 @@ bool TR_LoopStrider::reassociateAndHoistComputations(TR::Block *loopInvariantBlo
     * If first child of originalNode is not dataAddr pointer we have already
     * hoisted the array aload, no need to do it again.
     */
-   if (TR::Compiler->om.isOffHeapAllocationEnabled() && originalNode && originalNode->getFirstChild()->isDataAddrPointer())
+   if (false && // TODO enable storing dataAddrPtr in temps
+      TR::Compiler->om.isOffHeapAllocationEnabled() && originalNode && originalNode->getFirstChild()->isDataAddrPointer())
       {
       if ((isInternalPointer &&
             (comp()->getSymRefTab()->getNumInternalPointers() < maxInternalPointers())) &&

--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -983,7 +983,12 @@ int32_t TR_LoopStrider::detectCanonicalizedPredictableLoops(TR_Structure *loopSt
                      {
                      TR::Node *constantNode  = TR::Node::create(byteCodeInfoNode, TR::lconst);
                      constantNode->setLongInt((int64_t)index);
-                     arrayRefNode = TR::Node::create(TR::aladd, 2, TR::Node::createWithSymRef(byteCodeInfoNode, TR::aload, 0, origAuto), constantNode);
+                     arrayRefNode = TR::Node::createWithSymRef(byteCodeInfoNode, TR::aload, 0, origAuto);
+#if defined(OMR_GC_SPARSE_HEAP_ALLOCATION)
+                     if (TR::Compiler->om.isOffHeapAllocationEnabled())
+                        arrayRefNode = TR::TransformUtil::generateDataAddrLoadTrees(comp(), arrayRefNode);
+#endif /* OMR_GC_SPARSE_HEAP_ALLOCATION */
+                     arrayRefNode = TR::Node::create(TR::aladd, 2, arrayRefNode, constantNode);
                      }
                   else
                      arrayRefNode = TR::Node::create(TR::aiadd, 2, TR::Node::createWithSymRef(byteCodeInfoNode, TR::aload, 0, origAuto), TR::Node::create(byteCodeInfoNode, TR::iconst, 0, index));
@@ -992,7 +997,14 @@ int32_t TR_LoopStrider::detectCanonicalizedPredictableLoops(TR_Structure *loopSt
                   {
                   TR::SymbolReference *indexSymRef = symRefPair->_indexSymRef;
                   if (usingAladd)
-                     arrayRefNode = TR::Node::create(TR::aladd, 2, TR::Node::createWithSymRef(byteCodeInfoNode, TR::aload, 0, origAuto), TR::Node::createWithSymRef(byteCodeInfoNode, TR::lload, 0, indexSymRef));
+                     {
+                     arrayRefNode = TR::Node::createWithSymRef(byteCodeInfoNode, TR::aload, 0, origAuto);
+#if defined(OMR_GC_SPARSE_HEAP_ALLOCATION)
+                     if (TR::Compiler->om.isOffHeapAllocationEnabled())
+                        arrayRefNode = TR::TransformUtil::generateDataAddrLoadTrees(comp(), arrayRefNode);
+#endif /* OMR_GC_SPARSE_HEAP_ALLOCATION */
+                     arrayRefNode = TR::Node::create(TR::aladd, 2, arrayRefNode, TR::Node::createWithSymRef(byteCodeInfoNode, TR::lload, 0, indexSymRef));
+                     }
                   else
                      arrayRefNode = TR::Node::create(TR::aiadd, 2, TR::Node::createWithSymRef(byteCodeInfoNode, TR::aload, 0, origAuto), TR::Node::createWithSymRef(byteCodeInfoNode, TR::iload, 0, indexSymRef));
                   }


### PR DESCRIPTION
First commit fixes creating invariant initialization trees with array address calculation to insert loading the dataAddrPtr
```
BEFORE
n690n     astore  <internal pointer temp slot 8>[#450  Auto] [flags 0x40007 0x0 ]             [0x7815e188c760] bci=[-1,5,35] rc=0 vc=0 vn=- li=-1 udi=- nc=1
n689n       aladd (internalPtr )                                                              [0x7815e188c710] bci=[-1,5,35] rc=1 vc=0 vn=- li=- udi=- nc=2 flg=0x8000
n688n         aload  <pinning array temp slot 6>[#448  Auto] [flags 0x10000007 0x0 ]          [0x7815e188c6c0] bci=[-1,5,35] rc=1 vc=0 vn=- li=- udi=- nc=0
n687n         lconst 4 (highWordZero X!=0 X>=0 )                                              [0x7815e188c670] bci=[-1,5,35] rc=1 vc=0 vn=- li=- udi=- nc=0 flg=0x4104

AFTER
n692n     astore  <internal pointer temp slot 8>[#450  Auto] [flags 0x40007 0x0 ]             [0x70e90b08c800] bci=[-1,5,35] rc=0 vc=0 vn=- li=-1 udi=- nc=1
n691n       aladd (internalPtr )                                                              [0x70e90b08c7b0] bci=[-1,5,35] rc=1 vc=0 vn=- li=- udi=- nc=2 flg=0x8000
n690n         aloadi  <contiguousArrayDataAddrField>[#373  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [0x70e90b08c760] bci=[-1,5,35] rc=1 vc=0 vn=- li=- udi=->
n689n           aload  <pinning array temp slot 6>[#448  Auto] [flags 0x10000007 0x0 ]        [0x70e90b08c710] bci=[-1,5,35] rc=1 vc=0 vn=- li=- udi=- nc=0
n688n         lconst 4 (highWordZero X!=0 X>=0 )                                              [0x70e90b08c6c0] bci=[-1,5,35] rc=1 vc=0 vn=- li=- udi=- nc=0 flg=0x4104 
``` 

----

Second commit disables remaining code that stores dataAddr pointers and calculations using it in temp variables (addressed in https://github.com/eclipse-omr/omr/issues/7560).

It disables it in 2 areas:
1. Disable auto reassociation of dataAddrPtrs
```
BEFORE
n348n     astore  <internal pointer temp slot 7>[#427  Auto] [flags 0x40007 0x0 ]             [0x7009f90a5c80] bci=[-1,3,11] rc=0 vc=0 vn=- li=-1 udi=- nc=1
n347n       aloadi  <contiguousArrayDataAddrField>[#373  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [0x7009f90a5c30] bci=[-1,3,11] rc=1 vc=0 vn=- li=- udi=- nc=1 flg=0x8020
n346n         aload  <pinning array temp slot 3>[#423  Auto] [flags 0x10000007 0x0 ]          [0x7009f90a5be0] bci=[-1,3,11] rc=1 vc=0 vn=- li=- udi=- nc=0

n31n      istore  <auto slot 0>[#417  Auto] [flags 0x3 0x0 ]                                  [0x7009f9004ff0] bci=[-1,20,12] rc=0 vc=606 vn=- li=6 udi=4 nc=1
n30n        iadd                                                                              [0x7009f9004fa0] bci=[-1,19,12] rc=1 vc=606 vn=- li=- udi=- nc=2
n29n          iloadi  <array-shadow>[#224  Shadow] [flags 0x80000603 0x0 ] (cannotOverflow )  [0x7009f9004f50] bci=[-1,18,12] rc=1 vc=606 vn=- li=- udi=- nc=1 flg=0x1000
n28n            aladd (X>=0 internalPtr )                                                     [0x7009f9004f00] bci=[-1,18,12] rc=1 vc=606 vn=- li=- udi=- nc=2 flg=0x8100
n345n             aload  <internal pointer temp slot 7>[#427  Auto] [flags 0x40007 0x0 ]      [0x7009f90a5b90] bci=[-1,18,12] rc=1 vc=0 vn=- li=-1 udi=- nc=0
n27n              lload  <temp slot 6>[#426  Auto] [flags 0x4 0x0 ] (highWordZero X>=0 cannotOverflow )  [0x7009f9004eb0] bci=[-1,18,12] rc=2 vc=606 vn=- li=- udi=- nc=0 flg=0x5100
n16n          iload  <auto slot 0>[#417  Auto] [flags 0x3 0x0 ] (cannotOverflow )             [0x7009f9004b40] bci=[-1,10,12] rc=1 vc=606 vn=- li=- udi=11 nc=0 flg=0x1000


AFTER
n31n      istore  <auto slot 0>[#417  Auto] [flags 0x3 0x0 ]                                  [0x7c11e5a04ff0] bci=[-1,20,12] rc=0 vc=663 vn=- li=12 udi=7 nc=1
n30n        iadd                                                                              [0x7c11e5a04fa0] bci=[-1,19,12] rc=1 vc=663 vn=- li=- udi=- nc=2
n29n          iloadi  <array-shadow>[#224  Shadow] [flags 0x80000603 0x0 ] (cannotOverflow )  [0x7c11e5a04f50] bci=[-1,18,12] rc=1 vc=663 vn=- li=- udi=- nc=1 flg=0x1000
n28n            aladd (X>=0 internalPtr )                                                     [0x7c11e5a04f00] bci=[-1,18,12] rc=1 vc=663 vn=- li=- udi=- nc=2 flg=0x8100
n24n              aloadi  <contiguousArrayDataAddrField>[#373  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [0x7c11e5a04dc0] bci=[-1,18,12] rc=1 vc=661 vn=- li=- udi=- nc=1 flg=0x8000
n17n                aload  <temp slot 3>[#423  Auto] [flags 0x7 0x0 ] (X!=0 X>=0 )            [0x7c11e5a04b90] bci=[-1,11,12] rc=1 vc=661 vn=- li=- udi=18 nc=0 flg=0x104
n27n              lload  <temp slot 10>[#430  Auto] [flags 0x4 0x0 ] (X>=0 cannotOverflow )   [0x7c11e5a04eb0] bci=[-1,18,12] rc=2 vc=663 vn=- li=- udi=- nc=0 flg=0x1100
n16n          iload  <auto slot 0>[#417  Auto] [flags 0x3 0x0 ] (cannotOverflow )             [0x7c11e5a04b40] bci=[-1,10,12] rc=1 vc=663 vn=- li=- udi=20 nc=0 flg=0x1000
```

2. Disable hoisting invariant array address calculation that includes loading dataAddrPtr similar to
```
n691n     astore  <internal pointer temp slot 8>[#450  Auto] [flags 0x40007 0x0 ]             [0x7f2ea708c7b0] bci=[-1,5,35] rc=0 vc=0 vn=- li=-1 udi=- nc=1
n690n       aladd (internalPtr )                                                              [0x7f2ea708c760] bci=[-1,5,35] rc=1 vc=0 vn=- li=- udi=- nc=2 flg=0x8000
n689n         aloadi  <contiguousArrayDataAddrField>[#373  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [0x7f2ea708c710] bci=[-1,5,35] rc=1 vc=0 vn=- li=- udi=->
n688n           aload  <pinning array temp slot 6>[#448  Auto] [flags 0x10000007 0x0 ]        [0x7f2ea708c6c0] bci=[-1,5,35] rc=1 vc=0 vn=- li=- udi=- nc=0
n687n         lconst 4 (highWordZero X!=0 X>=0 )                                              [0x7f2ea708c670] bci=[-1,5,35] rc=1 vc=0 vn=- li=- udi=- nc=0 flg=0x4104
```
Keeping in note that hoisting loop induction variable related calculations is still enabled by hoisting the baseObj and calculation separately
```
n444n     astore  <temp slot 7>
n32n        aloadi  Loop.x [I[  // baseArray
n613n     lstore  <temp slot 11> // offset
n612n       ladd                                                                              [     0x3fcaeb8af00] bci=[-1,27,24] rc=1 vc=0 vn=- li=-1 udi=- nc=2
n610n         lmul                                                                            [     0x3fcaeb8ae60] bci=[-1,27,24] rc=1 vc=0 vn=- li=-1 udi=- nc=2
n608n           lload  <temp slot 10> // i
n609n           lconst 4 (highWordZero X!=0 X>=0 )                                            [     0x3fcaeb8ae10] bci=[-1,27,24] rc=1 vc=701 vn=- li=-1 udi=- nc=0 flg=0x4104
n611n         lconst 128 (highWordZero X!=0 X>=0 )                                            [     0x3fcaeb8aeb0] bci=[-1,27,24] rc=1 vc=0 vn=- li=-1 udi=- nc=0 flg=0x4104


n52n      BBStart <block_6> (freq 10000) (in loop 6)                                          [     0x3fcaeb80000] bci=[-1,29,24] rc=0 vc=703 vn=- li=- udi=- nc=0
n75n      istore  <auto slot 2>[#406  Auto] [flags 0x3 0x0 ]                                  [     0x3fcaeb80730] bci=[-1,48,25] rc=0 vc=703 vn=- li=8 udi=5 nc=1
n74n        iadd                                                                              [     0x3fcaeb806e0] bci=[-1,47,25] rc=1 vc=703 vn=- li=- udi=- nc=2
n73n          iloadi  <array-shadow>[#254  Shadow] [flags 0x80000603 0x0 ] (cannotOverflow )  [     0x3fcaeb80690] bci=[-1,46,25] rc=1 vc=703 vn=- li=- udi=- nc=1 flg=0x1000
n72n            aladd (X>=0 internalPtr )                                                     [     0x3fcaeb80640] bci=[-1,46,25] rc=1 vc=703 vn=- li=- udi=- nc=2 flg=0x8100
n68n              aloadi  <contiguousArrayDataAddrFieldSymbol>[#355  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [     0x3fcaeb80500] bci=[-1,46,25] rc=1 vc=703 vn=- li=- udi=- nc=1 flg=0x8000
n57n                aload  <temp slot 7>[#432  Auto] [flags 0x7 0x0 ] (X!=0 X>=0 )            [     0x3fcaeb80190] bci=[-1,38,25] rc=1 vc=703 vn=- li=- udi=12 nc=0 flg=0x104
n71n              lload  <temp slot 11>[#436  Auto] [flags 0x4 0x0 ] (highWordZero X>=0 cannotOverflow )  [     0x3fcaeb805f0] bci=[-1,46,25] rc=2 vc=703 vn=- li=- udi=- nc=0 flg=0x5100
n55n          iload  <auto slot 2>[#406  Auto] [flags 0x3 0x0 ] (cannotOverflow )             [     0x3fcaeb800f0] bci=[-1,36,25] rc=1 vc=703 vn=- li=- udi=14 nc=0 flg=0x1000
```