### PR TITLE
Replace "zNext" with "z17" in OMR

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -623,6 +623,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableZ14",                         "O\tdisable z14 support",                            SET_OPTION_BIT(TR_DisableZ14), "F"},
    {"disableZ15",                         "O\tdisable z15 support",                        SET_OPTION_BIT(TR_DisableZ15), "F"},
    {"disableZ16",                         "O\tdisable z16 support",                        SET_OPTION_BIT(TR_DisableZ16), "F"},
+   {"disableZ17",                         "O\tdisable z17 support",                        SET_OPTION_BIT(TR_DisableZ17), "F"},
    {"disableZ196",                        "O\tdisable z196 support",                           SET_OPTION_BIT(TR_DisableZ196), "F"},
    {"disableZArraySetUnroll",             "O\tdisable arraySet unrolling on 390.",             SET_OPTION_BIT(TR_DisableZArraySetUnroll), "F"},
    {"disableZealousCodegenOpts",          "O\tdisable use of zealous codegen optimizations.", SET_OPTION_BIT(TR_DisableZealousCodegenOpts), "F"},
@@ -2761,8 +2762,8 @@ OMR::Options::jitPreProcess()
          }
       else if (TR::Compiler->target.is32Bit())
          {
-         // On 31-Bit Linux on Z, zNext exploitation is disabled by default.
-         self()->setOption(TR_DisableZNext);
+         // On 31-Bit Linux on Z, z16+ exploitation is disabled by default.
+         self()->setOption(TR_DisableZ16);
          }
 
 #if defined(TR_HOST_X86) || defined(TR_HOST_S390) || defined(TR_HOST_ARM64)

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -408,7 +408,7 @@ enum TR_CompilationOptions
    TR_DisableSSE4_1                       = 0x01000000 + 10,
    TR_DisableSSE4_2                       = 0x02000000 + 10,
    TR_DisableNewX86VolatileSupport        = 0x04000000 + 10,
-   // Available                           = 0x08000000 + 10,
+   TR_DisableZ17                          = 0x08000000 + 10,
    // Available                           = 0x10000000 + 10,
    // Available                           = 0x20000000 + 10,
    // Available                           = 0x40000000 + 10,

--- a/compiler/z/codegen/OMRInstOpCode.enum
+++ b/compiler/z/codegen/OMRInstOpCode.enum
@@ -1179,7 +1179,7 @@
    VUPKZL,              // VECTOR UNPACK ZONED LOW
    VUPKZH,              // VECTOR UNPACK ZONED HIGH
 
-   /* zNext Instructions */
+   /* z17 Instructions */
    BDEPG,               // BIT DEPOSIT
    BEXTG,               // BIT EXTRACT
    CLZG,                // COUNT LEADING ZEROS

--- a/compiler/z/codegen/OMRInstOpCode.hpp
+++ b/compiler/z/codegen/OMRInstOpCode.hpp
@@ -630,7 +630,7 @@ class InstOpCode: public OMR::InstOpCode
    uint64_t isEmulatable() {return metadata[_mnemonic].properties & S390OpProp_IsEmulatable;}
    bool canEmulate()
    {
-#ifdef EMULATE_ZNEXT
+#ifdef EMULATE_Z17
       return isEmulatable();
 #else
       return false;

--- a/compiler/z/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeProperties.hpp
@@ -16045,7 +16045,7 @@
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x6D,
    /* .format      = */ RRFa_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_IsEmulatable
@@ -16058,7 +16058,7 @@
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x6C,
    /* .format      = */ RRFa_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_IsEmulatable
@@ -16071,7 +16071,7 @@
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x68,
    /* .format      = */ RRE_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_IsEmulatable
@@ -16084,7 +16084,7 @@
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x69,
    /* .format      = */ RRE_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_IsEmulatable
@@ -16097,7 +16097,7 @@
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x61,
    /* .format      = */ RXYc_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_IsEmulatable
@@ -16110,7 +16110,7 @@
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x65,
    /* .format      = */ RXYc_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_IsEmulatable
@@ -16123,7 +16123,7 @@
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x67,
    /* .format      = */ RXYc_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_IsEmulatable
@@ -16136,7 +16136,7 @@
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x63,
    /* .format      = */ RXYc_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_IsEmulatable
@@ -16149,7 +16149,7 @@
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x69,
    /* .format      = */ RXYc_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_IsEmulatable
@@ -16162,7 +16162,7 @@
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x60,
    /* .format      = */ RXYc_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_IsEmulatable
@@ -16175,7 +16175,7 @@
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x64,
    /* .format      = */ RXYc_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_IsEmulatable
@@ -16188,7 +16188,7 @@
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x66,
    /* .format      = */ RXYc_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_IsEmulatable
@@ -16201,7 +16201,7 @@
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x62,
    /* .format      = */ RXYc_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_IsEmulatable
@@ -16214,7 +16214,7 @@
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x68,
    /* .format      = */ RXYc_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_IsEmulatable
@@ -16227,7 +16227,7 @@
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x89,
    /* .format      = */ VRRd_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_SetsOperand1 |
                         S390OpProp_HasExtendedMnemonic |
                         S390OpProp_UsesM5
@@ -16240,7 +16240,7 @@
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x88,
    /* .format      = */ VRIk_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_SetsOperand1
    },
 
