### PR TITLE
Change access protection for performHelperCall on x86

### DIFF
--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -544,9 +544,11 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
                                                                               int repMovsThresholdBytes,
                                                                               TR::LabelSymbol *repMovsLabel,
                                                                               TR::LabelSymbol *mainEndLabel);
-   protected:
 
    static TR::Register *performHelperCall(TR::Node *node, TR::SymbolReference *helperSymRef, TR::ILOpCodes helperCallOpCode, bool spillFPRegs, TR::CodeGenerator *cg);
+
+   protected:
+
    static TR::Register *performIload(TR::Node *node, TR::MemoryReference  *sourceMR, TR::CodeGenerator *cg);
    static TR::Register *performFload(TR::Node *node, TR::MemoryReference  *sourceMR, TR::CodeGenerator *cg);
    static TR::Register *performDload(TR::Node *node, TR::MemoryReference  *sourceMR, TR::CodeGenerator *cg);


### PR DESCRIPTION
It can be useful to call this static function outside of the TreeEvaluator hierarchy, so make it public access.