### PR TITLE
Don't #define VMINLINE to be empty for unoptimized/debug builds

### DIFF
--- a/include_core/omrcomp.h
+++ b/include_core/omrcomp.h
@@ -108,6 +108,16 @@ EXE_EXTENSION_CHAR: the executable has a delimiter that we want to stop at as pa
 
 */
 
+/* GCC will respect the always_inline attribute even in unoptimized builds,
+ * where one might expect inlining to be inhibited regardless, so for VMINLINE,
+ * apply the attribute only in optimized builds.
+ */
+#if defined(__GNUC__) && defined(__OPTIMIZE__)
+#define OMR_GNUC_ALWAYS_INLINE_WHEN_OPTIMIZED __attribute__((__always_inline__))
+#else /* defined(__GNUC__) && defined(__OPTIMIZE__) */
+#define OMR_GNUC_ALWAYS_INLINE_WHEN_OPTIMIZED
+#endif /* defined(__GNUC__) && defined(__OPTIMIZE__) */
+
 /* Linux ANSI compiler (gcc) and OSX (clang). */
 #if defined(LINUX) || defined (OSX)
 
@@ -150,12 +160,7 @@ typedef double SYS_FLOAT;
 #endif
 
 #if defined(__GNUC__)
-#define VMINLINE_ALWAYS inline __attribute((always_inline))
-/* If -O0 is in effect, define VMINLINE to be empty */
-#if !defined(__OPTIMIZE__)
-#define VMINLINE
-#endif
-
+#define VMINLINE_ALWAYS inline OMR_GNUC_ALWAYS_INLINE_WHEN_OPTIMIZED
 #elif defined(__xlC__)
 /*
  * xlC11 C++ compiler reportedly supports attributes before function names, but we've only tested xlC12.
@@ -279,11 +284,7 @@ typedef double 					SYS_FLOAT;
 	THREAD_PRIORITY_TIME_CRITICAL			/*11 */}
 
 #if defined(__GNUC__)
-#define VMINLINE_ALWAYS inline __attribute((always_inline))
-/* If -O0 is in effect, define VMINLINE to be empty */
-#if !defined(__OPTIMIZE__)
-#define VMINLINE
-#endif
+#define VMINLINE_ALWAYS inline OMR_GNUC_ALWAYS_INLINE_WHEN_OPTIMIZED
 #define HAS_BUILTIN_EXPECT
 #else /* __GNUC__ */
 /* Only for use on static functions */
@@ -548,13 +549,8 @@ typedef struct U_128 {
 #if !defined(VMINLINE_ALWAYS)
 #define VMINLINE_ALWAYS
 #endif
-#if !defined(VMINLINE)
+
 #define VMINLINE VMINLINE_ALWAYS
-#endif
-#if defined(DEBUG)
-#undef VMINLINE
-#define VMINLINE
-#endif
 
 /* DDR cannot parse __builtin_expect */
 #if defined(TYPESTUBS_H)


### PR DESCRIPTION
For unoptimized builds with GCC, we only need to avoid the `always_inline` attribute. The mere presence of the inline keyword won't cause any actual inlining (since the build is unoptimized).

As for `DEBUG`, even if it's defined, many `VMINLINE` functions are likely to be inlined in optimized builds anyway, because they're implicitly declared inline by virtue of being defined within a class declaration. If a developer wants to prevent inlining for debugging purposes, they can edit their build flags to disable it (or disable optimization more generally), or they can inhibit inlining of particular functions in the source code, e.g. with `__attribute__((noinline))`.

`VMINLINE` will now always be defined as `VMINLINE_ALWAYS` because there is no prior definition.

This change avoids unused function warnings for standalone `static VMINLINE` functions that would end up being declared `static` but not `inline` in unoptimized builds with GCC.

It's still possible for `VMINLINE` to be empty if `VMINLINE_ALWAYS` is, but I ran builds to find when that definition of `VMINLINE_ALWAYS` is actually used, i.e. to declare a function, and it only happened in C files on z/OS and in source generated for DDR.