### PR TITLE
Fix omrsysinfo_get_memory_info for non-english locales on windows

### DIFF
--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -929,7 +929,9 @@ omrsysinfo_get_memory_info(struct OMRPortLibrary *portLibrary, struct J9MemoryIn
 		return OMRPORT_ERROR_SYSINFO_ERROR_READING_MEMORY_INFO;
 	}
 
-	status = PdhAddCounter(statsHandle,
+	// PdhAddCounter requires a localized counter path, and so fails on non-english locales.
+	// Replacing with PdhAddEnglishCounter should avoid the problem
+	status = PdhAddEnglishCounter(statsHandle,
 						   MEMORY_COMMIT_LIMIT_COUNTER_PATH,
 						   (DWORD_PTR)NULL,
 						   &memoryCommitLimitCounter);
@@ -940,7 +942,7 @@ omrsysinfo_get_memory_info(struct OMRPortLibrary *portLibrary, struct J9MemoryIn
 		return OMRPORT_ERROR_SYSINFO_ERROR_READING_MEMORY_INFO;
 	}
 
-	status = PdhAddCounter(statsHandle,
+	status = PdhAddEnglishCounter(statsHandle,
 						   MEMORY_COMMITTED_BYTES_COUNTER_PATH,
 						   (DWORD_PTR)NULL,
 						   &memoryCommittedBytesCounter);
@@ -951,7 +953,7 @@ omrsysinfo_get_memory_info(struct OMRPortLibrary *portLibrary, struct J9MemoryIn
 		return OMRPORT_ERROR_SYSINFO_ERROR_READING_MEMORY_INFO;
 	}
 
-	status = PdhAddCounter(statsHandle,
+	status = PdhAddEnglishCounter(statsHandle,
 						   MEMORY_CACHE_BYTES_COUNTER_PATH,
 						   (DWORD_PTR)NULL,
 						   &memoryCacheBytesCounter);


### PR DESCRIPTION
The windows implementation of omrsysinfo_get_memory_info used PdhAddCounter which requires the counter path string to be localized. Since we weren't doing so the function failed on non-english windows systems. Replacing the call with the language neutral PdhAddEnglishCounter fixes the problem.

I added some debug to check and print the error code.

Before the change:
```
omrsysinfo_get_memory_info: after GlobalMemoryStatusEx 4200
omrsysinfo_get_memory_info: after PdhOpenQuery 189500
omrsysinfo_get_memory_info: after PdhAddCounter 1 532003600
PdhAddCounter FAILED with c0000bb8
```

After the change:
```
omrsysinfo_get_memory_info: after GlobalMemoryStatusEx 5000
omrsysinfo_get_memory_info: after PdhOpenQuery 108600
omrsysinfo_get_memory_info: after PdhAddCounter 1 689300300
omrsysinfo_get_memory_info: after PdhAddCounter 2 309400
omrsysinfo_get_memory_info: after PdhAddCounter 3 161600
omrsysinfo_get_memory_info: after PdhCollectQueryData 201400
totalSwap 46477017088
```

Doc for PdhAddEnglishCounter: https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhaddenglishcountera