### PR TITLE
Move bitwise compress/expand support flags from OMR::CPU to OMR::CodeGenerator

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -677,6 +677,46 @@ public:
     */
    bool supportsFPAbs() { return true; }
 
+   /**
+    * @brief Answers whether bcompress/scompress/icompress evaluators are available or not
+    * @return true if bcompress/scompress/icompress evaluators are available
+    */
+   bool getSupports32BitCompress() { return _flags4.testAny(Supports32BitCompress); }
+   /**
+    * @brief The code generator supports the bcompress/scompress/icompress evaluators
+    */
+   void setSupports32BitCompress() { _flags4.set(Supports32BitCompress); }
+
+   /**
+    * @brief Answers whether lcompress evaluator is available or not
+    * @return true if lcompress evaluator is available
+    */
+   bool getSupports64BitCompress() { return _flags4.testAny(Supports64BitCompress); }
+   /**
+    * @brief The code generator supports the lcompress evaluator
+    */
+   void setSupports64BitCompress() { _flags4.set(Supports64BitCompress); }
+
+   /**
+    * @brief Answers whether bexpand/sexpand/iexpand evaluators are available or not
+    * @return true if bexpand/sexpand/iexpand evaluators are available
+    */
+   bool getSupports32BitExpand() { return _flags4.testAny(Supports32BitExpand); }
+   /**
+    * @brief The code generator supports the bexpand/sexpand/iexpand evaluators
+    */
+   void setSupports32BitExpand() { _flags4.set(Supports32BitExpand); }
+
+   /**
+    * @brief Answers whether lexpand evaluator is available or not
+    * @return true if lexpand evaluator is available
+    */
+   bool getSupports64BitExpand() { return _flags4.testAny(Supports64BitExpand); }
+   /**
+    * @brief The code generator supports the lexpand evaluator
+    */
+   void setSupports64BitExpand() { _flags4.set(Supports64BitExpand); }
+
    // --------------------------------------------------------------------------
    // Optimizer, not code generator
    //
@@ -2000,10 +2040,10 @@ public:
 
    enum // flags4
       {
-      // AVAILABLE                                        = 0x00000001,
-      // AVAILABLE                                        = 0x00000002,
-      // AVAILABLE                                        = 0x00000004,
-      // AVAILABLE                                        = 0x00000008,
+      Supports32BitCompress                               = 0x00000001,
+      Supports64BitCompress                               = 0x00000002,
+      Supports32BitExpand                                 = 0x00000004,
+      Supports64BitExpand                                 = 0x00000008,
       // AVAILABLE                                        = 0x00000010,
       IsInOOLSection                                      = 0x00000020,
       // AVAILABLE                                        = 0x00000040,

--- a/compiler/env/OMRCPU.hpp
+++ b/compiler/env/OMRCPU.hpp
@@ -137,10 +137,6 @@ public:
    bool getSupportsHardwareRound() { return false; }
    bool getSupportsHardwareCopySign() { return false; }
    bool hasPopulationCountInstruction() { return false; }
-   bool getSupportsHardware32bitCompress() { return false; }
-   bool getSupportsHardware64bitCompress() { return false; }
-   bool getSupportsHardware32bitExpand() { return false; }
-   bool getSupportsHardware64bitExpand() { return false; }
    bool supportsDecimalFloatingPoint() { return false; }
    bool hasFPU() { return true; }
 

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -367,6 +367,25 @@ OMR::Power::CodeGenerator::initialize()
    TR_ResolvedMethod *method = comp->getJittedMethodSymbol()->getResolvedMethod();
    TR_ReturnInfo      returnInfo = cg->getLinkage()->getReturnInfoFromReturnType(method->returnType());
    comp->setReturnInfo(returnInfo);
+
+   if (comp->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P10))
+      {
+      static bool disableBitwiseCompress = feGetEnv("TR_disableBitwiseCompress") != NULL;
+      if (!disableBitwiseCompress)
+         {
+         cg->setSupports32BitCompress();
+         if (cg->is64BitProcessor())
+            cg->setSupports64BitCompress();
+         }
+
+      static bool disableBitwiseExpand = feGetEnv("TR_disableBitwiseExpand") != NULL;
+      if (!disableBitwiseExpand)
+         {
+         cg->setSupports32BitExpand();
+         if (cg->is64BitProcessor())
+            cg->setSupports64BitExpand();
+         }
+      }
    }
 
 TR::Linkage *

