### PR TITLE
Use right owning method symbol for arraycopies

### DIFF
--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -1571,7 +1571,8 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
          }
 #endif
 
-      bool canSkipAllChecksOnArrayCopy = methodSymbol->safeToSkipChecksOnArrayCopies() || isRecognizedMultiLeafArrayCopy || isStringCompressedArrayCopy || isStringDecompressedArrayCopy;
+      bool canSkipAllChecksOnArrayCopy = comp()->getOwningMethodSymbol(node->getOwningMethod())->safeToSkipChecksOnArrayCopies() || isRecognizedMultiLeafArrayCopy || isStringCompressedArrayCopy || isStringDecompressedArrayCopy;
+
 
       if (!canSkipAllChecksOnArrayCopy)
          {


### PR DESCRIPTION
Arraycopy transformation in value propagation should check if checks can be skipped on the right owning method symbol. Previously, it was checking the method being compiled, whereas it should be checking the owning method on the arraycopy call node.