### PR TITLE
Support v2m opcode on Power

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1921,6 +1921,7 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
             return false;
       case TR::vbitselect:
       case TR::vcast:
+      case TR::v2m:
          return true;
       default:
          return false;


### PR DESCRIPTION
- TR::v2m opcode converts boolean vector into mask
- least-significant bit of each byte element should be left-extended
- mload/mloadi opcodes don't have to extend the bit since they load correct
  mask representation stored by mstore/mstorei