### PR TITLE
Add new object memory type: JITServerProfileCache

### DIFF
--- a/compiler/env/TRMemory.cpp
+++ b/compiler/env/TRMemory.cpp
@@ -309,6 +309,7 @@ const char * objectName[] =
    "ClientSessionData",
    "ROMClass",
    "JITServerAOTCache",
+   "JITServerProfileCache",
 
    "SymbolValidationManager",
 

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -452,6 +452,7 @@ public:
       ClientSessionData,
       ROMClass,
       JITServerAOTCache,
+      JITServerProfileCache,
 
       SymbolValidationManager,
 


### PR DESCRIPTION
This new type will be used for accounting memory used by the JITServer profiling infrastructure.