### PR TITLE
Ensure each TR_CallTarget represents one unambiguous target method

### DIFF
--- a/compiler/optimizer/CallInfo.hpp
+++ b/compiler/optimizer/CallInfo.hpp
@@ -215,6 +215,8 @@ struct TR_CallTarget : public TR_Link<TR_CallTarget>
       _numDeletedCallees++;
       }
 
+   void assertCalleeConsistency();
+
    TR_InlineBlocks             *_partialInline;
    TR_LinkHead<TR_CallSite>     _myCallees;
    int32_t                      _numCallees;
@@ -382,6 +384,8 @@ class TR_CallSite : public TR_Link<TR_CallSite>, private TR::Uncopyable
       const char*             signature(TR_Memory *trMemory);
 
       TR_OpaqueClassBlock    *calleeClass();
+
+      void assertInitialCalleeConsistency();
 
       TR::Compilation *             _comp;
       TR_ResolvedMethod *          _callerResolvedMethod;


### PR DESCRIPTION
Previously a `TR_CallTarget` could be mutated to represent a different target method if during physical inlining the corresponding call node was found to be a direct call to a method other than the one originally represented by the `TR_CallTarget`.

Now a `TR_CallTarget` will never be mutated in such a way. If that situation arises, then instead the target will be removed from its call site, and a new target will be added as though for a direct call site.

Additionally, physical inlining gets the actual method not directly from the target's `_calleeMethod`, but rather from its `_calleeSymbol`, which could be set to the call site's `_initialCalleeSymbol` even when it represents a different method from the call target. This would be fixed up afterward by `getSymbolAndFindInlineTargets()`, which would replace the `_calleeSymbol` with a new one based on `_calleeMethod` if the current value was missing or mismatching. Now when a `TR_CallTarget` has a non-null `_calleeSymbol`, it must agree with the `_calleeMethod`, and if `getSymbolAndFindInlineTargets()` detects a mismatch it will fail an assertion instead of silently fixing the problem. There are also now assertions to check for similar consistency between a `TR_CallSite`'s `_initialCalleeMethod` and `_initialCalleeSymbol`.

Finally, when an indirect call site is found to correspond to a direct call node, if the correct call target does already exist, we will now use the same guard as `TR_DirectCallSite` would use. The old logic in this case would skip the possibility of an HCR guard or breakpoint guard.