### PR TITLE
Add isStable() query to the TR_ResolvedMethod interface

### DIFF
--- a/compiler/compile/ResolvedMethod.cpp
+++ b/compiler/compile/ResolvedMethod.cpp
@@ -122,6 +122,7 @@ bool         TR_ResolvedMethod::isUnresolvedCallSiteTableEntry(int32_t callSiteI
 void *       TR_ResolvedMethod::callSiteTableEntryAddress(int32_t callSiteIndex)      { TR_UNIMPLEMENTED(); return 0; }
 bool         TR_ResolvedMethod::isUnresolvedMethodTypeTableEntry(int32_t cpIndex) { TR_UNIMPLEMENTED(); return false; }
 void *       TR_ResolvedMethod::methodTypeTableEntryAddress(int32_t cpIndex)      { TR_UNIMPLEMENTED(); return 0; }
+bool         TR_ResolvedMethod::isStable(int32_t cpIndex, TR::Compilation *comp)  { TR_UNIMPLEMENTED(); return false; }
 uint32_t     TR_ResolvedMethod::romMethodArgCountAtCallSiteIndex(int32_t callSiteIndex) {TR_UNIMPLEMENTED(); return 0;}
 uint32_t     TR_ResolvedMethod::romMethodArgCountAtCPIndex(int32_t cpIndex) {TR_UNIMPLEMENTED(); return 0;}
 

--- a/compiler/compile/ResolvedMethod.hpp
+++ b/compiler/compile/ResolvedMethod.hpp
@@ -148,6 +148,18 @@ public:
    virtual void *callSiteTableEntryAddress(int32_t callSiteIndex);
    virtual bool isUnresolvedMethodTypeTableEntry(int32_t cpIndex);
    virtual void *methodTypeTableEntryAddress(int32_t cpIndex);
+
+   /** \brief
+    *    Check the presence of the @Stable annotation for a field
+    *
+    *  \param cpIndex
+    *    The constant pool index corresponding to the desired field
+    *
+    *  \return bool
+    *    Return true if the field at the indicated cpIndex has the @Stable annotation
+    */
+   virtual bool isStable(int32_t cpIndex, TR::Compilation *comp);
+
    /** \brief
     *    Get the number of arguments in the ROM method signature of an invokedynamic call
     *
@@ -158,6 +170,7 @@ public:
     *    The number of arguments of the ROM Method
     */
    virtual uint32_t romMethodArgCountAtCallSiteIndex(int32_t callSiteIndex);
+
    /** \brief
     *    Get the number of arguments in the ROM method signature of an inovokehandle call
     *


### PR DESCRIPTION
The isStable() query will be used in a downstream project.