### PR TITLE
Delete unused snippet list printing method from TR_Debug

### DIFF
--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -2742,25 +2742,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::list<TR::Snippet*> & snippetList)
       _comp->cg()->dumpDataSnippets(pOutFile);
    }
 
-
-void
-TR_Debug::print(TR::FILE *pOutFile, List<TR::Snippet> & snippetList)
-   {
-   if (pOutFile == NULL)
-      return;
-
-   ListIterator<TR::Snippet> snippets(&snippetList);
-   for (TR::Snippet * snippet = snippets.getFirst(); snippet; snippet = snippets.getNext())
-      {
-      print(pOutFile, snippet);
-      }
-
-   if (_comp->cg()->hasDataSnippets())
-      _comp->cg()->dumpDataSnippets(pOutFile);
-
-   trfprintf(pOutFile, "\n");
-   }
-
 const char *
 TR_Debug::getName(TR::Snippet *snippet)
    {

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -567,7 +567,6 @@ public:
    virtual void         dumpInstructionComments(TR::FILE *, TR::Instruction *, bool needsStartComment = true );
    virtual void         print(TR::FILE *, TR::Instruction *);
    virtual void         print(TR::FILE *, TR::Instruction *, const char *);
-   virtual void         print(TR::FILE *, List<TR::Snippet> &);
    virtual void         print(TR::FILE *, TR::list<TR::Snippet*> &);
    virtual void         print(TR::FILE *, TR::Snippet *);
 


### PR DESCRIPTION
Snippets are printed instead using the `TR::list` version of this method, which is defined just prior to it.