### PR TITLE
Check for all interfaces implemented by java/lang/Class in VP

### DIFF
--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -610,11 +610,21 @@ TR_YesNoMaybe TR::VPClassType::isJavaLangClassObject()
    // it would make this look just like Class.class.
    if (_len == 17 && strncmp(_sig, "Ljava/lang/Class;", 17) == 0)
       return TR_maybe;
+
+   // If the type is java/lang/Object or an interface that is implemented
+   // by java/lang/Class, this may be the java/lang/Class object itself.
+   //
+   // java/lang/constant/Constable, java/lang/invoke/TypeDescriptor
+   // and java/lang/invoke/TypeDescriptor$OfField were introduced in JDK 12
+   //
    if ((_len == 18 && strncmp(_sig, "Ljava/lang/Object;", 18) == 0) ||
          (_len == 22 && strncmp(_sig, "Ljava/io/Serializable;", 22) == 0) ||
          (_len == 36 && strncmp(_sig, "Ljava/lang/reflect/AnnotatedElement;", 36) == 0) ||
          (_len == 38 && strncmp(_sig, "Ljava/lang/reflect/GenericDeclaration;", 38) == 0) ||
-         (_len == 24 && strncmp(_sig, "Ljava/lang/reflect/Type;", 24) == 0))
+         (_len == 24 && strncmp(_sig, "Ljava/lang/reflect/Type;", 24) == 0) ||
+         (_len == 30 && strncmp(_sig, "Ljava/lang/constant/Constable;", 30) == 0) ||
+         (_len == 33 && strncmp(_sig, "Ljava/lang/invoke/TypeDescriptor;", 33) == 0) ||
+         (_len == 41 && strncmp(_sig, "Ljava/lang/invoke/TypeDescriptor$OfField;", 41) == 0))
       return TR_maybe;
    return TR_no; // java.lang.Class is final and is the direct subclass of Object.
    }


### PR DESCRIPTION
Code in [`VPClassType::isJavaLangClassObject()`](https://github.com/eclipse-omr/omr/blob/edad43fbfc6393de2ff260f35227fe197e7d0c29/compiler/optimizer/VPConstraint.cpp#L606-L620) tests whether the `VPClassType` object refers to an instance of one of the interfaces that are known to be implemented by `java/lang/Class`.  The set of interfaces that were considered was incomplete, as it was missing interfaces that were added in JDK 12:

```
   java.lang.constant.Constable
   java.lang.invoke.TypeDescriptor
   java.lang.invoke.TypeDescriptor$OfField
```

That resulted in `VPClassType::isJavaLangClassObject()` returning `TR_no` for any reference that is known to be an instance of one of those interface classes rather than `TR_maybe`.

Fixes:  eclipse-openj9/openj9#21031