### PR TITLE
Add function declarations in atoe.c for Open XL

### DIFF
--- a/util/a2e/atoe.c
+++ b/util/a2e/atoe.c
@@ -158,8 +158,10 @@ char e2a_tab[CONV_TABLE_SIZE];
  */
 #include "atoe.h"
 
-int   atoe_vsnprintf(char *str, size_t count, const char *fmt, va_list args);
-int   atoe_fprintf(FILE *, const char *, ...);
+int   atoe_fprintf(FILE *file, const char *fmt, ...);
+int   atoe_vfprintf(FILE *file, const char *fmt, va_list args);
+int   atoe_vsnprintf(char *buf, size_t buflen, const char *fmt, va_list args);
+int   atoe_vsprintf(char *buf, const char *fmt, va_list args);
 struct passwd *etoa_passwd(struct passwd *e_passwd);
 
 /*


### PR DESCRIPTION
Open XL on z/OS throws undeclared function errors when a function is used before it has been declared or defined. The changes here reorder the function definitions so that these errors are addressed.

i.e. The function definitions are moved above, so that their definitions are available before their respective usages.

```bash
/omr/util/a2e/atoe.c:1343:8: error: call to undeclared function 'atoe_vfprintf'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]                                                                                                              
 1343 |         len = atoe_vfprintf(file, ascii_chars, args);
      |               ^
      
omr/util/a2e/atoe.c:1362:8: error: call to undeclared function 'atoe_vfprintf'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
 1362 |         len = atoe_vfprintf(stdout, ascii_chars, args);
      |               ^
omr/util/a2e/atoe.c:1404:8: error: call to undeclared function 'atoe_vsprintf'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
 1404 |         len = atoe_vsprintf(buf, ascii_chars, args);
      |               ^

omr/util/a2e/atoe.c:1451:8: error: call to undeclared function 'atoe_vsprintf'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
 1451 |         len = atoe_vsprintf(buf, ascii_chars, args);
      |               ^
```
