### PR TITLE
Add an API for native libraries

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1905,6 +1905,7 @@ typedef struct J9Heap J9Heap;
 
 typedef uintptr_t (*omrsig_protected_fn)(struct OMRPortLibrary *portLib, void *handler_arg);
 typedef uintptr_t (*omrsig_handler_fn)(struct OMRPortLibrary *portLib, uint32_t gpType, void *gpInfo, void *handler_arg);
+typedef uintptr_t (*OMRLibraryInfoCallback)(const char *name, void *addressLow, void *addressHigh, void *userData);
 
 typedef struct OMRPortLibrary {
 	/** portGlobals*/
@@ -2115,6 +2116,8 @@ typedef struct OMRPortLibrary {
 	uintptr_t (*sl_open_shared_library)(struct OMRPortLibrary *portLibrary, char *name, uintptr_t *descriptor, uintptr_t flags) ;
 	/** see @ref omrsl.c::omrsl_lookup_name "omrsl_lookup_name"*/
 	uintptr_t (*sl_lookup_name)(struct OMRPortLibrary *portLibrary, uintptr_t descriptor, char *name, uintptr_t *func, const char *argSignature) ;
+	/** see @ref omrsl.c::omrsl_get_libraries "omrsl_get_libraries"*/
+	uintptr_t (*sl_get_libraries)(struct OMRPortLibrary *portLibrary, OMRLibraryInfoCallback callback, void *userData);
 	/** see @ref omrtty.c::omrtty_startup "omrtty_startup"*/
 	int32_t (*tty_startup)(struct OMRPortLibrary *portLibrary) ;
 	/** see @ref omrtty.c::omrtty_shutdown "omrtty_shutdown"*/
@@ -2955,6 +2958,7 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrsl_close_shared_library(param1) privateOmrPortLibrary->sl_close_shared_library(privateOmrPortLibrary, (param1))
 #define omrsl_open_shared_library(param1,param2,param3) privateOmrPortLibrary->sl_open_shared_library(privateOmrPortLibrary, (param1), (param2), (param3))
 #define omrsl_lookup_name(param1,param2,param3,param4) privateOmrPortLibrary->sl_lookup_name(privateOmrPortLibrary, (param1), (param2), (param3), (param4))
+#define omrsl_get_libraries(callback, userData) privateOmrPortLibrary->sl_get_libraries(privateOmrPortLibrary, callback, userData)
 #define omrtty_startup() privateOmrPortLibrary->tty_startup(privateOmrPortLibrary)
 #define omrtty_shutdown() privateOmrPortLibrary->tty_shutdown(privateOmrPortLibrary)
 #define omrtty_printf(...) privateOmrPortLibrary->tty_printf(privateOmrPortLibrary, __VA_ARGS__)

--- a/port/aix/omrsl.c
+++ b/port/aix/omrsl.c
@@ -748,3 +748,20 @@ omrsl_startup(struct OMRPortLibrary *portLibrary)
 {
 	return 0;
 }
+
+/**
+ * Native Libraries
+ *
+ * This function is called to get all the shared libraries loaded by a process.
+ *
+ * @param[in] portLibrary Pointer to the OMR port library.
+ * @param[in] callback Function to be called for each library.
+ * @param[in] userData User-defined data passed to the callback.
+ *
+ * @return 0 if successful, or the first non-zero return value from the callback.
+ */
+uintptr_t
+omrsl_get_libraries(struct OMRPortLibrary *portLibrary, OMRLibraryInfoCallback callback, void *userData)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -139,6 +139,7 @@ static OMRPortLibrary MainPortLibraryTable = {
 	omrsl_close_shared_library, /* sl_close_shared_library */
 	omrsl_open_shared_library, /* sl_open_shared_library */
 	omrsl_lookup_name, /* sl_lookup_name */
+	omrsl_get_libraries, /* sl_get_libraries */
 	omrtty_startup, /* tty_startup */
 	omrtty_shutdown, /* tty_shutdown */
 	omrtty_printf, /* tty_printf */

--- a/port/common/omrport.tdf
+++ b/port/common/omrport.tdf
@@ -1635,3 +1635,5 @@ TraceEntry=Trc_PRT_sysinfo_get_process_start_time_enter Group=sysinfo Overhead=1
 TraceExit=Trc_PRT_sysinfo_get_process_start_time_exit Group=sysinfo Overhead=1 Level=1 NoEnv Template="Exit omrsysinfo_get_process_start_time, pid=%zu, processStartTimeInNanoseconds=%llu, rc=%d."
 
 TraceEvent=Trc_PRT_vmem_reserve_tempfile_not_created Group=mem Overhead=1 Level=5 NoEnv Template="reserve_memory cannot create temporary file %s of size %zu"
+
+TraceException=Trc_PRT_failed_to_open_proc_maps Group=sl Overhead=1 Level=1 NoEnv Template="Failed to open /proc/self/maps; error=%d"

--- a/port/common/omrsl.c
+++ b/port/common/omrsl.c
@@ -134,4 +134,19 @@ omrsl_startup(struct OMRPortLibrary *portLibrary)
 	return 0;
 }
 
-
+/**
+ * Native Libraries
+ *
+ * This function is called to get all the shared libraries loaded by a process.
+ *
+ * @param[in] portLibrary Pointer to the OMR port library.
+ * @param[in] callback Function to be called for each library.
+ * @param[in] userData User-defined data passed to the callback.
+ *
+ * @return 0 if successful, or the first non-zero return value from the callback.
+ */
+uintptr_t
+omrsl_get_libraries(struct OMRPortLibrary *portLibrary, OMRLibraryInfoCallback callback, void *userData)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -713,6 +713,8 @@ extern J9_CFUNC uintptr_t
 omrsl_open_shared_library(struct OMRPortLibrary *portLibrary, char *name, uintptr_t *descriptor, uintptr_t flags);
 extern J9_CFUNC void
 omrsl_shutdown(struct OMRPortLibrary *portLibrary);
+extern J9_CFUNC uintptr_t
+omrsl_get_libraries(struct OMRPortLibrary *portLibrary, OMRLibraryInfoCallback callback, void *userData);
 
 /* J9SourceJ9Sock*/
 extern J9_CFUNC int32_t

--- a/port/win32/omrsl.c
+++ b/port/win32/omrsl.c
@@ -463,3 +463,20 @@ findError(int32_t errorCode)
 		return OMRPORT_SL_UNKNOWN;
 	}
 }
