### PR TITLE
Assert at the end of the Register Allocation Phase that the numbers of Start and End internal control flow labels were equal

### DIFF
--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -391,6 +391,8 @@ OMR::CodeGenPhase::performRegisterAssigningPhase(TR::CodeGenerator * cg, TR::Cod
       cg->jettisonAllSpills(); // Spill temps used before now may lead to conflicts if also used by register assignment
       cg->doRegisterAssignment(kindsToAssign);
 
+      TR_ASSERT_FATAL(cg->internalControlFlowNestingDepth() == 0, "The numbers of labels marked as Start or End of internal control flow were unequal:  internalControlFlowNestingDepth == %d\n", cg->internalControlFlowNestingDepth());
+
       if (comp->compilationShouldBeInterrupted(AFTER_REGISTER_ASSIGNMENT_CONTEXT))
          {
          comp->failCompilation<TR::CompilationInterrupted>("interrupted after RA");


### PR DESCRIPTION
If the number of Start internal control flow labels does not equal the number of End internal control flow labels, the result might be subtle intermittent problems related to register allocation.

This change adds an assertion that, at the completion of the Register Allocation Phase, the register allocator must not indicate that it's still nested within a region of internal control flow nor popped out of too many regions of internal control flow.