### PR TITLE
Change return type of TR_FrontEnd::getStringUTF8Length to int32_t

### DIFF
--- a/compiler/env/FrontEnd.cpp
+++ b/compiler/env/FrontEnd.cpp
@@ -283,15 +283,22 @@ TR_FrontEnd::getClassFromMethodBlock(TR_OpaqueMethodBlock *mb)
    return NULL;
    }
 
-intptr_t
+int32_t
 TR_FrontEnd::getStringUTF8Length(uintptr_t objectPointer)
    {
    TR_UNIMPLEMENTED();
    return -1;
    }
 
+uint64_t
+TR_FrontEnd::getStringUTF8UnabbreviatedLength(uintptr_t objectPointer)
+   {
+   TR_UNIMPLEMENTED();
+   return -1;
+   }
+
 char *
-TR_FrontEnd::getStringUTF8(uintptr_t objectPointer, char *buffer, intptr_t bufferSize)
+TR_FrontEnd::getStringUTF8(uintptr_t objectPointer, char *buffer, uintptr_t bufferSize)
    {
    TR_UNIMPLEMENTED();
    return NULL;

--- a/compiler/env/FrontEnd.hpp
+++ b/compiler/env/FrontEnd.hpp
@@ -199,8 +199,9 @@ public:
    virtual TR_OpaqueClassBlock * getLeafComponentClassFromArrayClass(TR_OpaqueClassBlock *arrayClass);
 
    // Null-terminated.  bufferSize >= 1+getStringUTF8Length(objectPointer).  Returns buffer just for convenience.
-   virtual char *getStringUTF8(uintptr_t objectPointer, char *buffer, intptr_t bufferSize);
-   virtual intptr_t getStringUTF8Length(uintptr_t objectPointer);
+   virtual char *getStringUTF8(uintptr_t objectPointer, char *buffer, uintptr_t bufferSize);
+   virtual int32_t getStringUTF8Length(uintptr_t objectPointer);
+   virtual uint64_t getStringUTF8UnabbreviatedLength(uintptr_t objectPointer);
 
    // --------------------------------------------------------------------------
    // Code cache


### PR DESCRIPTION
A `String` object that might consist of up to 2<sup>31</sup>-1 chars could require up to three times as many bytes as chars to be encoded in UTF-8.  The current return type of `getUTF8StringLength` - `intptr_t` - is unable to correctly represent all valid lengths in 32-bit mode.

This change makes the return type of the existing `TR_FrontEnd::getStringUTF8Length` method `int32_t`.  It must only be used in situations where it is known that the UTF-8 encoded length of the String will not exceed 2<sup>31</sup>-1 bytes.

This change also introduces a new `getUTF8StringUnabbreviatedLength` method whose return type of `uint64_t` is able to represent all possible UTF-8 encoded string lengths.