### PR TITLE
Assorted small fixes

### DIFF
--- a/compiler/il/ILOpCodesEnum.hpp
+++ b/compiler/il/ILOpCodesEnum.hpp
@@ -22,7 +22,7 @@
 #ifndef ILOPCODES_ENUM_INCL
 #define ILOPCODES_ENUM_INCL
 
-#include "compiler/il/OMRILOpCodesEnum.hpp"
+#include "il/OMRILOpCodesEnum.hpp"
 
    FirstTROp = FirstOMROp,
    LastTROp = LastScalarOMROp,

--- a/compiler/il/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/OMRResolvedMethodSymbol.cpp
@@ -1985,12 +1985,7 @@ OMR::ResolvedMethodSymbol::getAutoSymRefs(int32_t slot)
    {
    TR_Memory * m = self()->comp()->trMemory();
    if (!_autoSymRefs)
-      {
-      if (self()->comp()->getJittedMethodSymbol() == self())
-         _autoSymRefs = new (m->trHeapMemory()) TR_Array<List<TR::SymbolReference> >(m, 100, true);
-      else
-         _autoSymRefs = new (m->trHeapMemory()) TR_Array<List<TR::SymbolReference> >(m, _resolvedMethod->numberOfParameterSlots() + _resolvedMethod->numberOfTemps() + 5, true);
-      }
+      _autoSymRefs = new (m->trHeapMemory()) TR_Array<List<TR::SymbolReference> >(m, _resolvedMethod->numberOfParameterSlots() + _resolvedMethod->numberOfTemps() + 5, true);
 
    (*_autoSymRefs)[slot].setRegion(m->heapMemoryRegion());
 

--- a/compiler/optimizer/OMRSimplifier.cpp
+++ b/compiler/optimizer/OMRSimplifier.cpp
@@ -158,6 +158,7 @@ OMR::Simplifier::Simplifier(TR::OptimizationManager *manager)
      _performLowerTreeNodePairs(getTypedAllocator<std::pair<TR::TreeTop*, TR::Node*>>(self()->allocator()))
    {
    _invalidateUseDefInfo      = false;
+   _invalidateValueNumberInfo = false;
    _alteredBlock = false;
    _blockRemoved = false;
 


### PR DESCRIPTION
Three small (1-3 lines each) fixes:
1) Initialize an uninitialized (but used) field in OMRSimplifier
2) Remove some dubious conditional code in OMRResolvedMethodSymbol that runs at the same time that a field it depends upon is not yet initialized
3) Correct what looks like an overly prescriptive extensible class #include