@@ -16251,7 +16251,7 @@
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xB2,
    /* .format      = */ VRRc_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_SetsOperand1 |
                         S390OpProp_HasExtendedMnemonic |
                         S390OpProp_UsesM4 |
@@ -16265,7 +16265,7 @@
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xB0,
    /* .format      = */ VRRc_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_SetsOperand1 |
                         S390OpProp_HasExtendedMnemonic |
                         S390OpProp_UsesM4 |
@@ -16279,7 +16279,7 @@
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x54,
    /* .format      = */ VRRa_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_SetsOperand1 |
                         S390OpProp_HasExtendedMnemonic |
                         S390OpProp_UsesM3
@@ -16292,7 +16292,7 @@
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xB3,
    /* .format      = */ VRRc_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_SetsOperand1 |
                         S390OpProp_HasExtendedMnemonic |
                         S390OpProp_UsesM4 |
@@ -16306,7 +16306,7 @@
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xB1,
    /* .format      = */ VRRc_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_SetsOperand1 |
                         S390OpProp_HasExtendedMnemonic |
                         S390OpProp_UsesM4 |
@@ -16320,6 +16320,6 @@
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x7F,
    /* .format      = */ VRIl_FORMAT,
-   /* .minimumALS  = */ OMR_PROCESSOR_S390_ZNEXT,
+   /* .minimumALS  = */ OMR_PROCESSOR_S390_Z17,
    /* .properties  = */ S390OpProp_SetsCC
    },

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -7924,9 +7924,9 @@ OMR::Z::TreeEvaluator::axaddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Node * firstChild = node->getFirstChild();
    TR::MemoryReference * axaddMR = generateS390MemoryReference(cg);
    TR::InstOpCode::Mnemonic loadOp;
-   static const bool disableLXAaxaddZNext = feGetEnv("TR_disableLXAaxaddZNext") != NULL;
+   static const bool disableLXAaxaddZ17 = feGetEnv("TR_disableLXAaxaddZ17") != NULL;
 
-   axaddMR->populateAddTree(node, cg, &loadOp, !disableLXAaxaddZNext && cg->getUseLXAInstructions());
+   axaddMR->populateAddTree(node, cg, &loadOp, !disableLXAaxaddZ17 && cg->getUseLXAInstructions());
    axaddMR->eliminateNegativeDisplacement(node, cg);
    axaddMR->enforceDisplacementLimit(node, cg, NULL);
 
@@ -8545,10 +8545,10 @@ OMR::Z::TreeEvaluator::inlineNumberOfTrailingZeros(TR::Node *node, TR::CodeGener
    TR::Register *tempReg = cg->allocateRegister();
    TR::Register *returnReg = NULL;
    bool isLong = (subfconst == 64);
-   static const bool disableTrailZeroZNext = feGetEnv("TR_disableTrailZeroZNext") != NULL;
+   static const bool disableTrailZeroZ17 = feGetEnv("TR_disableTrailZeroZ17") != NULL;
    static const bool canEmulateCTZG = TR::InstOpCode(TR::InstOpCode::CTZG).canEmulate();
 
-   if ((cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_ZNEXT) || canEmulateCTZG) && !disableTrailZeroZNext)
+   if ((cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z17) || canEmulateCTZG) && !disableTrailZeroZ17)
       {
       argReg = cg->gprClobberEvaluate(argNode);
       if (!(isLong))
@@ -8668,10 +8668,10 @@ OMR::Z::TreeEvaluator::inlineNumberOfLeadingZeros(TR::Node *node, TR::CodeGenera
    TR::Node *argNode = node->getChild(0);
    TR::Register *argReg = cg->gprClobberEvaluate(argNode);
    TR::Register *returnReg = NULL;
-   static const bool disableLeadZeroZNext = feGetEnv("TR_disableLeadZeroZNext") != NULL;
+   static const bool disableLeadZeroZ17 = feGetEnv("TR_disableLeadZeroZ17") != NULL;
    static const bool canEmulateCLZG = TR::InstOpCode(TR::InstOpCode::CLZG).canEmulate();
 
-   if ((cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_ZNEXT) || canEmulateCLZG) && !disableLeadZeroZNext)
+   if ((cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z17) || canEmulateCLZG) && !disableLeadZeroZ17)
       {
       // The leading zeros instruction assumes input data to be 64-bit. So we left shift it to zero out the
       // invalid higher order bits if the data type is initially smaller than 64-bits.

--- a/compiler/z/env/OMRCPU.cpp
+++ b/compiler/z/env/OMRCPU.cpp
@@ -81,7 +81,7 @@ OMR::Z::CPU::detect(OMRPortLibrary * const omrPortLib)
       omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY_2, FALSE);
       }
 
