### PR TITLE
Make MM_MemoryHandle methods be public

### DIFF
--- a/gc/base/MemoryHandle.hpp
+++ b/gc/base/MemoryHandle.hpp
@@ -43,6 +43,7 @@ public:
 	 */
 private:
 protected:
+public:
 	/**
 	 * Set _virtualMemory field
 	 * @param virtualMemory virtual memory pointer to set
@@ -97,7 +98,6 @@ protected:
 		return _memoryTop;
 	}
 
-public:
 	MM_MemoryHandle()
 		: _virtualMemory(NULL)
 		, _memoryBase(NULL)


### PR DESCRIPTION
Currently methods of MM_MemoryHandle are protected. It is not necessary to be so strict and it adds more flexibility to make them public.