### PR TITLE
Limit loopStrider to children of array-shadow symbol nodes

### DIFF
--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -1911,6 +1911,7 @@ bool TR_LoopStrider::examineTreeForInductionVariableUse(TR::Block *loopInvariant
    TR::AutomaticSymbol *pinningArrayPointer = NULL;
    TR::Node *originalNode = NULL;
    if (cg()->supportsInternalPointers() &&
+       _arrayShadowParent &&
        (node->isInternalPointer()) &&
        !node->isDataAddrPointer() &&
        node->getFirstChild()->getOpCode().isLoadVar() &&
@@ -2187,6 +2188,14 @@ bool TR_LoopStrider::examineTreeForInductionVariableUse(TR::Block *loopInvariant
                         (*newSymbolReference)->getReferenceNumber());
          }
       }
+
+   // Only first-level children of array-shadow symbol node have the _arrayShadowParent argument set
+   if (_arrayShadowParent)
+      _arrayShadowParent = false;
+   TR::Node* checkNode = originalNode ? originalNode : node;
+   if (checkNode->getOpCode().hasSymbolReference() && checkNode->getSymbolReference()->getSymbol()->isArrayShadowSymbol() &&
+       !checkNode->getSymbolReference()->getSymbol()->isUnsafeShadowSymbol())
+      _arrayShadowParent = true;
 
    if (examineChildren)
        {
@@ -3413,7 +3422,7 @@ bool TR_LoopStrider::reassociateAndHoistComputations(TR::Block *loopInvariantBlo
             mul/shift/integer offset
     */
    if (cg()->supportsInternalPointers() && reassociateAndHoistNonPacked() &&
-      node->isInternalPointer() && !node->isDataAddrPointer())
+   _arrayShadowParent && node->isInternalPointer() && !node->isDataAddrPointer())
       {
       if (node->getFirstChild()->isDataAddrPointer())
          pinningArrayNode = node->getFirstChild()->getFirstChild();
@@ -3738,6 +3747,14 @@ bool TR_LoopStrider::reassociateAndHoistComputations(TR::Block *loopInvariantBlo
          }
       }
 #endif /* J9_PROJECT_SPECIFIC */
+
+   // Only first-level children of array-shadow symbol node have the _arrayShadowParent argument set
+   if (_arrayShadowParent)
+      _arrayShadowParent = false;
+   TR::Node* checkNode = originalNode ? originalNode : node;
+   if (checkNode->getOpCode().hasSymbolReference() && checkNode->getSymbolReference()->getSymbol()->isArrayShadowSymbol() &&
+       !checkNode->getSymbolReference()->getSymbol()->isUnsafeShadowSymbol())
+      _arrayShadowParent = true;
 
    if (examineChildren)
        {

--- a/compiler/optimizer/InductionVariable.hpp
+++ b/compiler/optimizer/InductionVariable.hpp
@@ -335,6 +335,7 @@ class TR_LoopStrider : public TR_LoopTransformer
    bool _registersScarce;
    bool _newTempsCreated;
    bool _newNonAddressTempsCreated;
+   bool _arrayShadowParent;
 
    // (64-bit)
    // sign-extension elimination data-structures


### PR DESCRIPTION
LoopStrider currently performs on non-arrays and that's was not the intended design for it. This sets non-array nodes as pinning-array and the access as an array access.
This didn't cause an issue previously until OffHeap was introduced. Given that OffHeap array accesses requires loading the `dataAddrPtr`, after inserting the load to a non-array access, it ends up loading/storing to a different memory location.

The fix limits loopStrider to the first-level children of the array-shadow symbol nodes.

An extra check against unsafe-shadow symbols is added as unsafe-shadow symbols also have array-shadow symbol flag set.

Before the fix:
```
n25090n   astore  <temp slot 68>[#3108  Auto] [flags 0x7 0x0 ]                                [0x788beb709240] bci=[102,3,251] rc=0 vc=4560 vn=19 li=287 udi=3 nc=1
n25089n     aload  CurrentThread[#343  MethodMeta +160] [flags 0x207 0x400 ]                  [0x788beb7091f0] bci=[102,3,251] rc=1 vc=4560 vn=19 li=- udi=- nc=0
...
n6799n      iloadi  <unsafe shadow sym>[#1426  Shadow] [flags 0x80000603 0x100 ]              [0x788c01563cf0] bci=[4,9,232] rc=1 vc=4560 vn=54 li=- udi=- nc=1
n6812n        aladd (X>=0 internalPtr )                                                       [0x788c01564100] bci=[4,3,232] rc=1 vc=4560 vn=53 li=- udi=- nc=2 flg=0x8100
n6793n          aload  <temp slot 68>[#3108  Auto] [flags 0x7 0x0 ] (X!=0 createdByPRE )      [0x788c01563b10] bci=[4,3,232] rc=1 vc=4560 vn=19 li=- udi=642 nc=0 flg=0x40004
n6797n          lconst 108 (highWordZero X!=0 X>=0 )                                          [0x788c01563c50] bci=[4,6,232] rc=1 vc=4560 vn=52 li=- udi=- nc=0 flg=0x4104

loopStrider

n25090n   astore  <pinning array temp slot 68>[#3108  Auto] [flags 0x10000007 0x0 ]           [0x788beb709240] bci=[102,3,251] rc=0 vc=4560 vn=- li=287 udi=3 nc=1
n25089n     aload  CurrentThread[#343  MethodMeta +160] [flags 0x207 0x400 ]                  [0x788beb7091f0] bci=[102,3,251] rc=1 vc=4560 vn=- li=- udi=- nc=0
...
n26905n   astore  <internal pointer temp slot 93>[#3133  Auto] [flags 0x40007 0x0 ]           [0x788beaefc990] bci=[-1,5,170] rc=0 vc=0 vn=- li=-1 udi=- nc=1
n26904n     aladd (internalPtr )                                                              [0x788beaefc940] bci=[-1,5,170] rc=1 vc=0 vn=- li=- udi=- nc=2 flg=0x8000
n26903n       aloadi  <contiguousArrayDataAddrField>[#374  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [0x788beaefc8f0] bci=[-1,5,170] rc=1 vc=0 vn=- li=- udi=- nc=1 flg=0x8000
n26902n         aload  <pinning array temp slot 68>[#3108  Auto] [flags 0x10000007 0x0 ]      [0x788beaefc8a0] bci=[-1,5,170] rc=1 vc=0 vn=- li=- udi=- nc=0
n26901n       lconst 108 (highWordZero X!=0 X>=0 )                                            [0x788beaefc850] bci=[-1,5,170] rc=1 vc=0 vn=- li=- udi=- nc=0 flg=0x4104
```

Closes: https://github.com/eclipse-openj9/openj9/issues/21620