+
+/**
+ * Native Libraries
+ *
+ * This function is called to get all the shared libraries loaded by a process.
+ *
+ * @param[in] portLibrary Pointer to the OMR port library.
+ * @param[in] callback Function to be called for each library.
+ * @param[in] userData User-defined data passed to the callback.
+ *
+ * @return 0 if successful, or the first non-zero return value from the callback.
+ */
+uintptr_t
+omrsl_get_libraries(struct OMRPortLibrary *portLibrary, OMRLibraryInfoCallback callback, void *userData)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}

--- a/port/zos390/omrsl.c
+++ b/port/zos390/omrsl.c
@@ -355,3 +355,19 @@ getDLError(struct OMRPortLibrary *portLibrary, char *errBuf, uintptr_t bufLen)
 	errBuf[bufLen - 1] = '\0';
 }
 
+/**
+ * Native Libraries
+ *
+ * This function is called to get all the shared libraries loaded by a process.
+ *
+ * @param[in] portLibrary Pointer to the OMR port library.
+ * @param[in] callback Function to be called for each library.
+ * @param[in] userData User-defined data passed to the callback.
+ *
+ * @return 0 if successful, or the first non-zero return value from the callback.
+ */
+uintptr_t
+omrsl_get_libraries(struct OMRPortLibrary *portLibrary, OMRLibraryInfoCallback callback, void *userData)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}


### PR DESCRIPTION
Use /proc file system to capture the dependent libraries.
Invoke the callback on each library.