### PR TITLE
Add verbose options for shared profile cache

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -5063,7 +5063,9 @@ const char *OMR::Options::_verboseOptionNames[TR_NumVerboseOptions] =
    "RSSReport",
    "RSSReportDetailed",
    "dependencyTracking",
-   "dependencyTrackingDetails"
+   "dependencyTrackingDetails",
+   "JITServerSharedProfile",
+   "JITServerSharedProfileDetails"
    };
 
 

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1076,6 +1076,8 @@ enum TR_VerboseFlags
    TR_VerboseRSSReportDetailed,
    TR_VerboseDependencyTracking,
    TR_VerboseDependencyTrackingDetails,
+   TR_VerboseJITServerSharedProfile,
+   TR_VerboseJITServerSharedProfileDetails,
    //If adding new options add an entry to _verboseOptionNames as well
    TR_NumVerboseOptions        // Must be the last one;
    };


### PR DESCRIPTION
Added -Xjit:verbose={JITServerSharedProfile} and
-Xjit:verbose={JITServerSharedProfileDetails} options to be used in an downstream project.