### PR TITLE
WIP: Fix thread interrupt issue during monitor wait

### DIFF
--- a/thread/common/omrthread.c
+++ b/thread/common/omrthread.c
@@ -3247,10 +3247,17 @@ static void
 threadInterruptWake(omrthread_t thread, omrthread_monitor_t monitor)
 {
 	ASSERT(thread);
-	ASSERT(thread->flags & J9THREAD_FLAG_WAITING);
-	ASSERT(0 != monitor);
+	ASSERT(NULL != thread);
+	ASSERT(OMR_ARE_ANY_BITS_SET(thread->flags, J9THREAD_FLAG_WAITING));
 
-	thread->flags |= J9THREAD_FLAG_BLOCKED;
+	/* Clear the native interrupt flag. */
+	if (OMR_ARE_NO_BITS_SET(thread->flags, J9THREAD_FLAG_PRIORITY_INTERRUPTED | J9THREAD_FLAG_ABORTED)) {
+		thread->flags &= ~J9THREAD_FLAG_INTERRUPTED;
+	}
+	/* Clear the WAITING flag. */
+	thread->flags &= ~J9THREAD_FLAG_WAITING;
+	/* Mark thread as BLOCKED and NOTIFIED. */
+	thread->flags |= (J9THREAD_FLAG_BLOCKED | J9THREAD_FLAG_NOTIFIED);
 	NOTIFY_WRAPPER(thread);
 }
 


### PR DESCRIPTION
The changes reflect the fix for issue [21804](https://github.com/eclipse-openj9/openj9/issues/21804).

Clear waiting flag in threadInterruptWake helper.

Closes: [21804](https://github.com/eclipse-openj9/openj9/issues/21804)
Signed-off-by: Nick Kamal <[nick.kamal@ibm.com](mailto:nick.kamal@ibm.com)>