### PR TITLE
Propagate doNotProfile state when cloning nodes

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -273,18 +273,7 @@ OMR::Node::Node(TR::Node * from, uint16_t numChildren)
    if(comp->getDebug())
       comp->getDebug()->newNode(self());
 
-   TR_IlGenerator * ilGen = comp->getCurrentIlGenerator();
-   if (ilGen)
-      {
-      _byteCodeInfo.setDoNotProfile(0);
-      }
-   else
-      {
-      _byteCodeInfo.setDoNotProfile(1);
-      }
-
-   if (from->getOpCode().isBranch() || from->getOpCode().isSwitch())
-      _byteCodeInfo.setDoNotProfile(1);
+   self()->getByteCodeInfo().setDoNotProfile(from->getByteCodeInfo().doNotProfile());
 
    if (from->getOpCode().isStoreReg() || from->getOpCode().isLoadReg())
       {


### PR DESCRIPTION
BlockSplitter uses BlockCloner to split blocks along hot paths, with the duplicated blocks forming the new hot path (that can then be straightened) and the original blocks being pushed out to cold paths.

BlockCloner clones nodes using one of TR::Node's copy constructors, which sets the doNotProfile on the clone's bytecode info. The copy constructors are used all over the place, not just to create copies of the original node but to also create new nodes. Setting the doNotProfile flag avoids inadvertantly proflining semantically unrelated nodes that happen to share the same bytecode, thereby polluting the profiling data.

Because of the above, when BlockSplitter runs, nothing on the hot path will be profiled, and in cases where the cold paths are never executed, we will completely miss out on profiling information. Because BlockSplitter and BlockCloner are duplicating nodes they don't need to worry about polluting the profiling data and should propagate the doNotProfile flag state to the nodes they duplicate.