### PR TITLE
Stop VP from assuming that arrays are limited to INT32_MAX bytes

### DIFF
--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -1526,19 +1526,6 @@ TR::VPArrayInfo *TR::VPArrayInfo::create(OMR::ValuePropagation *vp, int32_t lowB
    return constraint;
    }
 
-TR::VPArrayInfo *TR::VPArrayInfo::create(OMR::ValuePropagation *vp, char *sig)
-   {
-   TR_ASSERT(*sig == '[', "expecting array signature");
-   TR::DataType d = TR::Symbol::convertSigCharToType(sig[1]);
-   int32_t stride;
-   if (d == TR::Address)
-      stride = TR::Compiler->om.sizeofReferenceField();
-   else
-      stride = TR::Symbol::convertTypeToSize(d);
-
-   return TR::VPArrayInfo::create(vp, 0, static_cast<int32_t>(TR::getMaxSigned<TR::Int32>()) / stride, stride);
-   }
-
 TR::VPMergedConstraints *TR::VPMergedConstraints::create(OMR::ValuePropagation *vp, TR::VPConstraint *first, TR::VPConstraint *second)
    {
    // If the constraint does not already exist, create it

--- a/compiler/optimizer/VPConstraint.hpp
+++ b/compiler/optimizer/VPConstraint.hpp
@@ -783,7 +783,6 @@ class VPArrayInfo : public TR::VPConstraint
       : TR::VPConstraint(ArrayInfoPriority), _lowBound(lowBound), _highBound(highBound), _elementSize(elementSize)
       {}
    static TR::VPArrayInfo *create(OMR::ValuePropagation *vp, int32_t lowBound, int32_t highBound, int32_t elementSize);
-   static TR::VPArrayInfo *create(OMR::ValuePropagation *vp, char *sig);
    virtual TR::VPArrayInfo *asArrayInfo();
 
    virtual TR::VPConstraint *merge1(TR::VPConstraint *other, OMR::ValuePropagation *vp);

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -12256,8 +12256,14 @@ TR::Node *constrainBndChkWithSpineChk(OMR::ValuePropagation *vp, TR::Node *node)
    //
    if (sizeNode->getOpCode().isArrayLength())
       {
+      // Get the low bound from the new index constraint. If n is the length
+      // and i is the index, then we know that n > i >= low, so n >= low + 1.
+      // Leave high unchanged because the high bound from indexConstraint is
+      // uninformative.
+      low = constraint->getLowInt();
+
       TR::Node *objectRef = sizeNode->getFirstChild();
-      vp->addBlockConstraint(objectRef, TR::VPArrayInfo::create(vp, low, high + 1, 0));
+      vp->addBlockConstraint(objectRef, TR::VPArrayInfo::create(vp, low + 1, high + 1, 0));
       }
 
    return node;

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2567,7 +2567,7 @@ TR::Node *constrainAloadi(OMR::ValuePropagation *vp, TR::Node *node)
                         vp->comp(), classBlock);
 
                   constraint = TR::VPClass::create(vp, (TR::VPClassType*)constraint, NULL, NULL,
-                        TR::VPArrayInfo::create(vp, 0, TR::getMaxSigned<TR::Int32>() / elementSize, elementSize),
+                        TR::VPArrayInfo::create(vp, 0, TR::Compiler->om.maxArraySizeInElements(elementSize, vp->comp()), elementSize),
                         TR::VPObjectLocation::create(vp, TR::VPObjectLocation::NotClassObject));
                   }
                }
@@ -12207,19 +12207,14 @@ TR::Node *constrainBndChkWithSpineChk(OMR::ValuePropagation *vp, TR::Node *node)
    //    2) its high bound must be (maximum array size-1)
    // -------------------------------------------------------------------------
 
-   uint32_t elementSize = 1;
+   int32_t elementSize = 1;
    if (sizeNode->getOpCode().isArrayLength())
       {
       elementSize = sizeNode->getArrayStride();
       }
 
    int32_t low = 0;
