### PR TITLE
Changes to generate DDR with OpenXL on AIX

### DIFF
--- a/ddr/lib/ddr-scanner/CMakeLists.txt
+++ b/ddr/lib/ddr-scanner/CMakeLists.txt
@@ -63,9 +63,14 @@ elseif(OMR_OS_OSX)
 			dwarf/DwarfScanner.cpp
 	)
 elseif(OMR_OS_AIX)
+	if(CMAKE_C_COMPILER_IS_OPENXL)
+		target_sources(omr_ddr_scanner PRIVATE dwarf/DwarfParser.cpp)
+	else()
+		target_sources(omr_ddr_scanner PRIVATE dwarf/AixSymbolTableParser.cpp)
+	endif()
+
 	target_sources(omr_ddr_scanner
 		PRIVATE
-			dwarf/AixSymbolTableParser.cpp
 			dwarf/DwarfFunctions.cpp
 			dwarf/DwarfScanner.cpp
 	)

--- a/ddr/lib/ddr-scanner/dwarf/DwarfParser.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfParser.cpp
@@ -117,8 +117,16 @@ dwarf_init(int fd,
 	 * newer compiler versions, so we prefer the more modern dwarfdump.
 	 */
 	char *toolpath = NULL;
-	if (findTool(&toolpath, "xcrun -f dwarfdump 2>/dev/null")
+
+	if (
+#if defined(AIXPPC)
+		// AIX with OpenXL
+		findTool(&toolpath, "which llvm-dwarfdump 2>/dev/null")
+#else /* defined (AIXPPC) */
+		// macOS
+		findTool(&toolpath, "xcrun -f dwarfdump 2>/dev/null")
 	||  findTool(&toolpath, "xcrun -f dwarfdump-classic 2>/dev/null")
+#endif /* defined (AIXPPC) */
 	) {
 		stringstream command;
 		command << toolpath << " " << DwarfScanner::getScanFileName() << " 2>&1";

--- a/include_core/omr.h
+++ b/include_core/omr.h
@@ -555,8 +555,7 @@ const char * const *OMR_Glue_GetMethodDictionaryPropertyNames(void);
  * (__xlC__ is defined by xlC_r, __ibmxl_version__ is defined by xlclang++).
  */
 #if (defined(__xlC__) && ((__xlC__ >> 8) >= 16)) \
- || (defined(__ibmxl_version__) && (__ibmxl_version__ >= 16)) \
- || defined(__open_xl__)
+ || (defined(__ibmxl_version__) && (__ibmxl_version__ >= 16))
 #define ddr_constant(name, value) static enum { name = value } ddr_ref_ ## name
 #else /* defined(__ibmxl_version__) && (__ibmxl_version__ >= 16) */
 #define ddr_constant(name, value)        enum { name = value }


### PR DESCRIPTION
Previously, when OpenJ9 builds on AIX were done with xlC16 as the C/C++ compiler, debugging information was generated in the stabstring format. However, with the switch to OpenXL17, stabstrings are no longer supported, and debug info can only be generated in DWARF format. Since libdwarf, the library used to parse DWARF format debug info on other platforms, is not available on AIX, we cannot read this information directly. Instead, we must parse the output given by dwarfdump, as is currently being done on macOS.