### PR TITLE
Fix several issues in omrfiletext.c

### DIFF
--- a/port/common/omrfiletext.c
+++ b/port/common/omrfiletext.c
@@ -44,20 +44,20 @@
 char *
 omrfile_read_text(struct OMRPortLibrary *portLibrary, intptr_t fd, char *buf, intptr_t nbytes)
 {
-	char temp[64];
-	intptr_t count, i, result;
 	char *cursor = buf;
 
 	if (nbytes <= 0) {
-		return 0;
+		return NULL;
 	}
 
 	/* discount 1 for the trailing NUL */
 	nbytes -= 1;
 
-	while (nbytes) {
-		count = sizeof(temp) > nbytes ? nbytes : sizeof(temp);
-		count = portLibrary->file_read(portLibrary, fd, temp, count);
+	while (nbytes > 0) {
+		char temp[64];
+		intptr_t size = sizeof(temp) > nbytes ? nbytes : sizeof(temp);
+		intptr_t count = portLibrary->file_read(portLibrary, fd, temp, size);
+		intptr_t i = 0;
 
 		/* ignore translation for now */
 		if (count < 0) {
@@ -120,18 +120,20 @@ omrfile_write_text(struct OMRPortLibrary *portLibrary, intptr_t fd, const char *
 int32_t
 omrfile_get_text_encoding(struct OMRPortLibrary *portLibrary, char *charsetName, uintptr_t nbytes)
 {
-	if (buf == NULL) {
+	if (NULL == buf) {
 		return -1;
-	}
+	} else {
+		uintptr_t length = strlen("CP850");
 
-	/* CP850 unless overridden because:
-	 * 1. Anything in a valid Java identifier in CP437, ASCII, and ANSI X3.4-1986 maps directly into CP850
-	 * 2. *most* CP1252 characters in Java identifiers have the same code point in CP850
-	 * 3. If the current platform doesn't provide an override, code pages really aren't Problem #1.
-	 */
-	if (nbytes <= strlen("CP850")) {
-		return (int32_t)(strlen("CP850") + 1);
+		/* CP850 unless overridden because:
+		 * 1. Anything in a valid Java identifier in CP437, ASCII, and ANSI X3.4-1986 maps directly into CP850.
+		 * 2. *Most* CP1252 characters in Java identifiers have the same code point in CP850.
+		 * 3. If the current platform doesn't provide an override, code pages really aren't Problem #1.
+		 */
+		if (nbytes <= length) {
+			return (int32_t)(length + 1);
+		}
+		strcpy(charsetName, "CP850");
 	}
-	strcpy(charsetName, "CP850");
 	return 0;
 }

--- a/port/win32/omrfiletext.c
+++ b/port/win32/omrfiletext.c
@@ -34,8 +34,6 @@
 char *
 omrfile_read_text(struct OMRPortLibrary *portLibrary, intptr_t fd, char *buf, intptr_t nbytes)
 {
-	char temp[64];
-	intptr_t count, i;
 	char *cursor = buf;
 
 	if (nbytes <= 0) {
@@ -45,9 +43,11 @@ omrfile_read_text(struct OMRPortLibrary *portLibrary, intptr_t fd, char *buf, in
 	/* discount 1 for the trailing NUL */
 	nbytes -= 1;
 
-	while (nbytes) {
-		count = sizeof(temp) > nbytes ? nbytes : sizeof(temp);
-		count = portLibrary->file_read(portLibrary, fd, temp, count);
+	while (nbytes > 0) {
+		char temp[64];
+		intptr_t size = sizeof(temp) > nbytes ? nbytes : sizeof(temp);
+		intptr_t count = portLibrary->file_read(portLibrary, fd, temp, size);
+		intptr_t i = 0;
 
 		/* ignore translation for now */
 		if (count < 0) {
@@ -61,33 +61,31 @@ omrfile_read_text(struct OMRPortLibrary *portLibrary, intptr_t fd, char *buf, in
 		for (i = 0; i < count; i++) {
 			char c = temp[i];
 
-			if (c == '\r') { /* EOL */
+			if ('\r' == c) { /* EOL */
 				/* is this a bare CR, or part of a CRLF pair? */
 				portLibrary->file_seek(portLibrary, fd, i - count + 1, EsSeekCur);
 				count = portLibrary->file_read(portLibrary, fd, temp, 1);
-				if (count && temp[0] == '\n') {
+				if ((count > 0) && ('\n' == temp[0])) {
 					/* matched CRLF pair */
-					*cursor++ = '\n';
+					c = '\n';
 				} else {
 					/* this was a bare CR -- back up */
-					*cursor++ = '\r';
 					portLibrary->file_seek(portLibrary, fd, -1, EsSeekCur);
 				}
-				*cursor = '\0';
-				return buf;
-			} else if (c == '\n') { /* this can onle be a bare LF */
+				*cursor++ = c;
+				goto done;
+			} else if ('\n' == c) { /* this can only be a bare LF */
 				portLibrary->file_seek(portLibrary, fd, i - count + 1, EsSeekCur);
 				*cursor++ = '\n';
-				*cursor = '\0';
-				return buf;
+				goto done;
 			} else {
 				*cursor++ = c;
 			}
-
 		}
 		nbytes -= count;
 	}
 
+done:
 	*cursor = '\0';
 	return buf;
 }
@@ -96,50 +94,51 @@ omrfile_read_text(struct OMRPortLibrary *portLibrary, intptr_t fd, char *buf, in
 intptr_t
 omrfile_write_text(struct OMRPortLibrary *portLibrary, intptr_t fd, const char *buf, intptr_t nbytes)
 {
-	intptr_t result;
-	intptr_t i;
-	int newlines = 0, highchars = 0;
+	intptr_t result = 0;
+	intptr_t i = 0;
+	int newlines = 0;
+	int highchars = 0;
 	char stackBuf[512];
 	char *newBuf = stackBuf;
-	intptr_t newLen;
+	intptr_t newLen = 0;
 
 	/* scan the buffer for any characters which need to be converted */
 	for (i = 0; i < nbytes; i++) {
-		if (buf[i] == '\n') {
+		if ('\n' == buf[i]) {
 			newlines += 1;
-		} else if ((uint8_t)buf[i] & 0x80) {
+		} else if (OMR_ARE_ANY_BITS_SET((uint8_t)buf[i], 0x80)) {
 			highchars += 1;
 		}
 	}
 
 	/* if there are any non-ASCII chars, convert to Unicode and then to the local code page */
-	if (highchars) {
+	if (0 != highchars) {
 		uint16_t wStackBuf[512];
 		uint16_t *wBuf = wStackBuf;
 		newLen = (nbytes + newlines) * 2;
 		if (newLen > sizeof(wStackBuf)) {
 			wBuf = portLibrary->mem_allocate_memory(portLibrary, newLen, OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
 		}
-		if (wBuf) {
-			uint8_t *in = (uint8_t *)buf;
-			uint8_t *end = in + nbytes;
+		if (NULL != wBuf) {
+			const uint8_t *in = (const uint8_t *)buf;
+			const uint8_t *end = in + nbytes;
 			uint16_t *out = wBuf;
 
 			while (in < end) {
-				if (*in == '\n') {
+				if ('\n' == *in) {
 					*out++ = (uint16_t)'\r';
 					*out++ = (uint16_t)'\n';
 					in += 1;
 				} else {
 					uint32_t numberU8Consumed = decodeUTF8CharN(in, out++, end - in);
-					if (numberU8Consumed == 0) {
+					if (0 == numberU8Consumed) {
 						break;
 					}
 					in += numberU8Consumed;
 				}
 			}
 			/* in will be NULL if an error occurred */
-			if (in) {
+			if (NULL != in) {
 				UINT codePage = GetConsoleOutputCP();
 				intptr_t wLen = out - wBuf;
 				intptr_t mbLen = WideCharToMultiByte(codePage, 0, wBuf, (int)wLen, NULL, 0, NULL, NULL);
@@ -148,28 +147,28 @@ omrfile_write_text(struct OMRPortLibrary *portLibrary, intptr_t fd, const char *
 						newBuf = portLibrary->mem_allocate_memory(portLibrary, mbLen, OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
 						/* if we couldn't allocate the buffer, just output the data the way it was */
 					}
-					if (newBuf) {
+					if (NULL != newBuf) {
 						WideCharToMultiByte(codePage, 0, wBuf, (int)wLen, newBuf, (int)mbLen, NULL, NULL);
 						buf = newBuf;
 						nbytes = mbLen;
 					}
 				}
 			}
-			if (wBuf != wStackBuf) {
+			if (wStackBuf != wBuf) {
 				portLibrary->mem_free_memory(portLibrary, wBuf);
 			}
 		}
-	} else if (newlines) {
+	} else if (0 != newlines) {
 		/* change any LFs to CRLFs */
 		newLen = nbytes + newlines;
 		if (newLen > sizeof(stackBuf)) {
 			newBuf = portLibrary->mem_allocate_memory(portLibrary, newLen, OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
 			/* if we couldn't allocate the buffer, just output the data the way it was */
 		}
-		if (newBuf) {
+		if (NULL != newBuf) {
 			char *cursor = newBuf;
 			for (i = 0; i < nbytes; i++) {
-				if (buf[i] == '\n') {
+				if ('\n' == buf[i]) {
 					*cursor++ = '\r';
 				}
 				*cursor++ = buf[i];
@@ -181,7 +180,7 @@ omrfile_write_text(struct OMRPortLibrary *portLibrary, intptr_t fd, const char *
 
 	result = portLibrary->file_write(portLibrary, fd, (void *)buf, nbytes);
 
-	if (newBuf != stackBuf && newBuf != NULL) {
+	if ((stackBuf != newBuf) && (NULL != newBuf)) {
 		portLibrary->mem_free_memory(portLibrary, newBuf);
 	}
 
@@ -191,32 +190,30 @@ omrfile_write_text(struct OMRPortLibrary *portLibrary, intptr_t fd, const char *
 int32_t
 omrfile_get_text_encoding(struct OMRPortLibrary *portLibrary, char *charsetName, uintptr_t nbytes)
 {
+	UINT outputCP = 0;
 	CPINFOEX cpix;
-	BOOL rc;
-	char *c_ptr;
 
-	if (charsetName == NULL) {
+	if (NULL == charsetName) {
 		return -1;
 	}
-
-	rc = GetCPInfoEx(GetConsoleOutputCP(), 0, &cpix);
-	if (rc == FALSE) {
+	outputCP = GetConsoleOutputCP();
+	if ((0 == outputCP) || !GetCPInfoEx(outputCP, 0, &cpix)) {
 		return -2;
-	}
+	} else {
+		uintptr_t length = strlen(cpix.CodePageName);
 
-	/* In case of very detailed text from OS truncate the string at first whitespace. */
-	c_ptr = cpix.CodePageName;
-	while (*c_ptr++ != '\0') {
-		if (*c_ptr == ' ') {
-			*c_ptr = '\0';
-			break;
+		/* In case of very detailed text from OS, truncate at the first space. */
+		char *c_ptr = strchr(cpix.CodePageName, ' ');
+		if (NULL != c_ptr) {
+			length = c_ptr - cpix.CodePageName;
 		}
-	}
 
-	if (nbytes <= strlen(cpix.CodePageName)) {
-		return (int32_t)(strlen(cpix.CodePageName) + 1);
-	}
+		if (nbytes <= length) {
+			return (int32_t)(intptr_t)(length + 1);
+		}
 
-	strcpy(charsetName, cpix.CodePageName);
+		memcpy(charsetName, cpix.CodePageName, length);
+		charsetName[length] = '\0';
+	}
 	return 0;
 }


### PR DESCRIPTION
* avoid use of `free`'d memory
* avoid unnecessary (repeated) calls to `strlen()`
* update for coding standard