### PR TITLE
UpdateKnownObjectTableAtServer also Updates isArrayWithConstantElements

### DIFF
--- a/compiler/env/OMRKnownObjectTable.cpp
+++ b/compiler/env/OMRKnownObjectTable.cpp
@@ -164,7 +164,7 @@ OMR::KnownObjectTable::getPointer(Index index)
    }
 
 void
-OMR::KnownObjectTable::updateKnownObjectTableAtServer(Index index, uintptr_t *objectReferenceLocation)
+OMR::KnownObjectTable::updateKnownObjectTableAtServer(Index index, uintptr_t *objectReferenceLocation, bool isArrayWithConstantElements)
    {
    TR_UNIMPLEMENTED();
    }

--- a/compiler/env/OMRKnownObjectTable.hpp
+++ b/compiler/env/OMRKnownObjectTable.hpp
@@ -97,7 +97,7 @@ public:
 
    uintptr_t getPointer(Index index);
 
-   void updateKnownObjectTableAtServer(Index index, uintptr_t *objectReferenceLocation);
+   void updateKnownObjectTableAtServer(Index index, uintptr_t *objectReferenceLocation, bool isArrayWithConstantElements = false);
 
 protected:
    void addArrayWithConstantElements(Index index);


### PR DESCRIPTION
Add a parameter to UpdateKnownObjectTableAtServer to update the _arrayWithConstantElements vector if necessary.

See also https://github.com/eclipse-openj9/openj9/pull/20767