### PR TITLE
Make hash computation consistent with comment

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -917,10 +917,10 @@ static void stopBeforeCompile()
 
 static int32_t strHash(const char *str)
    {
-   // The string hash from Java
+   // The string hash from Java.
    int32_t result = 0;
-   for (const unsigned char *s = reinterpret_cast<const unsigned char*>(str); *s; s++)
-      result = result * 33 + *s;
+   for (const unsigned char *s = reinterpret_cast<const unsigned char *>(str); '\0' != *s; ++s)
+      result = (result * 31) + *s;
    return result;
    }
 


### PR DESCRIPTION
The comment declares that the function computes the same hash as Java `String.hashCode()` - this updates the multiplier from 33 to 31 so that assertion is true.