### PR TITLE
Tune more inlining parameters without changing the source

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -376,6 +376,11 @@ TR_InlinerBase::setInlineThresholds(TR::ResolvedMethodSymbol *callerSymbol)
          _nodeCountThreshold *= 2;
       }
 
+   static const char *g = feGetEnv("TR_MaxInliningCallSites");
+   if (g)
+      _maxInliningCallSites = atoi(g);
+
+
    //call random functions to allow randomness to change limits
    if (comp()->getOption(TR_Randomize))
       {


### PR DESCRIPTION
Several inlining parameters can be tuned via command line options or env vars. Recently, I needed to tune some inlining parameters that could not be controlled without changing the source. This PR fixes the cases that I observed by adding env vars.