### PR TITLE
Calculate Scavenge stats on CS-to-Global transition

### DIFF
--- a/gc/base/Collector.cpp
+++ b/gc/base/Collector.cpp
@@ -194,15 +194,16 @@ MM_Collector::recordExcessiveStatsForGCEnd(MM_EnvironmentBase* env)
  * @param aggressive True if this is an aggressive collect, otherwise false
  */
 void
-MM_Collector::preCollect(MM_EnvironmentBase* env, MM_MemorySubSpace* subSpace, MM_AllocateDescription* allocDescription, uint32_t gcCode)
+MM_Collector::preCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription, uint32_t gcCode)
 {
-	MM_GCExtensionsBase* extensions = env->getExtensions();
+	MM_GCExtensionsBase *extensions = env->getExtensions();
 
 	/* There might be a colliding concurrent cycle in progress, that must be completed before we start this one.
 	 * Specific Collector subclass will have exact knowledge if that is the case.
 	 */
-	completeExternalConcurrentCycle(env);
+	completeExternalConcurrentCycle(env, subSpace, allocDescription, gcCode);
 
+	Assert_MM_false(_stwCollectionInProgress);
 	_stwCollectionInProgress = true;
 	
 	/* Record the main GC thread CPU time at the start to diff later */

--- a/gc/base/Collector.hpp
+++ b/gc/base/Collector.hpp
@@ -289,7 +289,7 @@ public:
 	virtual uintptr_t mainThreadConcurrentCollect(MM_EnvironmentBase *env) { return 0; }
 	virtual	void postConcurrentUpdateStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats, UDATA bytesConcurrentlyScanned) {}
 	virtual void forceConcurrentFinish() {}
-	virtual void completeExternalConcurrentCycle(MM_EnvironmentBase *env) {}
+	virtual void completeExternalConcurrentCycle(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription, uint32_t gcCode) {}
 	/**
 	 * Notify any (concurrent) collector that might block and hold VM access
 	 * that an Exclusive VM Access is to be requested so that VM access can be released

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -1621,12 +1621,12 @@ MM_ParallelGlobalGC::checkColorAndMark(MM_EnvironmentBase* env, omrobjectptr_t o
 }
 
 void
-MM_ParallelGlobalGC::completeExternalConcurrentCycle(MM_EnvironmentBase *env)
+MM_ParallelGlobalGC::completeExternalConcurrentCycle(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription, uint32_t gcCode)
 {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	if (_extensions->isConcurrentScavengerEnabled()) {
 		/* ParallelGlobalGC or ConcurrentGC (STW phase) cannot start before Concurrent Scavenger cycle is in progress */
-		_extensions->scavenger->completeConcurrentCycle(env);
+		_extensions->scavenger->completeConcurrentCycle(env, subSpace, allocDescription, gcCode);
 	}
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 }

--- a/gc/base/standard/ParallelGlobalGC.hpp
+++ b/gc/base/standard/ParallelGlobalGC.hpp
@@ -326,7 +326,7 @@ public:
 	}
 #endif /* OMR_GC_MODRON_COMPACTION */
 
-	virtual void completeExternalConcurrentCycle(MM_EnvironmentBase *env);
+	virtual void completeExternalConcurrentCycle(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription, uint32_t gcCode);
 	/**
 	 * Notify any (concurrent) collector (like Concurrent Scavenger) that might block and hold VM access
 	 * that an Exclusive VM Access is to be requested so that VM access can be released

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -771,7 +771,7 @@ public:
 	/**
 	 * complete (trigger end) of a Concurrent Scavenger Cycle
 	 */
-	void completeConcurrentCycle(MM_EnvironmentBase *envBase);
+	void completeConcurrentCycle(MM_EnvironmentBase *envBase, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription, uint32_t gcCode);
 
 	/* worker thread */
 	void workThreadProcessRoots(MM_EnvironmentStandard *env);


### PR DESCRIPTION
More generally, invoke pre/postCollect around the last CS increment when terminating CS cycle to transition to the final STW of the ConcurrentGC.

postCollect will then invoke calcGCStats, what will help with more correct Scavenger tenuring rate estimates and in turn more correct concurrent global kickoff logic.

For now, we are just calling internalPre(Post)Collect, but probably we should call full blown pre/postCollect that would account for excessive GC stats/calculation, as well. But that's a separate issue and a riskier change.