### PR TITLE
ZOS: Fix const length buffer used in atoe methods

### DIFF
--- a/util/a2e/atoe_utils.c
+++ b/util/a2e/atoe_utils.c
@@ -93,10 +93,10 @@ pchar(InstanceData *this, int c)
 
 	if (iscntrl(0xff & c) && c != '\n' && c != '\t') {
 		c = '@' + (c & 0x1F);
-		if (this->buffer >= this->end) {
-			return ERROR_RETVAL;
+		if (this->buffer < this->end) {
+			*this->buffer = '^';
 		}
-		*this->buffer++ = '^';
+		*this->buffer++;
 	}
 #endif /* 0 */
 


### PR DESCRIPTION
Some of the atoe methods were using a constant length buffer for string conversion. If the input format string and arguments are larger than the buffer size, buffer overflow would happen. This bug was fixed by running atoe_vsnprintf with NULL buffer to get the required buffer size then create the buffer and write in it.