### PR TITLE
Specify a 32 bit target for PMOVMSKB4RegReg

### DIFF
--- a/compiler/x/codegen/X86Ops.ins
+++ b/compiler/x/codegen/X86Ops.ins
@@ -3617,7 +3617,7 @@ INSTRUCTION(VPCMPQMaskMaskRegRegImm, vpcmpq,
             ),
 INSTRUCTION(PMOVMSKB4RegReg, pmovmskb,
             BINARY(VEX_L128, VEX_vNONE, PREFIX_66, REX__, ESCAPE_0F__, 0xd7, 0, ModRM_RM__, Immediate_0),
-            PROPERTY0(IA32OpProp_SourceRegisterInModRM),
+            PROPERTY0(IA32OpProp_SourceRegisterInModRM | IA32OpProp_IntTarget),
             PROPERTY1(IA32OpProp1_XMMSource),
             FEATURES(X86FeatureProp_MinTargetSupported |
                      X86FeatureProp_VEX128Supported | X86FeatureProp_VEX128RequiresAVX | X86FeatureProp_VEX256Supported | X86FeatureProp_VEX256RequiresAVX2)


### PR DESCRIPTION
Ensure that the code generator knows what size the target register should be for the `pmovmskb` instruction. From the Intel manual:
> Creates a mask made up of the most significant bit of each byte of the source operand (second operand) and stores
the result in the low byte or word of the destination operand (first operand).
The byte mask is 8 bits for 64-bit source operand, 16 bits for 128-bit source operand and 32 bits for 256-bit source
operand. The destination operand is a general-purpose register.

If the output is smaller than 32 bits, the rest of the register is zero extended, so a target GPR of 32 bits is always safe.