### PR TITLE
Lower optimization level workaround for omrzfs.c

### DIFF
--- a/port/zos390/omrzfs.c
+++ b/port/zos390/omrzfs.c
@@ -65,6 +65,9 @@ fillSyscallParamList(J9ZFSSyscallParamList *syscallParamListPtr, int32_t opcode,
  * @return 0 on success; negative value on failure.
  */
 static int32_t
+#if defined(__open_xl__)
+__attribute__((noinline))
+#endif /* defined(__open_xl__) */
 getZFSClientCacheSize(uint64_t *clientCacheSizePtr)
 {
 	uint64_t clientCacheSize = 0;
@@ -173,6 +176,9 @@ getZFSClientCacheSize(uint64_t *clientCacheSizePtr)
 
 /* Retrieve the amount of used ZFS file system user cache. */
 int32_t
+#if defined(__open_xl__)
+__attribute__((noinline))
+#endif /* defined(__open_xl__) */
 getZFSUserCacheUsed(uint64_t *userCacheUsedPtr)
 {
 


### PR DESCRIPTION
Some functions containing the native call BPX4PCT are causing
a crash with Open XL, when they are called back to back in omrzfs. Instead
of lowering optimization level to O0 entirely, specifying
no inlining for these functions seems to mitigate this problem.
This will be used as a workaround until a permanent fix is
released.

Related: https://github.com/eclipse-omr/omr/issues/7653