### PR TITLE
Remove unused off heap related APIs

### DIFF
--- a/gc/base/SparseAddressOrderedFixedSizeDataPool.cpp
+++ b/gc/base/SparseAddressOrderedFixedSizeDataPool.cpp
@@ -145,22 +145,6 @@ MM_SparseAddressOrderedFixedSizeDataPool::mapSparseDataPtrToHeapProxyObjectPtr(v
 }
 
 bool
-MM_SparseAddressOrderedFixedSizeDataPool::unmapSparseDataPtrFromHeapProxyObjectPtr(void *dataPtr)
-{
-	bool ret = true;
-	MM_SparseDataTableEntry entryToRemove = MM_SparseDataTableEntry(dataPtr);
-
-	if (0 != hashTableRemove(_objectToSparseDataTable, &entryToRemove)) {
-		Trc_MM_SparseAddressOrderedFixedSizeDataPool_removeEntry_failure(dataPtr);
-		ret = false;
-	} else {
-		Trc_MM_SparseAddressOrderedFixedSizeDataPool_removeEntry_success(dataPtr);
-	}
-
-	return ret;
-}
-
-bool
 MM_SparseAddressOrderedFixedSizeDataPool::unmapSparseDataPtrFromHeapProxyObjectPtr(void *dataPtr, void *proxyObjPtr, uintptr_t size)
 {
 	bool ret = true;
@@ -215,19 +199,6 @@ MM_SparseAddressOrderedFixedSizeDataPool::findHeapProxyObjectPtrForSparseDataPtr
 	}
 
 	return proxyObjPtr;
-}
-
-bool
-MM_SparseAddressOrderedFixedSizeDataPool::isValidDataPtr(void *dataPtr)
-{
-	MM_SparseDataTableEntry *entry = findSparseDataTableEntryForSparseDataPtr(dataPtr);
-	bool ret = true;
-
-	if (entry != NULL) {
-		ret = (entry->_dataPtr == dataPtr);
-	}
-
-	return ret;
 }
 
 bool
@@ -388,24 +359,6 @@ MM_SparseAddressOrderedFixedSizeDataPool::returnFreeListEntry(void *dataAddr, ui
 
 	Trc_MM_SparseAddressOrderedFixedSizeDataPool_returnFreeListEntry_success(dataAddr, (void *)size, _freeListPoolFreeNodesCount, (void *)_approximateFreeMemorySize, (void *)_freeListPoolAllocBytes);
 	return true;
-}
-
-bool
-MM_SparseAddressOrderedFixedSizeDataPool::updateSparseDataEntryAfterObjectHasMoved(void *dataPtr, void *proxyObjPtr)
-{
-	bool ret = true;
-	MM_SparseDataTableEntry lookupEntry = MM_SparseDataTableEntry(dataPtr);
-	MM_SparseDataTableEntry *entry = (MM_SparseDataTableEntry *)hashTableFind(_objectToSparseDataTable, &lookupEntry);
-
-	if ((NULL != entry) && (entry->_dataPtr == dataPtr)) {
-		Trc_MM_SparseAddressOrderedFixedSizeDataPool_updateEntry_success(dataPtr, entry->_proxyObjPtr, proxyObjPtr);
-		entry->_proxyObjPtr = proxyObjPtr;
-	} else {
-		Trc_MM_SparseAddressOrderedFixedSizeDataPool_findEntry_failure(dataPtr);
-		ret = false;
-	}
-
-	return ret;
 }
 
 bool

