### PR TITLE
Z: Ensure clean upper bits of arraycmplen result

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -15936,7 +15936,7 @@ OMR::Z::TreeEvaluator::arraycmpSIMDHelper(TR::Node *node,
       {
       if(isArrayCmpLen)
          {
-         generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, resultReg, lastByteIndexReg);
+         generateRRInstruction(cg, TR::InstOpCode::LGR, node, resultReg, lastByteIndexReg);
          }
       else
          {


### PR DESCRIPTION
The result of `arraycmplen` is 64 bits even in 31-bit mode, so we need to ensure that the upper 32 bits of the result do not contain any garbage.

Fixes https://github.com/eclipse-openj9/openj9/issues/21166