### PR TITLE
Remove depth and allConsts defaults from TR_CallSite constructor

### DIFF
--- a/compiler/optimizer/CallInfo.hpp
+++ b/compiler/optimizer/CallInfo.hpp
@@ -267,8 +267,8 @@ struct TR_CallTarget : public TR_Link<TR_CallTarget>
                   bool isInterface,  \
                   TR_ByteCodeInfo & bcInfo, \
                   TR::Compilation *comp, \
-                  int32_t depth=-1, \
-                  bool allConsts = false) :  \
+                  int32_t depth, \
+                  bool allConsts) :  \
                      BASE (callerResolvedMethod, \
                                  callNodeTreeTop, \
                                  parent, \
@@ -328,8 +328,8 @@ class TR_CallSite : public TR_Link<TR_CallSite>
                   bool isInterface,
                   TR_ByteCodeInfo & bcInfo,
                   TR::Compilation *comp,
-                  int32_t depth=-1,
-                  bool allConsts = false);
+                  int32_t depth,
+                  bool allConsts);
 
       TR_CallSite(const TR_CallSite& other) :
          _allConsts (other._allConsts),

--- a/compiler/optimizer/abstractinterpreter/OMRIDTBuilder.cpp
+++ b/compiler/optimizer/abstractinterpreter/OMRIDTBuilder.cpp
@@ -71,7 +71,9 @@ TR::IDT* OMR::IDTBuilder::buildIDT()
                                                 _rootSymbol->getMethodKind() == TR::MethodSymbol::Kinds::Virtual || _rootSymbol->getMethodKind() == TR::MethodSymbol::Kinds::Interface ,
                                                 _rootSymbol->getMethodKind() == TR::MethodSymbol::Kinds::Interface,
                                                 bcInfo,
-                                                comp());
+                                                comp(),
+                                                -1,
+                                                false);
 
    TR_CallTarget *rootCallTarget = new (region()) TR_CallTarget(
                                     region(),


### PR DESCRIPTION
These defaults are barely used anywhere, and soon I intend to add another parameter after them anyway.