### PR TITLE
Fix compactNullCheck to not replace PassThrough with dataAddrPtr load

### DIFF
--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -2209,6 +2209,10 @@ bool TR_CompactNullChecks::replacePassThroughIfPossible(TR::Node *currentNode, T
          if (opCode.isCallIndirect() && opCode.hasSymbolReference() && currentNode->getSymbol()->castToMethodSymbol()->isComputed())
             canCompact = false;
 
+         // Replacing PassThrough with a dataAddrPtr load changes the target of the NULLCHK from obj to dataAddr
+         if (currentNode->isDataAddrPointer()) 
+            canCompact = false;
+
          if (canCompact &&
             performTransformation(comp(), "%sCompact null check %p with node %p in next tree\n", optDetailString(), prevNode, currentNode))
             {


### PR DESCRIPTION
The `compactNullCheck` optimization allows replacing a PassThrough node with the `dataAddrPtr` load, changing the target of the `NullCheck` performed [1]. This PR fixes that by guarding against replacing PassThrough with `dataAddrPtr` loads in `replacePassThroughIfPossible()`. 


[1]
Current `compactNullCheck` transformation before the fix:
```
Before compactNullCheck
n228n     NULLCHK on n230n [#32]                                                              [     0x3fe17083700] bci=[-1,30,3753] rc=0 vc=603 vn=- li=- udi=- nc=1
n229n       PassThrough                                                                       [     0x3fe17083750] bci=[-1,30,3753] rc=1 vc=603 vn=- li=1 udi=- nc=1
n230n         aload  original<parm 0 [Ljava/lang/Object;>[#399  Parm] [flags 0x40000107 0x0 ] (X>=0 )  [     0x3fe170837a0] bci=[-1,29,3753] rc=6 vc=603 vn=- li=1 udi=16 nc=0 flg=0x100
...
        <some arraycopy>
n257n         aloadi  <contiguousArrayDataAddrField>[#355  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [     0x3fe17084010] bci=[-1,25,3753] rc=1 vc=603 vn=- li=1 udi=- nc=1 flg=0x8000
n230n           ==>aload

 
After compactNullCheck
n228n     NULLCHK on n230n [#32]                                                              [     0x3fe17083700] bci=[-1,30,3753] rc=0 vc=605 vn=- li=-1 udi=- nc=1
n257n       aloadi  <contiguousArrayDataAddrField>[#355  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [     0x3fe17084010] bci=[-1,25,3753] rc=2 vc=605 vn=- li=-1 udi=- nc=1 flg=0x8000
n230n         aload  original<parm 0 [Ljava/lang/Object;>[#399  Parm] [flags 0x40000107 0x0 ] (X>=0 )  [     0x3fe170837a0] bci=[-1,29,3753] rc=5 vc=605 vn=- li=-4 udi=16 nc=0 flg=0x100
```