### PR TITLE
Add AOT dependency tracking verbose options

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -4990,7 +4990,9 @@ const char *OMR::Options::_verboseOptionNames[TR_NumVerboseOptions] =
    "CheckpointRestore",
    "CheckpointRestoreDetails",
    "RSSReport",
-   "RSSReportDetailed"
+   "RSSReportDetailed",
+   "dependencyTracking",
+   "dependencyTrackingDetails"
    };
 
 

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1074,6 +1074,8 @@ enum TR_VerboseFlags
    TR_VerboseCheckpointRestoreDetails,
    TR_VerboseRSSReport,
    TR_VerboseRSSReportDetailed,
+   TR_VerboseDependencyTracking,
+   TR_VerboseDependencyTrackingDetails,
    //If adding new options add an entry to _verboseOptionNames as well
    TR_NumVerboseOptions        // Must be the last one;
    };


### PR DESCRIPTION
These options are required for https://github.com/eclipse-openj9/openj9/pull/20712.