### PR TITLE
Remove useless #undef DWARF lines

### DIFF
--- a/include_core/omrcfg.h.in
+++ b/include_core/omrcfg.h.in
@@ -225,14 +225,6 @@
 #undef OMR_THR_YIELD_ALG
 
 /**
- * Dwarf
- */
-#undef HAVE_DWARF_H
-#undef HAVE_LIBDWARF_DWARF_H
-#undef HAVE_LIBDWARF_H
-#undef HAVE_LIBDWARF_LIBDWARF_H
-
-/**
  * Flag to enable integration of valgrind api.
  */
 #undef OMR_VALGRIND_MEMCHECK


### PR DESCRIPTION
Those lines disappear when producing `omrfcf.h` even if DDR is enabled. Cmake generates makefiles which define those macros as necessary.