### PR TITLE
Define trivialInliningOnly() in TR_InlinerBase and OMR_InlinerPolicy

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -4763,6 +4763,17 @@ bool OMR_InlinerPolicy::tryToInlineTrivialMethod (TR_CallStack* callStack, TR_Ca
    return false;
    }
 
+bool TR_InlinerBase::trivialInliningOnly(
+   TR_CallStack *callStack, TR_CallTarget *callTarget)
+   {
+   return getPolicy()->trivialInliningOnly(callStack, callTarget);
+   }
+
+bool OMR_InlinerPolicy::trivialInliningOnly(TR_CallStack* callStack, TR_CallTarget* calltarget)
+   {
+   return false;
+   }
+
 //returns false when inlining fails
 //TODO: currently this method returns true in some cases when the inlining fails. This needs to be fixed
 bool TR_InlinerBase::inlineCallTarget2(TR_CallStack * callStack, TR_CallTarget *calltarget, TR::TreeTop** cursorTreeTop, bool inlinefromgraph, int32_t)
@@ -4788,6 +4799,11 @@ bool TR_InlinerBase::inlineCallTarget2(TR_CallStack * callStack, TR_CallTarget *
 
    if (tryToInlineTrivialMethod(callStack, calltarget))
       return true;
+
+   if (trivialInliningOnly(callStack, calltarget))
+      {
+      return false;
+      }
 
    if (comp()->getOption(TR_InlineNativeOnly))
       return false;

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -348,6 +348,16 @@ class TR_InlinerBase: public TR_HasRandomGenerator
       //inlineCallTarget2 methods
       bool tryToInlineTrivialMethod (TR_CallStack* callStack, TR_CallTarget* calltarget);
 
+      /**
+       * \brief Determine whether \p callTarget can be inlined only by
+       * tryToInlineTrivialMethod().
+       *
+       * \param callStack the inlined call stack
+       * \param callTarget the call target
+       * \return true if regular IL gen and inlining must be avoided, false otherwise
+       */
+      bool trivialInliningOnly(TR_CallStack *callStack, TR_CallTarget *callTarget);
+
       bool tryToGenerateILForMethod (TR::ResolvedMethodSymbol* calleeSymbol, TR::ResolvedMethodSymbol* callerSymbol, TR_CallTarget* calltarget);
 
       void inlineFromGraph(TR_CallStack *, TR_CallTarget *calltarget, TR_InnerPreexistenceInfo *);
@@ -661,6 +671,7 @@ class OMR_InlinerPolicy : public TR::OptimizationPolicy, public OMR_InlinerHelpe
 
    protected:
       virtual bool tryToInlineTrivialMethod (TR_CallStack* callStack, TR_CallTarget* calltarget);
+      virtual bool trivialInliningOnly(TR_CallStack* callStack, TR_CallTarget* calltarget);
       virtual bool alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::Node *callNode);
       virtual void determineInliningHeuristic(TR::ResolvedMethodSymbol *callerSymbol);
       bool tryToInlineGeneral(TR_CallTarget *, TR_CallStack *, bool);


### PR DESCRIPTION
Some targets are meant to be handled by `tryToInlineTrivialMethod()` and cannot be inlined by generating IL in the usual way. So far the implementation of `tryToInlineTrivialMethod()` has been required to return true for such targets even in cases where the call is not transformed.

This new method provides a way to tell the inliner that a given target should have been handled by `tryToInlineTrivialMethod()` and that IL generation should not be attempted. If the inliner is informed in this way, then it will be possible for `tryToInlineTrivialMethod()` to return false when it fails.