### PR TITLE
Consider the compileMethod() API in replenishInvocationCount() Assertion

### DIFF
--- a/compiler/control/OptimizationPlan.hpp
+++ b/compiler/control/OptimizationPlan.hpp
@@ -168,6 +168,9 @@ class TR_OptimizationPlan
    bool getDisableEDO() const { return _flags.testAny(DisableEDO); }
    void setDisableEDO(bool b) { _flags.set(DisableEDO, b); }
 
+   bool getIsCompileMethodAPI() const { return _flags.testAny(IsCompileMethodAPI); }
+   void setIsCompileMethodAPI(bool b) { _flags.set(IsCompileMethodAPI, b); }
+
    // --------------------------------------------------------------------------
    // GPU
    //
@@ -224,6 +227,7 @@ class TR_OptimizationPlan
       DowngradedDueToSamplingJProfiling=0x00400000, // Compilation was downgraded to cold just because we wanted to do JProfiling
       InducedByDLT            = 0x00800000, // Compilation that follows a DLT compilation
       DisableEDO              = 0x01000000, // Do not insert EDO profiling trees for this compilation
+      IsCompileMethodAPI      = 0x02000000, // plan created by TR_MethodEvent::CompileMethodAPI
    };
    private:
    TR_OptimizationPlan  *_next;       // to link events in the pool


### PR DESCRIPTION
Add a flag in the optimization plan for compilations triggered by the compileMethod API, which can have the invocation count be any positive integer; replenishInvocationCount will not raise the assertion failure for unexpected count value.

Based on https://github.com/eclipse-openj9/openj9/issues/15472

Depends on https://github.com/eclipse-openj9/openj9/pull/20876