### PR TITLE
Reject native methods in isRecursiveMethodTarget()

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -2687,7 +2687,10 @@ bool OMR::Compilation::incompleteOptimizerSupportForReadWriteBarriers()
 
 bool OMR::Compilation::isRecursiveMethodTarget(TR_ResolvedMethod *targetResolvedMethod)
    {
-   return targetResolvedMethod && targetResolvedMethod->isSameMethod(self()->getCurrentMethod()) && !self()->isDLT();
+   return targetResolvedMethod != NULL
+      && targetResolvedMethod->isSameMethod(self()->getCurrentMethod())
+      && !targetResolvedMethod->isNative() // linkage adapters are not recursive
+      && !self()->isDLT();
    }
 
 


### PR DESCRIPTION
A native linkage adapter must not be considered to be making a recursive call, or else the code generator could encode the call instruction as a recursive call to the JIT body instead of the intended call to the native implementation.

So far we've been avoiding that situation by having `isSameMethod()` return false for native methods, which is confusing. By rejecting native methods explicitly here, it will now be possible to correct this problem in `isSameMethod()`.