-   if (processorDescription.processor < OMR_PROCESSOR_S390_ZNEXT)
+   if (processorDescription.processor < OMR_PROCESSOR_S390_Z17)
       {
       omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_3, FALSE);
       omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_3, FALSE);
@@ -152,6 +152,9 @@ OMR::Z::CPU::isAtLeastOldAPI(OMRProcessorArchitecture p)
          break;
       case OMR_PROCESSOR_S390_Z16:
          ans = self()->getSupportsArch(TR::CPU::z16);
+         break;
+      case OMR_PROCESSOR_S390_Z17:
+         ans = self()->getSupportsArch(TR::CPU::z17);
          break;
       case OMR_PROCESSOR_S390_ZNEXT:
          ans = self()->getSupportsArch(TR::CPU::zNext);
@@ -269,6 +272,9 @@ OMR::Z::CPU::getProcessorName()
          break;
       case OMR_PROCESSOR_S390_Z16:
          result = "z16";
+         break;
+      case OMR_PROCESSOR_S390_Z17:
+         result = "z17";
          break;
       case OMR_PROCESSOR_S390_ZNEXT:
          result = "zNext";

--- a/compiler/z/env/OMRCPU.hpp
+++ b/compiler/z/env/OMRCPU.hpp
@@ -62,6 +62,7 @@ public:
       z14,
       z15,
       z16,
+      z17,
       zNext,
       };
 

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1388,6 +1388,7 @@ typedef enum OMRProcessorArchitecture {
 	OMR_PROCESSOR_S390_Z14,
 	OMR_PROCESSOR_S390_Z15,
 	OMR_PROCESSOR_S390_Z16,
+	OMR_PROCESSOR_S390_Z17,
 	OMR_PROCESSOR_S390_ZNEXT,
 	OMR_PROCESSOR_S390_LAST = OMR_PROCESSOR_S390_ZNEXT,
 
@@ -1652,7 +1653,7 @@ typedef struct OMRProcessorDesc {
 /* STFLE bit 192 - Vector-Packed-Decimal-Enhancement Facility 2 */
 #define OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY_2 192
 
-/* zNext facilities */
+/* z17 facilities */
 
 /* STFLE bit 84 - Miscellaneous-instruction-extensions facility 4 */
 #define OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_4 84

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -1804,12 +1804,12 @@ omrsysinfo_get_s390_description(struct OMRPortLibrary *portLibrary, OMRProcessor
 		}
 	}
 
-   /* zNext facility and processor detection */
+   /* z17 facility and processor detection */
 
 	if (omrsysinfo_test_stfle(portLibrary, OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_4)) {
 		omrsysinfo_set_feature(desc, OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_4);
 
-		desc->processor = OMR_PROCESSOR_S390_ZNEXT;
+		desc->processor = OMR_PROCESSOR_S390_Z17;
 	}
 
 	if (omrsysinfo_test_stfle(portLibrary, OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_3)) {
@@ -1821,14 +1821,14 @@ omrsysinfo_get_s390_description(struct OMRPortLibrary *portLibrary, OMRProcessor
 		{
 			omrsysinfo_set_feature(desc, OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_3);
 
-			desc->processor = OMR_PROCESSOR_S390_ZNEXT;
+			desc->processor = OMR_PROCESSOR_S390_Z17;
 		}
 	}
 
 	if (omrsysinfo_test_stfle(portLibrary, OMR_FEATURE_S390_PLO_EXTENSION)) {
 		omrsysinfo_set_feature(desc, OMR_FEATURE_S390_PLO_EXTENSION);
 
-		desc->processor = OMR_PROCESSOR_S390_ZNEXT;
+		desc->processor = OMR_PROCESSOR_S390_Z17;
 	}
 
 	if (omrsysinfo_test_stfle(portLibrary, OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY_3)) {
@@ -1840,7 +1840,7 @@ omrsysinfo_get_s390_description(struct OMRPortLibrary *portLibrary, OMRProcessor
 		{
 			omrsysinfo_set_feature(desc, OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY_3);
 
-			desc->processor = OMR_PROCESSOR_S390_ZNEXT;
+			desc->processor = OMR_PROCESSOR_S390_Z17;
 		}
 	}
 


### PR DESCRIPTION
This PR replaces the literal "zNext" with "z17" in OMR.