### PR TITLE
Increase a couple of inliner thresholds

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2667,9 +2667,9 @@ OMR::Options::jitPreProcess()
 #elif defined(TR_HOST_S390)
    _bigCalleeThreshold = 600;
 #else
-   _bigCalleeThreshold = 400;
+   _bigCalleeThreshold = 500;
 #endif
-   _bigCalleeThresholdForColdCallsAtWarm = 400;
+   _bigCalleeThresholdForColdCallsAtWarm = 500;
    _bigCalleeThresholdForColdCallsAtHot = 500;
    _bigCalleeFreqCutoffAtWarm = 0;
    _bigCalleeHotOptThreshold = 600;


### PR DESCRIPTION
This commit increases the default value of `_bigCalleeThreshold` from 400 to 500 on x86 and the default value of
`_bigCalleeThresholdForColdCallsAtWarm` from 400 to 500 for all platforms. These changes were found to increase the throughput of some benchmarks slightly (1-2%) with a minimal increase in compilation time (2-3%).