--- a/compiler/p/env/OMRCPU.cpp
+++ b/compiler/p/env/OMRCPU.cpp
@@ -49,30 +49,6 @@ OMR::Power::CPU::supportsDecimalFloatingPoint()
    }
 
 bool
-OMR::Power::CPU::getSupportsHardware32bitCompress()
-   {
-   return self()->isAtLeast(OMR_PROCESSOR_PPC_P10);
-   }
-
-bool
-OMR::Power::CPU::getSupportsHardware64bitCompress()
-   {
-   return self()->isAtLeast(OMR_PROCESSOR_PPC_P10) && TR::Compiler->target.is64Bit();
-   }
-
-bool
-OMR::Power::CPU::getSupportsHardware32bitExpand()
-   {
-   return self()->isAtLeast(OMR_PROCESSOR_PPC_P10);
-   }
-
-bool
-OMR::Power::CPU::getSupportsHardware64bitExpand()
-   {
-   return self()->isAtLeast(OMR_PROCESSOR_PPC_P10) && TR::Compiler->target.is64Bit();
-   }
-
-bool
 OMR::Power::CPU::getSupportsHardwareSQRT()
    {
    return self()->isAtLeast(OMR_PROCESSOR_PPC_HW_SQRT_FIRST);

--- a/compiler/p/env/OMRCPU.hpp
+++ b/compiler/p/env/OMRCPU.hpp
@@ -68,11 +68,6 @@ public:
    bool hasPopulationCountInstruction();
    bool supportsDecimalFloatingPoint();
 
-   bool getSupportsHardware32bitCompress();
-   bool getSupportsHardware64bitCompress();
-   bool getSupportsHardware32bitExpand();
-   bool getSupportsHardware64bitExpand();
-
    /**
     * @brief Determines whether 32bit integer rotate is available
     *

--- a/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
@@ -125,6 +125,23 @@ void OMR::X86::AMD64::CodeGenerator::initialize()
       {
       _maxObjectSizeGuaranteedNotToOverflow = (uint32_t)INT_MAX;
       }
+
+   if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_BMI2))
+      {
+      static bool disableBitwiseCompress = feGetEnv("TR_disableBitwiseCompress") != NULL;
+      if (!disableBitwiseCompress)
+         {
+         cg->setSupports32BitCompress();
+         cg->setSupports64BitCompress();
+         }
+
+      static bool disableBitwiseExpand = feGetEnv("TR_disableBitwiseExpand") != NULL;
+      if (!disableBitwiseExpand)
+         {
+         cg->setSupports32BitExpand();
+         cg->setSupports64BitExpand();
+         }
+      }
    }
 
 

--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -208,48 +208,6 @@ OMR::X86::CPU::supportsTransactionalMemoryInstructions()
    }
 
 bool
-OMR::X86::CPU::getSupportsHardware32bitCompress()
-   {
-   if (TR::Compiler->omrPortLib == NULL)
-      return TR::CodeGenerator::getX86ProcessorInfo().supportsBMI2();
-
-   return self()->supportsFeature(OMR_FEATURE_X86_BMI2);
-   }
-
-bool
-OMR::X86::CPU::getSupportsHardware64bitCompress()
-   {
-   if (self()->isI386())
-      return false;
-
-   if (TR::Compiler->omrPortLib == NULL)
-      return TR::CodeGenerator::getX86ProcessorInfo().supportsBMI2();
-
-   return self()->supportsFeature(OMR_FEATURE_X86_BMI2);
-   }
-
-bool
-OMR::X86::CPU::getSupportsHardware32bitExpand()
-   {
-   if (TR::Compiler->omrPortLib == NULL)
-      return TR::CodeGenerator::getX86ProcessorInfo().supportsBMI2();
-
-   return self()->supportsFeature(OMR_FEATURE_X86_BMI2);
-   }
-
-bool
-OMR::X86::CPU::getSupportsHardware64bitExpand()
-   {
-   if (self()->isI386())
-      return false;
-
-   if (TR::Compiler->omrPortLib == NULL)
-      return TR::CodeGenerator::getX86ProcessorInfo().supportsBMI2();
-
-   return self()->supportsFeature(OMR_FEATURE_X86_BMI2);
-   }
-
-bool
 OMR::X86::CPU::isGenuineIntel()
    {
    if (TR::Compiler->omrPortLib == NULL)

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -75,30 +75,6 @@ public:
 
    bool getSupportsHardwareSQRT();
 
-   /** @brief Determines whether the 32 bit bitwise compress instruction is available on the current processor.
-    *
-    *  @return true if the 32 bit bitwise compress instruction is available, false otherwise.
-    */
-   bool getSupportsHardware32bitCompress();
-
-   /** @brief Determines whether the 64 bit bitwise compress instruction is available on the current processor.
-    *
-    *  @return true if the 64 bit bitwise compress instruction is available, false otherwise.
-    */
-   bool getSupportsHardware64bitCompress();
-
-   /** @brief Determines whether the 32 bit bitwise expand instruction is available on the current processor.
-    *
-    *  @return true if the 32 bit bitwise expand instruction is available, false otherwise.
-    */
-   bool getSupportsHardware32bitExpand();
-
-   /** @brief Determines whether the 64 bit bitwise expand instruction is available on the current processor.
-    *
-    *  @return true if the 64 bit bitwise expand instruction is available, false otherwise.
-    */
-   bool getSupportsHardware64bitExpand();
-
    /** @brief Determines whether the popcnt instruction is available on the current processor.
     *
     *  @return true if popcnt is available, false otherwise.

--- a/compiler/x/i386/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/i386/codegen/OMRCodeGenerator.cpp
@@ -132,6 +132,21 @@ OMR::X86::I386::CodeGenerator::initialize()
    static char *dontConsiderAllAutosForGRA = feGetEnv("TR_dontConsiderAllAutosForGRA");
    if (!dontConsiderAllAutosForGRA)
       cg->setConsiderAllAutosAsTacticalGlobalRegisterCandidates();
+
+   if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_BMI2))
+      {
+      static bool disableBitwiseCompress = feGetEnv("TR_disableBitwiseCompress") != NULL;
+      if (!disableBitwiseCompress)
+         {
+         cg->setSupports32BitCompress();
+         }
+
+      static bool disableBitwiseExpand = feGetEnv("TR_disableBitwiseExpand") != NULL;
+      if (!disableBitwiseExpand)
+         {
+         cg->setSupports32BitExpand();
+         }
+      }
    }
 
 


### PR DESCRIPTION
- Remove the `getSupportsHardware(32|64)bit(Compress|Expand)` methods from the `OMR::CPU` class and their overrides in child classes
- Add `(get|set)Supports(32|64)Bit(Compress|Expand)` methods to the `OMR::CodeGenerator` class
- Call `setSupports(32|64)Bit(Compress|Expand)` in `OMR::X86::AMD64::CodeGenerator::initialize`, `OMR::X86::I386::CodeGenerator::initialize`, and `OMR::Power::CodeGenerator::initialize` as appropriate
- Use `TR_disableBitwiseCompress` and `TR_disableBitwiseExpand` to skip calling corresponding `setSupport*` methods in the `initialize` methods