-   int32_t high = static_cast<int32_t>(TR::getMaxSigned<TR::Int32>());
-
-   if (elementSize > 0)
-      {
-      high = high/elementSize - 1;
-      }
+   int32_t high = (int32_t)TR::Compiler->om.maxArraySizeInElements(elementSize, vp->comp()) - 1;
 
    // Calculate the new constraint for the index value.  If it is null, we
    // will definitely fail the bndchk
@@ -12262,7 +12257,7 @@ TR::Node *constrainBndChkWithSpineChk(OMR::ValuePropagation *vp, TR::Node *node)
    if (sizeNode->getOpCode().isArrayLength())
       {
       TR::Node *objectRef = sizeNode->getFirstChild();
-      vp->addBlockConstraint(objectRef, TR::VPArrayInfo::create(vp, low, high, 0));
+      vp->addBlockConstraint(objectRef, TR::VPArrayInfo::create(vp, low, high + 1, 0));
       }
 
    return node;
@@ -12305,7 +12300,7 @@ TR::Node *constrainArrayCopyBndChk(OMR::ValuePropagation *vp, TR::Node *node)
    //    3) The lhs low bound >= the rhs low bound
    //    3) The rhs high bound <= the lhs high bound
    //
-   uint32_t elementSize = 1;
+   int32_t elementSize = 1;
    bool isArrayLengthCheck = false;
    if (lhsNode->getOpCode().isArrayLength())
       {
@@ -12314,9 +12309,7 @@ TR::Node *constrainArrayCopyBndChk(OMR::ValuePropagation *vp, TR::Node *node)
       }
 
    int32_t low = 0;
-   int32_t high = static_cast<int32_t>(TR::getMaxSigned<TR::Int32>());
-   if (elementSize > 0)
-      high = high/elementSize-1;
+   int32_t high = (int32_t)TR::Compiler->om.maxArraySizeInElements(elementSize, vp->comp());
 
    if (lhs && lhs->getHighInt() < high)
       high = lhs->getHighInt();

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -12207,8 +12207,6 @@ TR::Node *constrainBndChkWithSpineChk(OMR::ValuePropagation *vp, TR::Node *node)
    //    2) its high bound must be (maximum array size-1)
    // -------------------------------------------------------------------------
 
