### PR TITLE
Fix supportsArrayTranslate and supportsArraySet

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -177,6 +177,7 @@ OMR::ARM64::CodeGenerator::initialize()
    // Enable compaction of local stack slots.  i.e. variables with non-overlapping live ranges
    // can share the same slot.
    cg->setSupportsCompactedLocals();
+
    if (!TR::Compiler->om.canGenerateArraylets())
       {
       static const bool disableArrayCmp = feGetEnv("TR_DisableArrayCmp") != NULL;
@@ -189,29 +190,29 @@ OMR::ARM64::CodeGenerator::initialize()
          {
          cg->setSupportsArrayCmpLen();
          }
-      }
 
-   if (!comp->getOption(TR_DisableArraySetOpts))
-      {
-      cg->setSupportsArraySet();
-      }
+      if (!comp->getOption(TR_DisableArraySetOpts))
+         {
+         cg->setSupportsArraySet();
+         }
 
-   static bool disableTRTO = (feGetEnv("TR_disableTRTO") != NULL);
-   if (!disableTRTO)
-      {
-      cg->setSupportsArrayTranslateTRTO();
-      }
+      static bool disableTRTO = (feGetEnv("TR_disableTRTO") != NULL);
+      if (!disableTRTO)
+         {
+         cg->setSupportsArrayTranslateTRTO();
+         }
 
-   static bool disableTRTO255 = (feGetEnv("TR_disableTRTO255") != NULL);
-   if (!disableTRTO255)
-      {
-      cg->setSupportsArrayTranslateTRTO255();
-      }
+      static bool disableTRTO255 = (feGetEnv("TR_disableTRTO255") != NULL);
+      if (!disableTRTO255)
+         {
+         cg->setSupportsArrayTranslateTRTO255();
+         }
 
-   static bool disableTROTNoBreak = (feGetEnv("TR_disableTROTNoBreak") != NULL);
-   if (!disableTROTNoBreak)
-      {
-      cg->setSupportsArrayTranslateTROTNoBreak();
+      static bool disableTROTNoBreak = (feGetEnv("TR_disableTROTNoBreak") != NULL);
+      if (!disableTROTNoBreak)
+         {
+         cg->setSupportsArrayTranslateTROTNoBreak();
+         }
       }
    }
 

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -218,16 +218,16 @@ OMR::Power::CodeGenerator::initialize()
     cg->setSupportsSelect();
     cg->setSupportsByteswap();
 
-    // disabled for now
-    //
-    if (comp->getOption(TR_AggressiveOpts) &&
-        !comp->getOption(TR_DisableArraySetOpts))
-       {
-       cg->setSupportsArraySet();
-       }
-
    if (!TR::Compiler->om.canGenerateArraylets())
       {
+      // disabled for now
+      //
+      if (comp->getOption(TR_AggressiveOpts) &&
+          !comp->getOption(TR_DisableArraySetOpts))
+         {
+         cg->setSupportsArraySet();
+         }
+
       static const bool disableArrayCmp = feGetEnv("TR_DisableArrayCmp") != NULL;
       if (!disableArrayCmp)
          {
@@ -238,28 +238,28 @@ OMR::Power::CodeGenerator::initialize()
          {
          cg->setSupportsArrayCmpLen();
          }
-      }
 
-    if (comp->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX))
-       {
-       static bool disablePPCTRTO = (feGetEnv("TR_disablePPCTRTO") != NULL);
-       static bool disablePPCTRTO255 = (feGetEnv("TR_disablePPCTRTO255") != NULL);
-       static bool disablePPCTROT = (feGetEnv("TR_disablePPCTROT") != NULL);
-       static bool disablePPCTROTNoBreak = (feGetEnv("TR_disablePPCTROTNoBreak") != NULL);
+      if (comp->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX))
+         {
+         static bool disablePPCTRTO = (feGetEnv("TR_disablePPCTRTO") != NULL);
+         static bool disablePPCTRTO255 = (feGetEnv("TR_disablePPCTRTO255") != NULL);
+         static bool disablePPCTROT = (feGetEnv("TR_disablePPCTROT") != NULL);
+         static bool disablePPCTROTNoBreak = (feGetEnv("TR_disablePPCTROTNoBreak") != NULL);
 
-       if (!disablePPCTRTO)
-          cg->setSupportsArrayTranslateTRTO();
+         if (!disablePPCTRTO)
+            cg->setSupportsArrayTranslateTRTO();
 #ifndef __LITTLE_ENDIAN__
-       else if (!disablePPCTRTO255)
-          setSupportsArrayTranslateTRTO255();
+         else if (!disablePPCTRTO255)
+            setSupportsArrayTranslateTRTO255();
 #endif
 
-       if (!disablePPCTROT)
-          cg->setSupportsArrayTranslateTROT();
+         if (!disablePPCTROT)
+            cg->setSupportsArrayTranslateTROT();
 
-       if (!disablePPCTROTNoBreak)
-          cg->setSupportsArrayTranslateTROTNoBreak();
-       }
+         if (!disablePPCTROTNoBreak)
+            cg->setSupportsArrayTranslateTROTNoBreak();
+         }
+      }
 
    _numberBytesReadInaccessible = 0;
    _numberBytesWriteInaccessible = 4096;


### PR DESCRIPTION
This commit fixes the condition for supporting arraytranslate and arrayset operations. They work only with contiguous arrays.