### PR TITLE
Force offheap region size alignment and granularity

### DIFF
--- a/gc/base/SparseVirtualMemory.cpp
+++ b/gc/base/SparseVirtualMemory.cpp
@@ -30,8 +30,6 @@
 #include "Forge.hpp"
 #include "GCExtensionsBase.hpp"
 #include "Math.hpp"
-#include "Heap.hpp"
-#include "HeapRegionManager.hpp"
 #include "ModronAssertions.h"
 #include "SparseVirtualMemory.hpp"
 #include "SparseAddressOrderedFixedSizeDataPool.hpp"

--- a/gc/base/SparseVirtualMemory.hpp
+++ b/gc/base/SparseVirtualMemory.hpp
@@ -34,6 +34,8 @@
 #include "modronopt.h"
 
 #include "BaseVirtual.hpp"
+#include "Heap.hpp"
+#include "HeapRegionManager.hpp"
 #include "VirtualMemory.hpp"
 
 class MM_GCExtensions;
@@ -68,16 +70,16 @@ public:
 private:
 	MMINLINE uintptr_t adjustSize(uintptr_t size)
 	{
-		/* Committing and de-committing memory sizes must be a multiple of page size. */
-		return MM_Math::roundToCeiling(_pageSize, size);
+		/* Committing and de-committing memory sizes must be a multiple of region size. */
+		return MM_Math::roundToCeiling(_heap->getHeapRegionManager()->getRegionSize(), size);
 	}
 
 protected:
-	bool initialize(MM_EnvironmentBase* env, uint32_t memoryCategory);
+	bool initialize(MM_EnvironmentBase *env, uint32_t memoryCategory);
 	void tearDown(MM_EnvironmentBase *env);
 
-	MM_SparseVirtualMemory(MM_EnvironmentBase* env, uintptr_t pageSize, uintptr_t pageFlags, MM_Heap *in_heap)
-		: MM_VirtualMemory(env, env->getExtensions()->heapAlignment, pageSize, pageFlags, 0, OMRPORT_VMEM_MEMORY_MODE_READ | OMRPORT_VMEM_MEMORY_MODE_WRITE)
+	MM_SparseVirtualMemory(MM_EnvironmentBase *env, uintptr_t pageSize, uintptr_t pageFlags, MM_Heap *in_heap)
+		: MM_VirtualMemory(env, in_heap->getHeapRegionManager()->getRegionSize(), pageSize, pageFlags, 0, OMRPORT_VMEM_MEMORY_MODE_READ | OMRPORT_VMEM_MEMORY_MODE_WRITE)
 		, _heap(in_heap)
 		, _sparseDataPool(NULL)
 		, _largeObjectVirtualMemoryMutex(NULL)
@@ -86,7 +88,7 @@ protected:
 	}
 
 public:
-	static MM_SparseVirtualMemory* newInstance(MM_EnvironmentBase* env, uint32_t memoryCategory, MM_Heap *in_heap);
+	static MM_SparseVirtualMemory *newInstance(MM_EnvironmentBase *env, uint32_t memoryCategory, MM_Heap *in_heap);
 	virtual void kill(MM_EnvironmentBase *env);
 
 	/**
@@ -134,7 +136,7 @@ public:
 	 *
 	 * @return true if memory was successfully decommited, false otherwise
 	 */
-	virtual bool decommitMemory(MM_EnvironmentBase* env, void* address, uintptr_t size);
+	virtual bool decommitMemory(MM_EnvironmentBase *env, void *address, uintptr_t size);
 	/* tell the compiler we want both decommit from Base class and our class */
 	using MM_VirtualMemory::decommitMemory;
 

--- a/gc/base/j9mm.tdf
+++ b/gc/base/j9mm.tdf
@@ -987,8 +987,8 @@ TraceException=Trc_MM_SparseAddressOrderedFixedSizeDataPool_allocation_failure n
 TraceEvent=Trc_MM_SparseAddressOrderedFixedSizeDataPool_initialization_success noEnv Overhead=1 Level=1 Group=gclogger Template="Successfully intialized SparseAddressOrderedFixedSizeDataPool: sparseHeapBase: %p, freeListPool: %p, objectToSparseDataTable: %p, heapFreeList: %p"
 TraceException=Trc_MM_SparseAddressOrderedFixedSizeDataPool_initialization_failure noEnv Overhead=1 Level=1 Group=arraylet Template="Failed to initialize SparseAddressOrderedFixedSizeDataPool: sparseHeapBase: %p, freeListPool: %p, objectToSparseDataTable: %p, heapFreeList: %p"
 
-TraceEvent=Trc_MM_SparseAddressOrderedFixedSizeDataPool_insertEntry_success noEnv Overhead=1 Level=1 Group=arraylet Template="Successfully inserted an entry into objectToSparseDataTable: sparseHeapObjectDataPointer: %p, adjustedSize: %p, inHeapObjectPointer (spine): %p"
-TraceException=Trc_MM_SparseAddressOrderedFixedSizeDataPool_insertEntry_failure noEnv Overhead=1 Level=1 Group=arraylet Template="Failed to insert an entry into objectToSparseDataTable: sparseHeapObjectDataPointer: %p, adjustedSize: %p, inHeapObjectPointer (spine): %p"
+TraceEvent=Trc_MM_SparseAddressOrderedFixedSizeDataPool_insertEntry_success noEnv Overhead=1 Level=1 Group=arraylet Template="Successfully inserted an entry into objectToSparseDataTable: sparseHeapObjectDataPointer: %p, requestedSize: %p, inHeapObjectPointer (spine): %p"
+TraceException=Trc_MM_SparseAddressOrderedFixedSizeDataPool_insertEntry_failure noEnv Overhead=1 Level=1 Group=arraylet Template="Failed to insert an entry into objectToSparseDataTable: sparseHeapObjectDataPointer: %p, requestedSize: %p, inHeapObjectPointer (spine): %p"
 
 TraceEvent=Trc_MM_SparseAddressOrderedFixedSizeDataPool_removeEntry_success noEnv Overhead=1 Level=1 Group=arraylet Template="Successfully removed an entry from objectToSparseDataTable: sparseHeapObjectDataPointer: %p"
 TraceException=Trc_MM_SparseAddressOrderedFixedSizeDataPool_removeEntry_failure noEnv Overhead=1 Level=1 Group=arraylet Template="Failed to remove an entry from objectToSparseDataTable: sparseHeapObjectDataPointer: %p"


### PR DESCRIPTION
While it may little to no effects on offheap fragmentation it is certainly easier to keep track of dataAddr during debugging, if they are region based rounded.