-   bool isSizeContigArrayLength = true; //(sizeNode->getOpCodeValue() == TR::contigarraylength) ? true : false;
-
    uint32_t elementSize = 1;
    if (sizeNode->getOpCode().isArrayLength())
       {
@@ -12218,11 +12216,7 @@ TR::Node *constrainBndChkWithSpineChk(OMR::ValuePropagation *vp, TR::Node *node)
    int32_t low = 0;
    int32_t high = static_cast<int32_t>(TR::getMaxSigned<TR::Int32>());
 
-   if (sizeConstraint && !isSizeContigArrayLength)
-      {
-      high = sizeConstraint->getHighInt() - 1;
-      }
-   else if (elementSize > 0)
+   if (elementSize > 0)
       {
       high = high/elementSize - 1;
       }
@@ -12233,44 +12227,26 @@ TR::Node *constrainBndChkWithSpineChk(OMR::ValuePropagation *vp, TR::Node *node)
    TR::VPConstraint *constraint = NULL;
    bool foundArrayInfo = false;
 
-   if (isSizeContigArrayLength)
+   // See if the underlying array has bound limits
+   //
+   if (objConstraint)
       {
-      // See if the underlying array has bound limits
-      //
-      TR::Node *objectRef = node->getChild(arrayChildNum);
-      bool isGlobal;
-      TR::VPConstraint *objConstraint = vp->getConstraint(objectRef, isGlobal);
-
-      if (objConstraint)
+      TR::VPArrayInfo *arrayInfo = objConstraint->getArrayInfo();
+      if (arrayInfo)
          {
-         TR::VPArrayInfo *arrayInfo = objConstraint->getArrayInfo();
-         if (arrayInfo)
-            {
-            int32_t lowerBoundLimit = arrayInfo->lowBound();
-            int32_t upperBoundLimit = arrayInfo->highBound();
-            constraint = TR::VPIntRange::create(vp, 0, upperBoundLimit-1);
-            foundArrayInfo = true;
-            }
+         int32_t upperBoundLimit = arrayInfo->highBound();
+         constraint = TR::VPIntRange::create(vp, 0, upperBoundLimit-1);
+         foundArrayInfo = true;
          }
-
-      if (!constraint)
-         constraint = TR::VPIntRange::create(vp, low, high);
-
-      if (indexConstraint && constraint)
-         constraint = indexConstraint->intersect(constraint, vp);
       }
-   else if (low <= high)
-      {
+
+   if (!constraint)
       constraint = TR::VPIntRange::create(vp, low, high);
 
-      if (indexConstraint && constraint)
-         constraint = indexConstraint->intersect(constraint, vp);
-      }
-   else
-      constraint = NULL;
+   if (indexConstraint && constraint)
+      constraint = indexConstraint->intersect(constraint, vp);
 
-   if (/* (!isSizeContigArrayLength || foundArrayInfo) && */
-       (!constraint || (indexConstraint && indexConstraint->getLowInt() >= high+1)))
+   if (!constraint || (indexConstraint && indexConstraint->getLowInt() >= high + 1))
       {
       // Everything past this point in the block is dead, since the exception
       // will always be taken.
@@ -12279,57 +12255,7 @@ TR::Node *constrainBndChkWithSpineChk(OMR::ValuePropagation *vp, TR::Node *node)
       return node;
       }
 
-
    vp->addBlockConstraint(indexNode, constraint);
-
-   // -------------------------------------------------------------------------
-   // We can make an assertion about the minimum array size.  It must be at
-   // least as large as the low end of the index range + 1.
-   // -------------------------------------------------------------------------
-
-   if (!isSizeContigArrayLength)
-      {
-      // Contiguous arraylengths with a lower bound of zero imply the array may be
-      // discontiguous and hence the lower bound must remain at zero.
-      //
-      low = constraint->getLowInt();
-      if (!isSizeContigArrayLength || (low > 0))
-         low++;
-
-      high = static_cast<int32_t>(TR::getMaxSigned<TR::Int32>());
-      if (elementSize > 0)
-         {
-         high = high/elementSize;
-         }
-
-      constraint =  TR::VPIntRange::create(vp, low, high);
-
-      if (sizeConstraint)
-         {
-         constraint =  TR::VPIntRange::create(vp, low, high);
-         constraint = sizeConstraint->intersect(constraint, vp);
-         }
-
-      vp->addBlockConstraint(sizeNode, constraint);
-      }
-
-#if 0
-//-----------------------------------------------
-   // We can make an assertion about the minimum array size. It must be at least
-   // as large as the low end of the index range + 1.
-   //
-   low = constraint->getLowInt()+1;
-
-   high = TR::getMaxSigned<TR::Int32>();
-   if (elementSize > 0)
-      high = high/elementSize;
-   constraint =  TR::VPIntRange::create(vp, low, high);
-   if (size)
-     constraint = size->intersect(constraint, vp);
-
-   vp->addBlockConstraint(sizeNode, constraint);
-//----------------------------------------------------------
-#endif
 
    // Propagate the array size down to the underlying array object
    //


### PR DESCRIPTION
...and therefore at most `INT32_MAX` / `elementSize` elements. This could result in incorrect transformations, e.g. incorrect comparison folding.

These are (hopefully all of the) additional instances of the bug fixed in #7461.

Furthermore, there are two clean-up commits that delete dead code containing what would otherwise be additional instances of this bug:
- Delete unused signature-based overload of `VPArrayInfo::create()`.
- Clean up code in `constrainBndChkWithSpineChk()`

Review resulted in one more commit:
- VP: Propagate index lower bound to array length for `BNDCHKwithSpineCHK`