### PR TITLE
Inhibit preexistence based on the number of preexistence invalidations

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1910,7 +1910,7 @@ OMR::Options::Options(
       TR_PersistentJittedBodyInfo *bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(oldStartPC);
       if (bodyInfo->getIsInvalidated())
          {
-         if (bodyInfo->getMethodInfo()->getNumberOfInvalidations() >= 2)
+         if (bodyInfo->getMethodInfo()->getNumberOfPreexistenceInvalidations() >= 2)
             {
             this->_disabledOptimizations[invariantArgumentPreexistence] = true;
             }

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -7463,7 +7463,7 @@ void TR_InvariantArgumentPreexistence::processIndirectCall(TR::Node *node, TR::T
             // been invalidated once
             //
             TR::Recompilation *recompInfo = comp()->getRecompilationInfo();
-            if (recompInfo && recompInfo->getMethodInfo()->getNumberOfInvalidations() >= 1 && !chTable->findSingleConcreteSubClass(receiverInfo->getClass(), comp()))
+            if (recompInfo && recompInfo->getMethodInfo()->getNumberOfPreexistenceInvalidations() >= 1 && !chTable->findSingleConcreteSubClass(receiverInfo->getClass(), comp()))
                {
                // will exit without performing any transformation
                //fprintf(stderr, "will not perform devirt\n");


### PR DESCRIPTION
...rather than all invalidations regardless of the reason.

It makes sense to avoid making preexistence assumptions if we've seen that those made in earlier compilations of the same method were invalidated, but invalidations unrelated to preexistence give us no reason to suspect that preexistence assumptions will not hold.