### PR TITLE
Revert Open XL MetalC flag changes

### DIFF
--- a/cmake/modules/OmrMetalC.cmake
+++ b/cmake/modules/OmrMetalC.cmake
@@ -58,11 +58,7 @@ function(omr_compile_metalc mfile ofile)
 	omr_assert(TEST AS_EXECUTABLE)
 
 	if(OMR_ENV_DATA64)
-		if(CMAKE_C_COMPILER_IS_OPENXL)
-			list(APPEND OMR_METALC_XLC_FLAGS "-m64")
-		else()
-			list(APPEND OMR_METALC_XLC_FLAGS "-q64")
-		endif()
+		list(APPEND OMR_METALC_XLC_FLAGS "-q64")
 	endif()
 
 	if(NOT IS_ABSOLUTE "${mfile}")


### PR DESCRIPTION
Open XL z/OS does not yet support metal-c. These files are always compiled with xlc. As such, the conditional -m64 flag is invalid when running with a full Open XL build. This change reverts it to the original logic so that it compiles properly.