### PR TITLE
gcthreads adaptive fix with overloaded max count

### DIFF
--- a/gc/base/ParallelDispatcher.cpp
+++ b/gc/base/ParallelDispatcher.cpp
@@ -478,7 +478,7 @@ MM_ParallelDispatcher::recomputeActiveThreadCountForTask(MM_EnvironmentBase *env
 		/* Bound the recommended thread count. Determine the  upper bound for the thread count,
 		 * This will either be the user specified gcMaxThreadCount (-XgcmaxthreadsN) or else default max
 		 */
-		taskActiveThreadCount = OMR_MIN(_threadCount, task->getRecommendedWorkingThreads());
+		taskActiveThreadCount = OMR_MIN(taskActiveThreadCount, task->getRecommendedWorkingThreads());
 
 		_activeThreadCount = taskActiveThreadCount;
 


### PR DESCRIPTION
In a rare scenario, if a user specifies max GC thread count above h/w
available thread count, adaptive threading math would incorrectly
disregard the current h/w thread count.

This fix makes adaptive threading math apply its logic on top of
taskActiveThreadCount rather than _threadCount. It is more correct since
the former not already accounts for the latter (_threadCount, what is
currently spawned count of GC threads) but also
accounts for _activeThreadCount which in turn has been adjusted to
account of the number of h/w available threads.