### PR TITLE
Fix for test failure: java/foreign/TestClassLoaderFindNative.java

### DIFF
--- a/port/zos390/omrsl.c
+++ b/port/zos390/omrsl.c
@@ -287,6 +287,9 @@ omrsl_lookup_name(struct OMRPortLibrary *portLibrary, uintptr_t descriptor, char
 	{
 		handle = (dllhandle *)descriptor;
 		address = (void *)dllqueryfn(handle, name);
+		if (NULL == address) {
+			address = (void *)dllqueryvar(handle, name);
+		}
 	}
 
 	if (address == NULL) {


### PR DESCRIPTION
Update `j9sl_lookup_name` to work for both function and variable lookup.

These changes address the failure of testcase on z/os: [java/foreign/TestClassLoaderFindNative.java](https://github.com/ibmruntimes/openj9-openjdk-jdk21/blob/openj9/test/jdk/java/foreign/TestClassLoaderFindNative.java)
- Added call to `dllqueryvar` for variable lookup