--- a/gc/base/SparseAddressOrderedFixedSizeDataPool.hpp
+++ b/gc/base/SparseAddressOrderedFixedSizeDataPool.hpp
@@ -132,15 +132,6 @@ public:
 	bool mapSparseDataPtrToHeapProxyObjectPtr(void *dataPtr, void *proxyObjPtr, uintptr_t size);
 
 	/**
-	 * Remove entry from the hash table that is associated the object data pointer provided
-	 *
-	 * @param dataPtr	void*	Data pointer
-	 *
-	 * @return true if key associated to dataPtr is removed successfully, false otherwise
-	 */
-	bool unmapSparseDataPtrFromHeapProxyObjectPtr(void *dataPtr);
-
-	/**
 	 * Remove entry from the hash table that is associated the object data pointer provided.
 	 * Verify if the entry is consistent(the size and associated the object) before removing.
 	 * Assert if no entry is found or the verifying is failed.
@@ -176,13 +167,6 @@ public:
 	 */
 	void *findHeapProxyObjectPtrForSparseDataPtr(void *dataPtr);
 
-	/**
-	 * Check if the given data pointer is valid
-	 *
-	 * @param dataPtr	void*	Data pointer
-	 * @return true if data pointer is valid
-	 */
-	bool isValidDataPtr(void *dataPtr);
 	/**
 	 * Check if the given data pointer is valid and consistent(dataPtr, proxyObjPtr and size)
 	 *
@@ -224,16 +208,6 @@ public:
 	{
 		return _allocObjectCount;
 	}
-
-	/**
-	 * Update the proxyObjPtr after an object has moved for the sparse data entry associated with the given dataPtr.
-	 *
-	 * @param dataPtr       void*   Data pointer
-	 * @param proxyObjPtr   void*   Updated in-heap proxy object pointer for data pointer
-	 *
-	 * @return true if the sparse data entry was successfully updated, false otherwise
-	 */
-	bool updateSparseDataEntryAfterObjectHasMoved(void *dataPtr, void *proxyObjPtr);
 
 	/**
 	 * Update the newProxyObjPtr after an object has moved for the sparse data entry associated with the given dataPtr.

--- a/gc/base/SparseVirtualMemory.hpp
+++ b/gc/base/SparseVirtualMemory.hpp
@@ -91,16 +91,6 @@ public:
 
 	/**
 	 * After the in-heap proxy object pointer has moved, update the proxyObjPtr for the sparse data entry associated with the dataPtr.
-	 *
-	 * @param dataPtr		void*	Data pointer
-	 * @param proxyObjPtr	void*	Updated in-heap proxy object pointer for the data pointer
-	 *
-	 * @return true if the table entry was successfully updated, false otherwise
-	 */
-	bool updateSparseDataEntryAfterObjectHasMoved(void *dataPtr, void *proxyObjPtr);
-
-	/**
-	 * After the in-heap proxy object pointer has moved, update the proxyObjPtr for the sparse data entry associated with the dataPtr.
 	 * Verify if the entry is consistent(the size and associated the object) before updating.
 	 * Assert if no entry is found or the verifying is failed.
 	 *
@@ -121,17 +111,6 @@ public:
 	 * @return data pointer at sparse heap that satisfies the requested size
 	 */
 	void *allocateSparseFreeEntryAndMapToHeapObject(void *proxyObjPtr, uintptr_t size);
-
-	/**
-	 * Once object is collected by GC, we need to free the sparse region associated
-	 * with the object pointer. Therefore we decommit sparse region and return free
-	 * region to the sparse free region pool.
-	 *
-	 * @param dataPtr	void*	Data pointer
-	 *
-	 * @return true if region associated to object was decommited and freed successfully, false otherwise
-	 */
-	bool freeSparseRegionAndUnmapFromHeapObject(MM_EnvironmentBase* env, void *dataPtr);
 
 	/**
 	 * Once object is collected by GC, we need to free the sparse region associated


### PR DESCRIPTION
caller has been updated to use new signature of
the below APIs, remove the old unused APIs.

class MM_SparseVirtualMemory
updateSparseDataEntryAfterObjectHasMoved()
freeSparseRegionAndUnmapFromHeapObject()

class MM_SparseAddressOrderedFixedSizeDataPool
isValidDataPtr()
unmapSparseDataPtrFromHeapProxyObjectPtr()
updateSparseDataEntryAfterObjectHasMoved()