### PR TITLE
Add -Xjit:disableCodeAllocationTrimming option

### DIFF
--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -170,7 +170,10 @@ OMR::CodeGenPhase::performProcessRelocationsPhase(TR::CodeGenerator * cg, TR::Co
 
    cg->processRelocations();
 
-   cg->trimCodeMemoryToActualSize();
+   if (!comp->getOption(TR_DisableCodeAllocationTrimming))
+      {
+      cg->trimCodeMemoryToActualSize();
+      }
    cg->registerAssumptions();
 
    cg->syncCode(cg->getBinaryBufferStart(), static_cast<uint32_t>(cg->getBinaryBufferCursor() - cg->getBinaryBufferStart()));

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -294,6 +294,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableClassChainSharing",            "M\tdisable class sharing", RESET_OPTION_BIT(TR_EnableClassChainSharing), "F", NOT_IN_SUBSET},
    {"disableClassChainValidationCaching",  "M\tdisable class chain validation caching", RESET_OPTION_BIT(TR_EnableClassChainValidationCaching), "F", NOT_IN_SUBSET},
    {"disableClearCodeCacheFullFlag",      "I\tdisable the re-enabling of full code cache when a method body is freed.", SET_OPTION_BIT(TR_DisableClearCodeCacheFullFlag),"F", NOT_IN_SUBSET},
+   {"disableCodeAllocationTrimming",      "M\tdisable code cache allocation trimming at end of codegen", SET_OPTION_BIT(TR_DisableCodeAllocationTrimming), "F"},
    {"disableCodeCacheConsolidation",      "M\tdisable code cache consolidation", RESET_OPTION_BIT(TR_EnableCodeCacheConsolidation), "F", NOT_IN_SUBSET},
    {"disableCodeCacheReclamation",        "I\tdisable the freeing of compilations.", SET_OPTION_BIT(TR_DisableCodeCacheReclamation),"F", NOT_IN_SUBSET},
    {"disableCodeCacheSnippets",           "O\tdisable code cache snippets (e.g. allocation prefetch snippet) ", SET_OPTION_BIT(TR_DisableCodeCacheSnippets), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -458,7 +458,7 @@ enum TR_CompilationOptions
    TR_AggressiveOpts                          = 0x00010000 + 12,
    TR_DisableMarshallingIntrinsics            = 0x00020000 + 12,
    TR_DisablePackedDecimalIntrinsics          = 0x00040000 + 12,
-   // Available                               = 0x00080000 + 12,
+   TR_DisableCodeAllocationTrimming           = 0x00080000 + 12,
    TR_DisableDememoization                    = 0x00100000 + 12,
    TR_DisableStringBuilderTransformer         = 0x00200000 + 12,
    TR_TraceILGen                              = 0x00400000 + 12,


### PR DESCRIPTION
The codegen typically overestimates the code cache space needed for a compiled method body. However, after the jitted code is generated, the codegen "trims" the initial code cache allocation to the right size.
This commit introduces an option to disable such code cache allocation trimming. By default, code cache allocation trimming is enabled, preserving the current behavior.