### PR TITLE
PRE fix to handle data address pointer correctly

### DIFF
--- a/compiler/optimizer/LocalAnticipatability.cpp
+++ b/compiler/optimizer/LocalAnticipatability.cpp
@@ -590,7 +590,8 @@ bool TR_LocalAnticipatability::updateAnticipatabilityForSupportedNodes(TR::Node 
          }
       else
          {
-         if (opCode.isLoad() || node->getOpCodeValue() == TR::loadaddr)
+         if ((opCode.isLoad() || node->getOpCodeValue() == TR::loadaddr) &&
+             !node->isDataAddrPointer())
             {
             if (opCode.hasSymbolReference() &&
                 (loadaddrAsLoad() || node->getOpCodeValue() != TR::loadaddr))
@@ -609,6 +610,11 @@ bool TR_LocalAnticipatability::updateAnticipatabilityForSupportedNodes(TR::Node 
             if (!adjustInfoForAddressAdd(node, firstChild, seenDefinedSymbolReferences, seenStoredSymbolReferences, killedExpressions, storeNodes, block))
                return false;
             if (!adjustInfoForAddressAdd(node, secondChild, seenDefinedSymbolReferences, seenStoredSymbolReferences, killedExpressions, storeNodes, block))
+               return false;
+            }
+         else if (node->isDataAddrPointer())
+            {
+            if (!adjustInfoForAddressAdd(node, node->getFirstChild(), seenDefinedSymbolReferences, seenStoredSymbolReferences, killedExpressions, storeNodes, block))
                return false;
             }
          else
@@ -766,7 +772,8 @@ bool TR_LocalAnticipatability::updateAnticipatabilityForSupportedNodes(TR::Node 
       }
    else
       {
-      if (opCode.isLoad() || opCode.getOpCodeValue() == TR::loadaddr)
+      if ((opCode.isLoad() || opCode.getOpCodeValue() == TR::loadaddr) &&
+          !node->isDataAddrPointer())
          {
          if (opCode.hasSymbolReference() &&
              (loadaddrAsLoad() || opCode.getOpCodeValue() != TR::loadaddr))
@@ -788,6 +795,11 @@ bool TR_LocalAnticipatability::updateAnticipatabilityForSupportedNodes(TR::Node 
          if (!adjustInfoForAddressAdd(node, firstChild, seenDefinedSymbolReferences, seenStoredSymbolReferences, killedExpressions, storeNodes, block))
             return false;
          if (!adjustInfoForAddressAdd(node, secondChild, seenDefinedSymbolReferences, seenStoredSymbolReferences, killedExpressions, storeNodes, block))
+            return false;
+         }
+      else if (node->isDataAddrPointer())
+         {
+         if (!adjustInfoForAddressAdd(node, node->getFirstChild(), seenDefinedSymbolReferences, seenStoredSymbolReferences, killedExpressions, storeNodes, block))
             return false;
          }
       else
@@ -827,7 +839,8 @@ bool TR_LocalAnticipatability::adjustInfoForAddressAdd(TR::Node *node, TR::Node 
       }
    else
       {
-      if (childOpCode.isLoad() || child->getOpCodeValue() == TR::loadaddr)
+      if ((childOpCode.isLoad() || child->getOpCodeValue() == TR::loadaddr) &&
+          !child->isDataAddrPointer())
          {
          if (childOpCode.hasSymbolReference() &&
              (loadaddrAsLoad() || child->getOpCodeValue() != TR::loadaddr))

--- a/compiler/optimizer/LocalTransparency.cpp
+++ b/compiler/optimizer/LocalTransparency.cpp
@@ -728,7 +728,8 @@ void TR_LocalTransparency::updateInfoForSupportedNodes(TR::Node *node, Container
             }
          else
             {
-            if (child->getOpCode().isLoad() || child->getOpCodeValue() == TR::loadaddr)
+            if ((child->getOpCode().isLoad() || child->getOpCodeValue() == TR::loadaddr) &&
+                !child->isDataAddrPointer())
                {
                if (child->getOpCode().hasSymbolReference() &&
                    (loadaddrAsLoad() || child->getOpCodeValue() != TR::loadaddr))
@@ -753,7 +754,7 @@ void TR_LocalTransparency::updateInfoForSupportedNodes(TR::Node *node, Container
 
                         }
 
-                if (trace())
+                  if (trace())
                         traceMsg(comp(), "Expression %d (n%dn) killed by symRef #%d (loaded in child)\n", node->getLocalIndex(), node->getGlobalIndex(), childSymRefNum);
                      }
                   }
@@ -767,6 +768,8 @@ void TR_LocalTransparency::updateInfoForSupportedNodes(TR::Node *node, Container
                   adjustInfoForAddressAdd(node, firstGrandChild, seenDefinedSymbolReferences, seenStoredSymRefs);
                   adjustInfoForAddressAdd(node, secondGrandChild, seenDefinedSymbolReferences, seenStoredSymRefs);
                   }
+               else if (child->isDataAddrPointer())
+                  adjustInfoForAddressAdd(node, child->getFirstChild(), seenDefinedSymbolReferences, seenStoredSymRefs);
                else
                   {
                   _supportedNodes->reset(node->getLocalIndex());
@@ -897,7 +900,8 @@ void TR_LocalTransparency::adjustInfoForAddressAdd(TR::Node *node, TR::Node *chi
       }
    else
       {
-      if (child->getOpCode().isLoad() || child->getOpCodeValue() == TR::loadaddr)
+      if ((child->getOpCode().isLoad() || child->getOpCodeValue() == TR::loadaddr) &&
+          !child->isDataAddrPointer())
          {
          if (child->getOpCode().hasSymbolReference() &&
              (loadaddrAsLoad() || child->getOpCodeValue() != TR::loadaddr))


### PR DESCRIPTION
Data address pointers are internal pointers and need special handling in the PRE optimization. Like aladd/aiadd, they are skipped over in the analysis and optimization itself, but we are aiming to allow parent nodes that contain such a node as a child to participate in the analysis and get optimized. This commit changes the local analyses in PRE to treat data address pointer analogously to how aladd/aiadd.