### PR TITLE
In splitPostGRA(), find the GlRegDeps for switch children correctly

### DIFF
--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -1418,7 +1418,7 @@ OMR::Block::splitPostGRA(TR::TreeTop * startOfNewBlock, TR::CFG *cfg, bool copyE
                TR::Node *branch = node->getChild(i);
                if (branch->getOpCode().isBranch() && branch->getNumChildren() > 0)
                   {
-                  TR::Node *regDeps = node->getChild(node->getNumChildren() - 1);
+                  TR::Node *regDeps = branch->getChild(branch->getNumChildren() - 1);
                   if (regDeps->getOpCodeValue() == TR::GlRegDeps)
                      {
                      gatherUnavailableRegisters(comp, regDeps, iter, nodeInfo, storeNodeInfo, &storeRegNodePostSplitPoint, unavailableRegisters);


### PR DESCRIPTION
We've been looking for `GlRegDeps` as the last child of `node`, which is the top-level switch node, when we should have instead been looking at the last child of `branch`, i.e. the last child of the child of `node`.

This caused `splitPostGRA()` to completely ignore `GlRegDeps` beneath switch nodes, which could result in failure to generate a register store. Without a register store, the `GlRegDeps` could end up with a `PassThrough` whose child doesn't occur in any prior tree.

Fixes eclipse-openj9/openj9#21148