### PR TITLE
Do not clear stats on STW scan phase end

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -5599,8 +5599,6 @@ MM_Scavenger::scavengeIncremental(MM_EnvironmentBase *env)
 
 			_concurrentPhase = concurrent_phase_complete;
 
-			mergeIncrementGCStats(env, false);
-			clearIncrementGCStats(env, false);
 			continue;
 		}
 


### PR DESCRIPTION
In a relatively uncommon case were scan phase of Concurrent Scavenge is not completed fully concurrently, but a part of it is done in the final STW increment, we would prematurely clear the stats of that phase, so that GC end hook for that final increment would report incorrect (too low) copy data. It would report only the copy data from the complete phase (only copying during clearable phase, which is typically very minimal), while there could be signficant amount of tenuring (due to failed fipping)

Such clearing is already done at the beginning of each STW increment - so it's just removed from the end of STW scan phase.

Also no need to merge those stats to the global Scavenge stats structure, since it's already done at the end of any STW increment.

The change is supposed to be a non-fuctional. It's just correcting the VGC reporting. For example, average tenuring is not affected (since a merge was already being performed, although at 2 steps, rather than 1 that was sufficient).