### PR TITLE
Remove isdigit macro redefs, replace with OMR_ISDIGIT

### DIFF
--- a/cmake/modules/platform/os/zos.cmake
+++ b/cmake/modules/platform/os/zos.cmake
@@ -20,6 +20,7 @@
 #############################################################################
 
 list(APPEND OMR_PLATFORM_DEFINITIONS
+	-D_AE_BIMODAL
 	-D_ALL_SOURCE
 	-DJ9ZOS390
 	-DLONGLONG

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1377,7 +1377,7 @@ OMR::Options::getNumericValue(const char *& option)
    while (pendingOperation)
       {
       int64_t current = 0;
-      while (isdigit(*option))
+      while (OMR_ISDIGIT(*option))
          {
          current = 10 * current + *option - '0';
          option++;
@@ -3427,7 +3427,7 @@ OMR::Options::processOptionSet(
             options++;
             //assume this is a digit
             value=0;
-            while (isdigit(*options))
+            while (OMR_ISDIGIT(*options))
                {
                value = 10 * value + *options - '0';
                options++;
@@ -3444,7 +3444,7 @@ OMR::Options::processOptionSet(
                options++;
                //assume this is a digit
                value=0;
-               while (isdigit(*options))
+               while (OMR_ISDIGIT(*options))
                   {
                   value = 10*value + *options - '0';
                   options++;
@@ -4391,10 +4391,10 @@ OMR::Options::setCounts()
          {
          while (s[0] == ' ')
             ++s;
-         if (isdigit(s[0]))
+         if (OMR_ISDIGIT(s[0]))
             {
             count[i] = atoi(s);
-            while(isdigit(s[0]))
+            while (OMR_ISDIGIT(s[0]))
                ++s;
             if (initialCount >= 0)
                {
@@ -4416,10 +4416,10 @@ OMR::Options::setCounts()
             count[i] = -1;
          while (s[0] == ' ')
             ++s;
-         if (isdigit(s[0]))
+         if (OMR_ISDIGIT(s[0]))
             {
             bcount[i] = atoi(s);
-            while(isdigit(s[0]))
+            while (OMR_ISDIGIT(s[0]))
                ++s;
             if (initialBCount >= 0)
                {
@@ -4439,10 +4439,10 @@ OMR::Options::setCounts()
          bcount[i] = -1;
          while (s[0] == ' ')
             ++s;
-         if (isdigit(s[0]))
+         if (OMR_ISDIGIT(s[0]))
             {
             milcount[i] = atoi(s);
-            while(isdigit(s[0]))
+            while (OMR_ISDIGIT(s[0]))
                ++s;
             if (initialMILCount >= 0)
                {

--- a/compiler/ras/LimitFile.cpp
+++ b/compiler/ras/LimitFile.cpp
@@ -544,10 +544,10 @@ TR_Debug::limitfileOption(const char *option, void *base, TR::OptionTable *entry
                }
 
             int32_t randNum;
-            while (isdigit(p[0]))
+            while (OMR_ISDIGIT(p[0]))
                {
                randNum = atoi(p);
-               while(isdigit(p[0]))
+               while(OMR_ISDIGIT(p[0]))
                   ++p;
 
                if (isNegative)

--- a/ddr/include/ddr/std/sstream.hpp
+++ b/ddr/include/ddr/std/sstream.hpp
@@ -24,19 +24,6 @@
 
 #include "ddr/config.hpp"
 
-#if defined(J9ZOS390)
-
 #include <ctype.h>
-#undef toupper
-#undef tolower
-
 #include <sstream>
-
-#define toupper(c)     (islower(c) ? (c & _XUPPER_ASCII) : c)
-#define tolower(c)     (isupper(c) ? (c | _XLOWER_ASCII) : c)
-
-#else /* defined(J9ZOS390) */
-#include <sstream>
-#endif /* defined(J9ZOS390) */
-
 #endif /* SSTREAM_HPP */

--- a/ddr/include/ddr/std/string.hpp
+++ b/ddr/include/ddr/std/string.hpp
@@ -24,19 +24,6 @@
 
 #include "ddr/config.hpp"
 
-#if defined(J9ZOS390)
-
 #include <ctype.h>
-#undef toupper
-#undef tolower
-
 #include <string>
-
-#define toupper(c)     (islower(c) ? (c & _XUPPER_ASCII) : c)
-#define tolower(c)     (isupper(c) ? (c | _XLOWER_ASCII) : c)
-
-#else /* defined(J9ZOS390) */
-#include <string>
-#endif /* defined(J9ZOS390) */
-
 #endif /* STRING_HPP */

--- a/ddr/include/ddr/std/unordered_map.hpp
+++ b/ddr/include/ddr/std/unordered_map.hpp
@@ -24,12 +24,7 @@
 
 #include "ddr/config.hpp"
 
-#if defined(J9ZOS390)
 #include <ctype.h>
-#undef toupper
-#undef tolower
-#endif /* defined(J9ZOS390) */
-
 #include <unordered_map>
 
 #if defined(OMR_HAVE_CXX11)
@@ -37,10 +32,5 @@ using std::unordered_map;
 #else /* defined(OMR_HAVE_CXX11) */
 using std::tr1::unordered_map;
 #endif /* defined(OMR_HAVE_CXX11) */
-
-#if defined(J9ZOS390)
-#define toupper(c)     (islower(c) ? (c & _XUPPER_ASCII) : c)
-#define tolower(c)     (isupper(c) ? (c | _XLOWER_ASCII) : c)
-#endif /* defined(J9ZOS390) */
 
 #endif /* DDR_UNORDERED_MAP */

--- a/fvtest/omrGtestGlue/omrGtest.cpp
+++ b/fvtest/omrGtestGlue/omrGtest.cpp
@@ -26,15 +26,5 @@
  * So we explicitly include <ctype.h> and undefine the macros for gtest, after gtest we then define back the macros.
  */
 #include <ctype.h>
-#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
-#undef toupper
-#undef tolower
 
 #include "gtest-all.cc"
-
-#define toupper(c)     (islower(c) ? (c & _XUPPER_ASCII) : c)
-#define tolower(c)     (isupper(c) ? (c | _XLOWER_ASCII) : c)
-
-#else
-#include "gtest-all.cc"
-#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */

--- a/fvtest/omrGtestGlue/omrTest.h
+++ b/fvtest/omrGtestGlue/omrTest.h
@@ -30,24 +30,8 @@ extern int iconv_initialization(void);
 static int iconv_init_static_variable = iconv_initialization();
 #endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 
-
-#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
-/*  Gtest invokes xlocale, which has function definition for tolower and toupper.
- * This causes compilation issue since the a2e macros (tolower and toupper) automatically replace the function definitions.
- * So we explicitly include <ctype.h> and undefine the macros for gtest, after gtest we then define back the macros.
- */
 #include <ctype.h>
-#undef toupper
-#undef tolower
-
 #include "gtest/gtest.h"
-
-#define toupper(c)     (islower(c) ? (c & _XUPPER_ASCII) : c)
-#define tolower(c)     (isupper(c) ? (c | _XLOWER_ASCII) : c)
-
-#else
-#include "gtest/gtest.h"
-#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 
 using namespace testing;
 

--- a/include_core/omrcomp.h
+++ b/include_core/omrcomp.h
@@ -613,4 +613,10 @@ typedef struct U_128 {
 #endif /* defined(__GNUC__) && (__GNUC__ < 5) */
 #endif /* defined(__cplusplus) && (__cplusplus >= 201103L) */
 
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
+#define OMR_ISDIGIT(x) __isdigit_a(x)
+#else /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
+#define OMR_ISDIGIT(x) isdigit(x)
+#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
+
 #endif /* OMRCOMP_H */

--- a/util/a2e/headers/ctype.h
+++ b/util/a2e/headers/ctype.h
@@ -80,7 +80,6 @@
                 #define isalnum(c)     (_IN_RANGE(c) ? (_ascii_is_tab[c] & _ISALNUM_ASCII) : 0)
                 #define isalpha(c)     (_IN_RANGE(c) ? (_ascii_is_tab[c] & _ISALPHA_ASCII) : 0)
                 #define iscntrl(c)     (_IN_RANGE(c) ? (_ascii_is_tab[c] & _ISCNTRL_ASCII) : 0)
-                #define isdigit(c)     (_IN_RANGE(c) ? (_ascii_is_tab[c] & _ISDIGIT_ASCII) : 0)
                 #define isgraph(c)     (_IN_RANGE(c) ? (_ascii_is_tab[c] & _ISGRAPH_ASCII) : 0)
                 #define islower(c)     (_IN_RANGE(c) ? (_ascii_is_tab[c] & _ISLOWER_ASCII) : 0)
                 #define isprint(c)     (_IN_RANGE(c) ? (_ascii_is_tab[c] & _ISPRINT_ASCII) : 0)
@@ -88,12 +87,6 @@
                 #define isspace(c)     (_IN_RANGE(c) ? (_ascii_is_tab[c] & _ISSPACE_ASCII) : 0)
                 #define isupper(c)     (_IN_RANGE(c) ? (_ascii_is_tab[c] & _ISUPPER_ASCII) : 0)
                 #define isxdigit(c)    (_IN_RANGE(c) ? (_ascii_is_tab[c] & _ISXDIGIT_ASCII) : 0)
-
-                /*
-                 *  In ASCII, upper case characters have the bit off    ibm@4345
-                 */
-                #define toupper(c)     (islower(c) ? (c & _XUPPER_ASCII) : c)
-                #define tolower(c)     (isupper(c) ? (c | _XLOWER_ASCII) : c)
 
         #endif
 


### PR DESCRIPTION
Changes here remove the redefinition of isdigit() in
the a2e ctype.h headers. In order to fully make this
work functionally, the references/usages of isdigit()
are replaced with OMR_ISDIGIT to properly recognize
ascii digit literals. This is done by conditionally
using __isdigit_a() on z/OS platforms.

---

This is the cleaned-up changes from https://github.com/eclipse-omr/omr/pull/7413 (for historical related comments)