### PR TITLE
Only free options objects in Options::shutdown if safe for FrontEnd

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2994,19 +2994,22 @@ OMR::Options::shutdown(TR_FrontEnd * fe)
          TR::Options::closeLogsForOtherCompilationThreads(fe);
       }
 
-   if (TR::Options::getAOTCmdLineOptions()->_countString)
+   if (fe->isSafeToFreeOptionsOnShutdown())
       {
-      TR::Options::jitPersistentFree(const_cast<void *>(reinterpret_cast<const void *>(TR::Options::getAOTCmdLineOptions()->_countString)));
-      }
-   TR::Options::jitPersistentFree(_aotCmdLineOptions);
-   _aotCmdLineOptions = NULL;
+      if (TR::Options::getAOTCmdLineOptions()->_countString)
+         {
+         TR::Options::jitPersistentFree(const_cast<void *>(reinterpret_cast<const void *>(TR::Options::getAOTCmdLineOptions()->_countString)));
+         }
+      TR::Options::jitPersistentFree(_aotCmdLineOptions);
+      _aotCmdLineOptions = NULL;
 
-   if (TR::Options::getJITCmdLineOptions()->_countString)
-      {
-      TR::Options::jitPersistentFree(const_cast<void *>(reinterpret_cast<const void *>(TR::Options::getJITCmdLineOptions()->_countString)));
+      if (TR::Options::getJITCmdLineOptions()->_countString)
+         {
+         TR::Options::jitPersistentFree(const_cast<void *>(reinterpret_cast<const void *>(TR::Options::getJITCmdLineOptions()->_countString)));
+         }
+      TR::Options::jitPersistentFree(_jitCmdLineOptions);
+      _jitCmdLineOptions = NULL;
       }
-   TR::Options::jitPersistentFree(_jitCmdLineOptions);
-   _jitCmdLineOptions = NULL;
    }
 
 

--- a/compiler/env/FrontEnd.cpp
+++ b/compiler/env/FrontEnd.cpp
@@ -318,3 +318,15 @@ TR_FrontEnd::methodTrampolineLookup(TR::Compilation *comp, TR::SymbolReference *
    TR_UNIMPLEMENTED();
    return 0;
    }
+
+void
+TR_FrontEnd::setIsSafeToFreeOptionsOnShutdown(bool isSafe)
+   {
+   _isSafeToFreeOptionsOnShutdown = isSafe;
+   }
+
+bool
+TR_FrontEnd::isSafeToFreeOptionsOnShutdown()
+   {
+   return _isSafeToFreeOptionsOnShutdown;
+   }

--- a/compiler/env/FrontEnd.hpp
+++ b/compiler/env/FrontEnd.hpp
@@ -103,7 +103,9 @@ struct TR_BinaryEncodingData
 class TR_FrontEnd : private TR::Uncopyable
    {
 public:
-   TR_FrontEnd() {}
+   TR_FrontEnd()
+      : _isSafeToFreeOptionsOnShutdown(false)   // most conservative setting, relied upon by OpenJ9
+      {}
 
    // --------------------------------------------------------------------------
    // Method
@@ -222,6 +224,11 @@ public:
    virtual char *getFormattedName(char *, int32_t, char *, char *, bool);
    virtual void printVerboseLogHeader(TR::Options *cmdLineOptions) {}
 
+   virtual void setIsSafeToFreeOptionsOnShutdown(bool isSafe=true);
+   virtual bool isSafeToFreeOptionsOnShutdown();
+
+private:
+   bool _isSafeToFreeOptionsOnShutdown;
    };
 
 #endif

--- a/fvtest/compilertest/control/TestJit.cpp
+++ b/fvtest/compilertest/control/TestJit.cpp
@@ -166,6 +166,8 @@ initializeTestJit(TR_RuntimeHelper *helperIDs, void **helperAddresses, int32_t n
 
    // --------------------------------------------------------------------------
    static TR::FrontEnd fe;
+   fe.setIsSafeToFreeOptionsOnShutdown(true);
+
    auto jitConfig = fe.jitConfig();
 
    initializeAllHelpers(jitConfig, helperIDs, helperAddresses, numHelpers);

--- a/jitbuilder/control/Jit.cpp
+++ b/jitbuilder/control/Jit.cpp
@@ -137,6 +137,8 @@ initializeJitBuilder(TR_RuntimeHelper *helperIDs, void **helperAddresses, int32_
 
    // --------------------------------------------------------------------------
    static TR::FrontEnd fe;
+   fe.setIsSafeToFreeOptionsOnShutdown(true);
+
    auto jitConfig = fe.jitConfig();
 
    initializeAllHelpers(jitConfig, helperIDs, helperAddresses, numHelpers);


### PR DESCRIPTION
Adds a query to TR_FrontEnd (which defaults to "no") to answer whether Options::shutdown() should free the command-line options objects. For compilers like JitBuilder and the Test compiler, not freeing the options represents a memory leak and there is no reason not to free the options objects, so these compilers arrange for the objects to be freed.

Other FrontEnds (but notably OpenJ9) by default will not free the options objects, because e.g. OpenJ9 cannot guarantee that the options objects will not be later read in one of its many event handlers that continue to operate throughout the shutdown process. Other front ends can opt in by adding the same line of code in their startup to tell their TR_FrontEnd object that it's safe to free the options object.

This change addresses crashes in OpenJ9 that started happening after we plugged the memory leak represented by the options objects previously not being freed at shutdown. Those crashes currently block OMR promotion into OpenJ9.

fya @hzongaro 