### PR TITLE
Check if an array class can be trusted as a fixed class

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -7247,6 +7247,16 @@ bool OMR::ValuePropagation::isUnreliableSignatureType(
    return false;
    }
 
+bool OMR::ValuePropagation::canArrayClassBeTrustedAsFixedClass(TR_OpaqueClassBlock *arrayClass, TR_OpaqueClassBlock *componentClass)
+   {
+   return true;
+   }
+
+bool OMR::ValuePropagation::canClassBeTrustedAsFixedClass(TR::SymbolReference *symRef, TR_OpaqueClassBlock *classObject)
+   {
+   return true;
+   }
+
 void OMR::ValuePropagation::doDelayedTransformations()
    {
    ListIterator<TR_TreeTopNodePair> treesIt1(&_scalarizedArrayCopies);

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -662,6 +662,25 @@ class ValuePropagation : public TR::Optimization
    virtual bool isUnreliableSignatureType(
       TR_OpaqueClassBlock *klass, TR_OpaqueClassBlock *&erased);
 
+   /**
+    * \brief Determine whether an \p arrayClass with the \p componentClass can be trusted as a fixed class
+    *
+    * \param arrayClass The array class.
+    * \param componentClass The component class of the array.
+    *
+    * \return true if an array with the component class can be trusted as a fixed class, and false otherwise.
+    */
+   virtual bool canArrayClassBeTrustedAsFixedClass(TR_OpaqueClassBlock *arrayClass, TR_OpaqueClassBlock *componentClass);
+   /**
+    * \brief Determine whether a class retrieved from signature can be trusted as a fixed class
+    *
+    * \param symRef The symbol reference of the class object.
+    * \param classObject The class object to be checked.
+    *
+    * \return true if a class can be trusted as a fixed class, and false otherwise.
+    */
+   virtual bool canClassBeTrustedAsFixedClass(TR::SymbolReference *symRef, TR_OpaqueClassBlock *classObject);
+
    struct ObjCloneInfo {
       TR_ALLOC(TR_Memory::ValuePropagation)
 

--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -1286,7 +1286,7 @@ TR::VPResolvedClass *TR::VPResolvedClass::create(OMR::ValuePropagation *vp, TR_O
          // An array class is fixed if the base class for the array is final
          //
          TR_OpaqueClassBlock * baseClass = vp->fe()->getLeafComponentClassFromArrayClass(klass);
-         if (baseClass && TR::Compiler->cls.isClassFinal(vp->comp(), baseClass))
+         if (baseClass && TR::Compiler->cls.isClassFinal(vp->comp(), baseClass) && vp->canArrayClassBeTrustedAsFixedClass(klass, baseClass))
             return TR::VPFixedClass::create(vp, klass);
          }
       else
@@ -6078,7 +6078,7 @@ void TR::VPResolvedClass::print(TR::Compilation *comp, TR::FILE *outFile)
       len = static_cast<int32_t>(strlen(sig));
       }
 
-   trfprintf(outFile, "class %.*s", len, sig);
+   trfprintf(outFile, "class 0x%p %.*s", _class, len, sig);
    if (_typeHintClass)
       {
       trfprintf(outFile, " (hint 0x%p", _typeHintClass);

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -1938,6 +1938,7 @@ TR::Node *constrainAload(OMR::ValuePropagation *vp, TR::Node *node)
                   {
                   if (classBlock != jlClass)
                      {
+                     isFixed = isFixed ? vp->canClassBeTrustedAsFixedClass(NULL, classBlock) : isFixed;
                      constraint = TR::VPClassType::create(vp, sig, len, owningMethod, isFixed, classBlock);
                      if (*sig == '[' || sig[0] == 'L')
                         {
@@ -11207,9 +11208,11 @@ static void constrainClassObjectLoadaddr(
       "constrainClassObjectLoadaddr: n%un loadaddr is not for a class\n",
       node->getGlobalIndex());
 
+   bool isFixed = vp->canClassBeTrustedAsFixedClass(symRef, NULL);
+
    TR::VPConstraint *constraint = TR::VPClass::create(
       vp,
-      TR::VPClassType::create(vp, symRef, true),
+      TR::VPClassType::create(vp, symRef, isFixed),
       TR::VPNonNullObject::create(vp),
       NULL,
       NULL,


### PR DESCRIPTION
There are cases where two different array classes could share the same signature in downstream projects. In such cases, the class retrieved from signature cannot be trusted as a fixed class.

Related: eclipse-openj9/openj9#20522