### PR TITLE
Revert "Merge pull request #7534"

### DIFF
--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1495,11 +1495,11 @@ public:
       _edoRecompSizeThreshold = 0;
       _edoRecompSizeThresholdInStartupMode = 0;
       _catchBlockCounterThreshold = 0;
-      _arraycopyRepMovsByteArrayThreshold = 0;
-      _arraycopyRepMovsCharArrayThreshold = 0;
-      _arraycopyRepMovsIntArrayThreshold = 0;
-      _arraycopyRepMovsLongArrayThreshold = 0;
-      _arraycopyRepMovsReferenceArrayThreshold = 0;
+      _arraycopyRepMovsByteArrayThreshold = 32;
+      _arraycopyRepMovsCharArrayThreshold = 32;
+      _arraycopyRepMovsIntArrayThreshold = 32;
+      _arraycopyRepMovsLongArrayThreshold = 32;
+      _arraycopyRepMovsReferenceArrayThreshold = 32;
 
       memset(_options, 0, sizeof(_options));
       memset(_disabledOptimizations, false, sizeof(_disabledOptimizations));

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -2743,7 +2743,7 @@ static bool enablePrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS(uint8_t elemen
 
    bool disableEnhancement = false;
 
-   threshold = 64;
+   threshold = 32;
 
    switch (elementSize)
       {
@@ -2752,10 +2752,8 @@ static bool enablePrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS(uint8_t elemen
          disableEnhancement = disable64BitPrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS
                               || cg->comp()->getOption(TR_Disable64BitPrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS);
 
-         threshold = cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F) ? 128 : 64;
-
          int32_t newThreshold = cg->comp()->getOptions()->getArraycopyRepMovsLongArrayThreshold();
-         if ((newThreshold == 32) || (newThreshold == 64) || (newThreshold == 128))
+         if ((threshold < newThreshold) && ((newThreshold == 64) || (newThreshold == 128)))
             {
             // If the CPU doesn't support AVX512, reduce the threshold to 64 bytes
             threshold = ((newThreshold == 128) && !cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F)) ? 64 : newThreshold;
@@ -2767,10 +2765,8 @@ static bool enablePrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS(uint8_t elemen
          disableEnhancement = disable32BitPrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS
                               || cg->comp()->getOption(TR_Disable32BitPrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS);
 
-         threshold = cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F) ? 128 : 64;
-
          int32_t newThreshold = cg->comp()->getOptions()->getArraycopyRepMovsIntArrayThreshold();
-         if ((newThreshold == 32) || (newThreshold == 64) || (newThreshold == 128))
+         if ((threshold < newThreshold) && ((newThreshold == 64) || (newThreshold == 128)))
             {
             // If the CPU doesn't support AVX512, reduce the threshold to 64 bytes
             threshold = ((newThreshold == 128) && !cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F)) ? 64 : newThreshold;
@@ -2785,7 +2781,7 @@ static bool enablePrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS(uint8_t elemen
          int32_t newThreshold = cg->comp()->getOptions()->getArraycopyRepMovsCharArrayThreshold();
 
          // Char array enhancement supports only 32 or 64 bytes
-         threshold = (newThreshold == 32) ? 32 : threshold;
+         threshold = (newThreshold == 64) ? 64 : threshold;
          }
          break;
       default: // 1 byte
@@ -2796,7 +2792,7 @@ static bool enablePrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS(uint8_t elemen
          int32_t newThreshold = cg->comp()->getOptions()->getArraycopyRepMovsByteArrayThreshold();
 
          // Byte array enhancement supports only 32 or 64 bytes
-         threshold = (newThreshold == 32) ? 32 : threshold;
+         threshold = (newThreshold == 64) ? 64 : threshold;
          }
          break;
       }


### PR DESCRIPTION
This reverts commit e934391bcc27c5db207431ec6601a5e9788feb7d, reversing changes made to 5ff6dd7c8ed2dae194ade8f31d276b538133ffb6.

This reverts PR #7534 and reduces the thresholds for arraycopy REP MOVS instructions back to 32 bytes.

This addresses the performance regression reported in the internal issue 482.