### PR TITLE
Update to an in support cuda container

### DIFF
--- a/buildenv/docker/x86_64/ubuntu/Dockerfile
+++ b/buildenv/docker/x86_64/ubuntu/Dockerfile
@@ -20,9 +20,9 @@
 
 # Create the OMR build environment with Ubuntu 20.04.
 
-FROM nvidia/cuda:9.0-devel-ubuntu16.04 AS cuda-dev
+FROM nvcr.io/nvidia/cuda:12.2.0-devel-ubi8 as cuda
 
-FROM ubuntu:20.04 AS base
+FROM public.ecr.aws/lts/ubuntu:22.04_stable AS base
 
 # Workaround for a hang during docker build.
 ENV TZ=America/Toronto
@@ -39,10 +39,10 @@ RUN apt-get update && apt-get install -y \
         libdwarf-dev \
         gdb \
         vim \
-        gcc-7-multilib \
-        g++-7-multilib \
-        gcc-7 \
-        g++-7 \
+        gcc-11-multilib \
+        g++-11-multilib \
+        gcc-11 \
+        g++-11 \
         ninja-build \
         ccache \
         && rm -rf /var/lib/apt/lists/*
@@ -56,10 +56,10 @@ RUN groupadd -r jenkins \
 
 # Copy header files necessary to build with CUDA support.
 RUN mkdir -p /usr/local/cuda/nvvm
-COPY --from=cuda-dev /usr/local/cuda-9.0/include /usr/local/cuda/include
-COPY --from=cuda-dev /usr/local/cuda-9.0/nvvm/include /usr/local/cuda/nvvm/include
+COPY --from=cuda /usr/local/cuda/include /usr/local/cuda/include
+COPY --from=cuda /usr/local/cuda/nvvm/include /usr/local/cuda/nvvm/include
 
 USER jenkins
 ENV CUDA_HOME=/usr/local/cuda
 
-ENV CC=gcc-7 CXX=g++-7
+ENV CC=gcc-11 CXX=g++-11

--- a/buildenv/jenkins/omrbuild.groovy
+++ b/buildenv/jenkins/omrbuild.groovy
@@ -35,7 +35,7 @@ dockerImageName = (params.IMAGE_NAME) ? params.IMAGE_NAME : "buildomr"
  * Move the below parameters into SPECS while implementing a generic
  * approach to support Dockerfiles.
  */
-os = (params.OS) ? params.OS : "ubuntu20"
+os = (params.OS) ? params.OS : "ubuntu"
 arch = (params.ARCH) ? params.ARCH : "x86_64"
 
 buildSpec = (params.BUILDSPEC) ? params.BUILDSPEC : error("BUILDSPEC not specified")


### PR DESCRIPTION
Pull from Nvidia registry to avoid any DockerHub restrictions.
Bump cuda level from 9.0 to 12.2.0 which matches level used by OpenJ9.
Change from Ubuntu16 to ubi8 to match OpenJ9 as well as provide
support for plinux if needed in the future.

Bump from ub20 to ub22 for base image.
Also pull from Amazon registry to avoid any DockerHub restrictions

Issue automation 72
