### PR TITLE
Remove updateKnownObjectTableAtServer in OMR::KnownObjectTable

### DIFF
--- a/compiler/env/OMRKnownObjectTable.cpp
+++ b/compiler/env/OMRKnownObjectTable.cpp
@@ -162,9 +162,3 @@ OMR::KnownObjectTable::getPointer(Index index)
    else
       return *self()->getPointerLocation(index);
    }
-
-void
-OMR::KnownObjectTable::updateKnownObjectTableAtServer(Index index, uintptr_t *objectReferenceLocation)
-   {
-   TR_UNIMPLEMENTED();
-   }

--- a/compiler/env/OMRKnownObjectTable.hpp
+++ b/compiler/env/OMRKnownObjectTable.hpp
@@ -97,8 +97,6 @@ public:
 
    uintptr_t getPointer(Index index);
 
-   void updateKnownObjectTableAtServer(Index index, uintptr_t *objectReferenceLocation);
-
 protected:
    void addArrayWithConstantElements(Index index);
 


### PR DESCRIPTION
Remove updateKnownObjectTableAtServer in the OMR since it is only used in OpenJ9.