### PR TITLE
Remember whether dltOptLevel= is specified in a subset

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -3723,11 +3723,23 @@ OMR::Options::processOption(
          }
       }
    else
+      {
       processingMethod = opt->fcn;
+      }
 
    // Process this entry
    //
-   return processingMethod(option + opt->length, base, opt);
+   const char *retVal = processingMethod(option + opt->length, base, opt);
+
+   // Check to see whether the dltOptLevel option is specified in a subset
+   // and remember that information in the global JIT cmdLineOptions
+   if (optionSet)
+      {
+      if (optionSet->getOptions()->getDLTOptLevel() != -1)
+         _jitCmdLineOptions->setAnOptionSetContainsADltOptLevel(true);
+      }
+
+   return retVal;
    }
 
 

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1421,6 +1421,7 @@ public:
       _osVersionString = NULL;
       _allowRecompilation = false;
       _anOptionSetContainsACountValue = false;
+      _anOptionSetContainsADltOptLevel = false;
       _numInterfaceCallCacheSlots = 0;
       _numInterfaceCallStaticSlots = 0;
       _storeSinkingLastOpt = 0;
@@ -1434,9 +1435,9 @@ public:
       _maxStaticPICSlots = 0;
       _hotMaxStaticPICSlots = 0;
       _newAotrtDebugLevel = 0;
-      _disableDLTBytecodeIndex = 0;
-      _enableDLTBytecodeIndex = 0;
-      _dltOptLevel = 0;
+      _disableDLTBytecodeIndex = -1;
+      _enableDLTBytecodeIndex = -1;
+      _dltOptLevel = -1;
       _profilingCount = 0;
       _profilingFrequency = 0;
       _counterBucketGranularity = 0;
@@ -1665,6 +1666,9 @@ public:
 
    bool      anOptionSetContainsACountValue()          {return _anOptionSetContainsACountValue; }
    void      setAnOptionSetContainsACountValue(bool b) { _anOptionSetContainsACountValue = b; }
+
+   bool      anOptionSetContainsADltOptLevel()          {return _anOptionSetContainsADltOptLevel; }
+   void      setAnOptionSetContainsADltOptLevel(bool b) { _anOptionSetContainsADltOptLevel = b; }
    int32_t   getEnableDLTBytecodeIndex()       {return _enableDLTBytecodeIndex;}
    int32_t   getDisableDLTBytecodeIndex()      {return _disableDLTBytecodeIndex;}
    int32_t   getDLTOptLevel()                  {return _dltOptLevel;}
@@ -2440,6 +2444,7 @@ protected:
    char *                      _osVersionString;
    bool                        _allowRecompilation;
    bool                        _anOptionSetContainsACountValue;
+   bool                        _anOptionSetContainsADltOptLevel;
    int32_t                     _numInterfaceCallCacheSlots;
    int32_t                     _numInterfaceCallStaticSlots;
    int32_t                     _storeSinkingLastOpt;


### PR DESCRIPTION
The command line option -Xjit:dltOptLevel=... existed, but it was inspected in the OpenJ9 downstream project only when the `TR_DebugDLT` env var was set. The reason is that we have to account for the possibility of specifying the option in a subset and retrieving options from subsets is relatively expensive and not something that we may want to do too often.
This commit remembers whether `dltOptLevel=` is specified in any subset by setting a flag in the JIT command line options. Then, in OpenJ9 we can first check if this flag is set and only then proceed to find the correct subset for the method in question. This should eliminate the overhead when -Xjit:dltOptLevel= is not specified in a subset, which is the common case.