### PR TITLE
TRIL: Fix opcode parsing bug

### DIFF
--- a/fvtest/tril/tril/ilgen.hpp
+++ b/fvtest/tril/tril/ilgen.hpp
@@ -72,7 +72,7 @@ class OpCodeTable : public TR::ILOpCode {
             std::string opcodeAndSrcType = name;
             TR::DataType resType = TR::NoType;
 
-            std::size_t pos = name.find("To");
+            std::size_t pos = name.find('_');
             std::size_t divider = 2;
 
             if (pos != std::string::npos)


### PR DESCRIPTION
Some vector opcodes (such as vconv) have two types, source type, and result type. TRIL attempts to parse these opcodes and their types by looking for the substring 'To'. This substring is problematic because some opcodes contain this substrain in their name. Furthermore, two-type opcodes have always used the substring '_' to separate source and result type.