### PR TITLE
Misc jb changes

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2994,6 +2994,19 @@ OMR::Options::shutdown(TR_FrontEnd * fe)
          TR::Options::closeLogsForOtherCompilationThreads(fe);
       }
 
+   if (TR::Options::getAOTCmdLineOptions()->_countString)
+      {
+      TR::Options::jitPersistentFree(const_cast<void *>(reinterpret_cast<const void *>(TR::Options::getAOTCmdLineOptions()->_countString)));
+      }
+   TR::Options::jitPersistentFree(_aotCmdLineOptions);
+   _aotCmdLineOptions = NULL;
+
+   if (TR::Options::getJITCmdLineOptions()->_countString)
+      {
+      TR::Options::jitPersistentFree(const_cast<void *>(reinterpret_cast<const void *>(TR::Options::getJITCmdLineOptions()->_countString)));
+      }
+   TR::Options::jitPersistentFree(_jitCmdLineOptions);
+   _jitCmdLineOptions = NULL;
    }
 
 

--- a/compiler/ilgen/BytecodeBuilder.hpp
+++ b/compiler/ilgen/BytecodeBuilder.hpp
@@ -29,7 +29,7 @@ namespace TR
    class BytecodeBuilder : public OMR::BytecodeBuilder
       {
       public:
-         BytecodeBuilder(TR::MethodBuilder *methodBuilder, int32_t bcIndex, char *name=NULL, int32_t bcLength=-1)
+         BytecodeBuilder(TR::MethodBuilder *methodBuilder, int32_t bcIndex, const char *name=NULL, int32_t bcLength=-1)
             : OMR::BytecodeBuilder(methodBuilder, bcIndex, name, bcLength)
             { }
          void initialize(TR::IlGeneratorMethodDetails * details,

--- a/compiler/ilgen/OMRBytecodeBuilder.cpp
+++ b/compiler/ilgen/OMRBytecodeBuilder.cpp
@@ -46,7 +46,7 @@ OMR::BytecodeBuilder::BytecodeBuilder(TR::MethodBuilder *methodBuilder,
    _initialVMState(0),
    _vmState(0)
    {
-   _successorBuilders = new (PERSISTENT_NEW) List<TR::BytecodeBuilder>(_types->trMemory());
+   _successorBuilders = new (_types->trMemory()->heapMemoryRegion()) List<TR::BytecodeBuilder>(_types->trMemory());
    initialize(methodBuilder->details(), methodBuilder->methodSymbol(),
               methodBuilder->fe(), methodBuilder->symRefTab());
    initSequence();

--- a/compiler/ilgen/OMRBytecodeBuilder.cpp
+++ b/compiler/ilgen/OMRBytecodeBuilder.cpp
@@ -37,7 +37,7 @@
 
 OMR::BytecodeBuilder::BytecodeBuilder(TR::MethodBuilder *methodBuilder,
                                       int32_t bcIndex,
-                                      char *name,
+                                      const char *name,
                                       int32_t bcLength)
    : TR::IlBuilder(methodBuilder, methodBuilder->typeDictionary(), bcIndex),
    _fallThroughBuilder(0),

--- a/compiler/ilgen/OMRBytecodeBuilder.hpp
+++ b/compiler/ilgen/OMRBytecodeBuilder.hpp
@@ -36,12 +36,12 @@ class BytecodeBuilder : public TR::IlBuilder
 public:
    TR_ALLOC(TR_Memory::IlGenerator)
 
-   BytecodeBuilder(TR::MethodBuilder *methodBuilder, int32_t bcIndex, char *name=NULL, int32_t bcLength=-1);
+   BytecodeBuilder(TR::MethodBuilder *methodBuilder, int32_t bcIndex, const char *name=NULL, int32_t bcLength=-1);
 
    virtual bool isBytecodeBuilder() { return true; }
 
    /* The name for this BytecodeBuilder. This can be very helpful for debug output */
-   char *name() { return _name; }
+   const char *name() { return _name; }
 
    /**
     * @brief bytecode length for this builder object
@@ -116,7 +116,7 @@ public:
 protected:
    TR::BytecodeBuilder       * _fallThroughBuilder;
    List<TR::BytecodeBuilder> * _successorBuilders;
-   char                      * _name;
+   const char                * _name;
    int32_t                     _bcLength;
    TR::VirtualMachineState   * _initialVMState;
    TR::VirtualMachineState   * _vmState;

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -510,7 +510,7 @@ OMR::IlBuilder::OrphanBuilder()
    }
 
 TR::BytecodeBuilder *
-OMR::IlBuilder::OrphanBytecodeBuilder(int32_t bcIndex, char *name)
+OMR::IlBuilder::OrphanBytecodeBuilder(int32_t bcIndex, const char *name)
    {
    TR::BytecodeBuilder *orphan = new (comp()->trHeapMemory()) TR::BytecodeBuilder(_methodBuilder, bcIndex, name);
    orphan->initialize(_details, _methodSymbol, _fe, _symRefTab);

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -782,6 +782,7 @@ OMR::IlBuilder::StoreIndirect(const char *type, const char *field, TR::IlValue *
    TraceIL("IlBuilder[ %p ]::StoreIndirect %s.%s = %d (base is %d)\n", this, type, field, value->getID(), object->getID());
    TR::ILOpCodes storeOp = comp()->il.opCodeForIndirectStore(fieldType);
    genTreeTop(TR::Node::createWithSymRef(storeOp, 2, loadValue(object), loadValue(value), 0, symRef));
+   jitPersistentFree(fieldRef);
    }
 
 TR::IlValue *
@@ -816,6 +817,7 @@ OMR::IlBuilder::LoadIndirect(const char *type, const char *field, TR::IlValue *o
    TR::DataType fieldType = symRef->getSymbol()->getDataType();
    TR::IlValue *returnValue = newValue(fieldType, TR::Node::createWithSymRef(comp()->il.opCodeForIndirectLoad(fieldType), 1, loadValue(object), 0, symRef));
    TraceIL("IlBuilder[ %p ]::%d is LoadIndirect %s.%s from (%d)\n", this, returnValue->getID(), type, field, object->getID());
+   jitPersistentFree(fieldRef);
    return returnValue;
    }
 

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -1258,6 +1258,13 @@ OMR::IlBuilder::Return()
 void
 OMR::IlBuilder::Return(TR::IlValue *value)
    {
+   TR::DataType retType = value->getDataType();
+   if (value->getDataType() == TR::Int8 || value->getDataType() == TR::Int16 || (Word == Int64 && value->getDataType() == TR::Int32))
+      {
+      retType = Word->getPrimitiveType();
+      value = ConvertTo(Word, value);
+      }
+
    TR::IlBuilder *returnBuilder = _methodBuilder->returnBuilder();
    if (returnBuilder != NULL)
       {
@@ -2144,7 +2151,7 @@ OMR::IlBuilder::Call(TR::MethodBuilder *calleeMB, int32_t numArgs, TR::IlValue *
       return NULL;
 
    // otherwise, return callee's return value
-   TR::IlValue *returnValue = returnBuilder->Load(returnSymbol);
+   TR::IlValue *returnValue = ConvertTo(calleeMB->getReturnType(), returnBuilder->Load(returnSymbol));
    TraceIL("IlBuilder[ %p ]::Call callee return value is %d loaded from %s\n", this, returnValue->getID(), returnSymbol);
    return returnValue;
    }

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -231,7 +231,7 @@ public:
 
    TR::IlBuilder *createBuilderIfNeeded(TR::IlBuilder *builder);
    TR::IlBuilder *OrphanBuilder();
-   TR::BytecodeBuilder *OrphanBytecodeBuilder(int32_t bcIndex=0, char *name=NULL);
+   TR::BytecodeBuilder *OrphanBytecodeBuilder(int32_t bcIndex=0, const char *name=NULL);
 
    bool TraceEnabled_log();
    void TraceIL_log(const char *s, ...);

--- a/compiler/ilgen/OMRMethodBuilder.cpp
+++ b/compiler/ilgen/OMRMethodBuilder.cpp
@@ -295,7 +295,17 @@ OMR::MethodBuilder::connectTrees()
       _countBlocksWorklist = new (comp()->trHeapMemory()) List<TR::BytecodeBuilder>(comp()->trMemory());
       _connectTreesWorklist = new (comp()->trHeapMemory()) List<TR::BytecodeBuilder>(comp()->trMemory());
 
-      // this will go count everything up front
+      // following is needed by JB2 to ensure all builders are appropriately counted */
+      ListIterator<TR::BytecodeBuilder> iter(_allBytecodeBuilders);
+      for (TR::BytecodeBuilder *builder=iter.getFirst();
+           !iter.atEnd();
+           builder = iter.getNext())
+         {
+         TraceIL("[ %p ] Adding BytecodeBuilder %p to count block worklist\n", this, builder);
+         _countBlocksWorklist->add(builder);
+         }
+
+      // count everything up front
       _count = countBlocks();
       }
 

--- a/compiler/ilgen/OMRMethodBuilder.cpp
+++ b/compiler/ilgen/OMRMethodBuilder.cpp
@@ -582,6 +582,7 @@ OMR::MethodBuilder::DefineFunction(const char* const name,
    va_end(parms);
 
    DefineFunction(name, fileName, lineNumber, entryPoint, returnType, numParms, parmTypes);
+   trMemory()->trPersistentMemory()->freePersistentMemory(parmTypes);
    }
 
 void
@@ -596,7 +597,7 @@ OMR::MethodBuilder::DefineFunction(const char* const name,
    TR_ASSERT_FATAL(_functions.find(name) == _functions.end(), "Function '%s' already defined", name);
 
    // copy parameter types so don't have to force caller to keep the parmTypes array alive
-   TR::IlType **copiedParmTypes = (TR::IlType **) trMemory()->trPersistentMemory()->allocatePersistentMemory(numParms * sizeof(TR::IlType *));
+   TR::IlType **copiedParmTypes = (TR::IlType **) trMemory()->heapMemoryRegion().allocate(numParms * sizeof(TR::IlType *));
    for (int32_t p=0;p < numParms;p++)
       copiedParmTypes[p] = parmTypes[p];
 

--- a/compiler/ilgen/OMRMethodBuilder.hpp
+++ b/compiler/ilgen/OMRMethodBuilder.hpp
@@ -284,10 +284,11 @@ class MethodBuilder : public TR::IlBuilder
       _getImpl = getter;
       }
 
+   TR_Memory *trMemory() { return memoryManager._trMemory; }
+
    protected:
    virtual uint32_t countBlocks();
    virtual bool connectTrees();
-   TR_Memory *trMemory() { return memoryManager._trMemory; }
 
    /*
     * @brief adjusts a local variable name so that it will be unique to the current inlined site to prevent inlining-induced name aliasing

--- a/compiler/ilgen/OMRTypeDictionary.cpp
+++ b/compiler/ilgen/OMRTypeDictionary.cpp
@@ -527,6 +527,15 @@ OMR::TypeDictionary::TypeDictionary() :
       }
    }
 
+// Copy constructor is private but it must be defined
+// to avoid undefined behaviour, since we can't use `delete`
+OMR::TypeDictionary::TypeDictionary(const TypeDictionary &src) :
+   _client(0),
+   _pointersByName(str_comparator, trMemory()->heapMemoryRegion()),
+   _structsByName(str_comparator, trMemory()->heapMemoryRegion()),
+   _unionsByName(str_comparator, trMemory()->heapMemoryRegion())
+   {}
+
 OMR::TypeDictionary::~TypeDictionary() throw()
    {
    // Cleanup allocations in _memoryRegion *before* its destroyed in

--- a/compiler/ilgen/OMRTypeDictionary.hpp
+++ b/compiler/ilgen/OMRTypeDictionary.hpp
@@ -231,6 +231,10 @@ protected:
 
    typedef bool (*StrComparator)(const char *, const char *);
 
+   typedef TR::typed_allocator<std::pair<const char * const, TR::IlType *>, TR::Region &> PointerMapAllocator;
+   typedef std::map<const char *, TR::IlType *, StrComparator, PointerMapAllocator> PointerMap;
+   PointerMap          _pointersByName;
+
    typedef TR::typed_allocator<std::pair<const char * const, OMR::StructType *>, TR::Region &> StructMapAllocator;
    typedef std::map<const char *, OMR::StructType *, StrComparator, StructMapAllocator> StructMap;
    StructMap          _structsByName;

--- a/compiler/ilgen/OMRTypeDictionary.hpp
+++ b/compiler/ilgen/OMRTypeDictionary.hpp
@@ -50,6 +50,8 @@ public:
    TR_ALLOC(TR_Memory::IlGenerator)
 
    TypeDictionary();
+   TypeDictionary(const TypeDictionary &src);
+
    ~TypeDictionary() throw();
 
    TR::IlType * LookupStruct(const char *structName);

--- a/jitbuilder/CMakeLists.txt
+++ b/jitbuilder/CMakeLists.txt
@@ -153,15 +153,3 @@ endif()
 if(OMR_LLJB)
 	add_subdirectory(lljb)
 endif()
-
-# install(TARGETS jitbuilder
-#         ARCHIVE       DESTINATION ${CMAKE_BINARY_DIR}/jitbuilder_release
-#         PUBLIC_HEADER DESTINATION ${CMAKE_BINARY_DIR}/jitbuilder_release/include
-#         )
-#
-# # Create release directory
-# file(MAKE_DIRECTORY jitbuilder_release)
-# file(COPY ${jitbuilder_library} DESTINATION jitbuilder_release)
-# file(COPY ${CMAKE_SOURCE_DIR}/compiler/env   DESTINATION jitbuilder_release/include)
-# file(COPY ${CMAKE_SOURCE_DIR}/compiler/il    DESTINATION jitbuilder_release/include)
-# file(COPY ${CMAKE_SOURCE_DIR}/compiler/ilgen DESTINATION jitbuilder_release/include)

--- a/jitbuilder/apigen/jitbuilder.api.json
+++ b/jitbuilder/apigen/jitbuilder.api.json
@@ -60,7 +60,7 @@
                 { "name": "name"
                 , "overloadsuffix": ""
                 , "flags": []
-                , "return": "string"
+                , "return": "constString"
                 , "parms": []
                 },
                 { "name": "vmState"
@@ -424,7 +424,7 @@
                 , "return": "BytecodeBuilder"
                 , "parms": [
                     {"name":"bcIndex","type":"int32"},
-                    {"name":"name","type":"string"}
+                    {"name":"name","type":"constString"}
                     ]
                 },
                 { "name": "Copy"


### PR DESCRIPTION
A collection of (mostly) relatively small changes to the jitbuilder code discovered during the development of jb2 (so not likely to have been bothering anyone else, it seems).

Two things that may impact users (first possibly negative, second possibly positive) :
1) The "name" parameter for BytecodeBuilder has been promoted to const char * from char *. Hopefully that shouldn't bother anyone, but code that asks for the name of a bytecode builder may not be expecting a const char * back.

2) I've improved the handling of short integer width operands for IfCmp statements for AArch64. These don't work very well on some code generators (I'm looking at you, AArch64!) but JitBuilder allows it. JitBuilder will now automatically insert additional conversions to promote the operands to platform word-sized values before comparing specifically on AArch64 now. One less platform-ism that escapes the JitBuilder API...