### PR TITLE
Fix how overflow property is set for arithmetic operations during ValuePropagation

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -146,13 +146,15 @@ static void checkForNonNegativeAndOverflowProperties(OMR::ValuePropagation *vp, 
 
          ///if ((node->getOpCode().isArithmetic() || node->getOpCode().isLoad()) &&
          ///      ((low > TR::getMinSigned<TR::Int32>()) || (high < TR::getMaxSigned<TR::Int32>())))
-         if ((node->getOpCode().isLoad() &&
-               ((low > TR::getMinSigned<TR::Int32>()) || (high < TR::getMaxSigned<TR::Int32>()))) ||
-               (node->getOpCode().isArithmetic() &&
-                (range->canOverflow() != TR_yes)))
+         if (node->getOpCode().isLoad() &&
+               ((low > TR::getMinSigned<TR::Int32>()) || (high < TR::getMaxSigned<TR::Int32>())))
             {
             node->setCannotOverflow(true);
             //dumpOptDetails(vp->comp(), "Node %p cannot overflow\n", node);
+            }
+         else if (node->getOpCode().isArithmetic())
+            {
+            node->setCannotOverflow(false);
             }
          }
       else if (constraint->asLongRange())

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -170,13 +170,15 @@ static void checkForNonNegativeAndOverflowProperties(OMR::ValuePropagation *vp, 
 
          ///if ((node->getOpCode().isArithmetic() || node->getOpCode().isLoad()) &&
          ///      ((low > TR::getMinSigned<TR::Int64>()) || (high < TR::getMaxSigned<TR::Int64>())))
-         if ((node->getOpCode().isLoad() &&
-                  ((low > TR::getMinSigned<TR::Int64>()) || (high < TR::getMaxSigned<TR::Int64>()))) ||
-               (node->getOpCode().isArithmetic() &&
-                (range->canOverflow() != TR_yes)))
+         if (node->getOpCode().isLoad() &&
+                  ((low > TR::getMinSigned<TR::Int64>()) || (high < TR::getMaxSigned<TR::Int64>())))
             {
             node->setCannotOverflow(true);
             //dumpOptDetails(vp->comp(), "Node %p cannot overflow\n", node);
+            }
+         else if(node->getOpCode().isArithmetic())
+            {
+            node->setCannotOverflow(false);
             }
          }
       else if (constraint->asShortRange())

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -104,7 +104,6 @@ static void checkForNonNegativeAndOverflowProperties(OMR::ValuePropagation *vp, 
    if (node->getOpCode().isLoad())
       {
       node->setCannotOverflow(true);
-      //dumpOptDetails(vp->comp(), "Load node %p cannot overflow\n", node);
       }
 
    if (constraint)
@@ -144,13 +143,10 @@ static void checkForNonNegativeAndOverflowProperties(OMR::ValuePropagation *vp, 
          if (high <= 0)
             node->setIsNonPositive(true);
 
-         ///if ((node->getOpCode().isArithmetic() || node->getOpCode().isLoad()) &&
-         ///      ((low > TR::getMinSigned<TR::Int32>()) || (high < TR::getMaxSigned<TR::Int32>())))
          if (node->getOpCode().isLoad() &&
                ((low > TR::getMinSigned<TR::Int32>()) || (high < TR::getMaxSigned<TR::Int32>())))
             {
             node->setCannotOverflow(true);
-            //dumpOptDetails(vp->comp(), "Node %p cannot overflow\n", node);
             }
          else if (node->getOpCode().isArithmetic())
             {
@@ -168,13 +164,10 @@ static void checkForNonNegativeAndOverflowProperties(OMR::ValuePropagation *vp, 
          if (high <= 0)
             node->setIsNonPositive(true);
 
-         ///if ((node->getOpCode().isArithmetic() || node->getOpCode().isLoad()) &&
-         ///      ((low > TR::getMinSigned<TR::Int64>()) || (high < TR::getMaxSigned<TR::Int64>())))
          if (node->getOpCode().isLoad() &&
                   ((low > TR::getMinSigned<TR::Int64>()) || (high < TR::getMaxSigned<TR::Int64>())))
             {
             node->setCannotOverflow(true);
-            //dumpOptDetails(vp->comp(), "Node %p cannot overflow\n", node);
             }
          else if(node->getOpCode().isArithmetic())
             {

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -193,11 +193,14 @@ static void checkForNonNegativeAndOverflowProperties(OMR::ValuePropagation *vp, 
          if (high <= 0)
              node->setIsNonPositive(true);
 
-         if ((node->getOpCode().isLoad() && ((low > TR::getMinSigned<TR::Int16>()) || (high < TR::getMaxSigned<TR::Int16>()))) ||
-             (node->getOpCode().isArithmetic() && (range->canOverflow() != TR_yes)))
+         if ((node->getOpCode().isLoad() && ((low > TR::getMinSigned<TR::Int16>()) || (high < TR::getMaxSigned<TR::Int16>()))))
               {
               node->setCannotOverflow(true);
               }
+         else if (node->getOpCode().isArithmetic())
+            {
+            node->setCannotOverflow(false);
+            }
 
          }
       }


### PR DESCRIPTION
In `checkForNonNegativeAndOverflowProperties`, an arithmetic operation node with a constraint that's a range rather than a constant constraint means that one or both the operands are not known. Therefore, it is not possible to determine that an arithmetic operation would not result in an overflow. While the result of the operation would be within the range, it may be achieved through intentionally causing an overflow.

Issue: eclipse-openj9/openj9#19139