### PR TITLE
x86: Call TR::CPU::customize in CPU detection logic

### DIFF
--- a/compiler/env/OMRCPU.cpp
+++ b/compiler/env/OMRCPU.cpp
@@ -162,6 +162,12 @@ OMR::CPU::detect(OMRPortLibrary * const omrPortLib)
    }
 
 TR::CPU
+OMR::CPU::customize(OMRProcessorDesc processorDescription)
+   {
+   return TR::CPU(processorDescription);
+   }
+
+TR::CPU
 OMR::CPU::detectRelocatable(OMRPortLibrary * const omrPortLib)
    {
    return TR::CPU::detect(omrPortLib);

--- a/compiler/env/OMRCPU.hpp
+++ b/compiler/env/OMRCPU.hpp
@@ -107,6 +107,13 @@ public:
     */
    static TR::CPU detect(OMRPortLibrary * const omrPortLib);
 
+   /**
+    * @brief A factory method used to construct a CPU object based on user customized processorDescription
+    * @param[in] OMRProcessorDesc : the processor description
+    * @return TR::CPU
+    */
+   static TR::CPU customize(OMRProcessorDesc processorDescription);
+
   /**
     * @brief Returns the processor type and features that will be used by portable AOT compilations
     * @param[in] omrPortLib : the port library

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -61,6 +61,8 @@ public:
 
    static TR::CPU detect(OMRPortLibrary * const omrPortLib);
 
+   static TR::CPU customize(OMRProcessorDesc processorDescription);
+
    static void initializeTargetProcessorInfo(bool force = false);
 
    TR_X86CPUIDBuffer *queryX86TargetCPUID();


### PR DESCRIPTION
Issue: eclipse-openj9/openj9#19408