### PR TITLE
Prevent null check compaction for dataAddr nodes

### DIFF
--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -2145,6 +2145,9 @@ bool TR_CompactNullChecks::replacePassThroughIfPossible(TR::Node *currentNode, T
    if (currentNode->getVisitCount() == initialVisitCount)
       return false;
 
+   if (currentNode->isDataAddrPointer())
+      return false;
+
    currentNode->setVisitCount(visitCount);
 
    if (currentNode->isNopableInlineGuard())


### PR DESCRIPTION
Null check compaction was incorrectly replacing array object with dataAddr
pointer, resulting in the pointer being alive across GC point.

Signed-off-by: Shubham Verma <shubhamv.sv@gmail.com>