### PR TITLE
x86: Implement OS checks in port library

### DIFF
--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -39,28 +39,16 @@ OMR::X86::CPU::detect(OMRPortLibrary * const omrPortLib)
    OMRProcessorDesc processorDescription;
    omrsysinfo_get_processor_description(&processorDescription);
 
-   bool disableAVX = true;
-   bool disableAVX512 = true;
-
-   // Check XCRO register for OS support of xmm/ymm/zmm
-   if (TRUE == omrsysinfo_processor_has_feature(&processorDescription, OMR_FEATURE_X86_OSXSAVE))
+   if (!omrsysinfo_processor_has_feature(&processorDescription, OMR_FEATURE_X86_XSAVE_AVX))
       {
-      // '6' = mask for XCR0[2:1]='11b' (XMM state and YMM state are enabled)
-      disableAVX = ((6 & _xgetbv(0)) != 6);
-      // 'e6' = (mask for XCR0[7:5]='111b' (Opmask, ZMM_Hi256, Hi16_ZMM) + XCR0[2:1]='11b' (XMM/YMM))
-      disableAVX512 = ((0xe6 & _xgetbv(0)) != 0xe6);
-      }
-
-   if (disableAVX)
-      {
-      // Unset AVX/AVX2 if not enabled via CR0 or otherwise disabled
+      // Unset AVX/AVX2 if not enabled via XCR0 or otherwise disabled
       omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_X86_AVX, FALSE);
       omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_X86_AVX2, FALSE);
       }
 
-   if (disableAVX512)
+   if (!omrsysinfo_processor_has_feature(&processorDescription, OMR_FEATURE_X86_XSAVE_AVX512))
       {
-      // Unset AVX-512 if not enabled via CR0 or otherwise disabled
+      // Unset AVX-512 if not enabled via XCR0 or otherwise disabled
       // If other AVX-512 extensions are supported in the port library, they need to be disabled here
       omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_X86_AVX512F, FALSE);
       omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_X86_AVX512VL, FALSE);

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1767,6 +1767,19 @@ typedef struct OMRProcessorDesc {
 #define OMR_FEATURE_X86_RDRAND       32 + 30 /* Processor supports RDRAND instruction. */
 #define OMR_FEATURE_X86_1_31         32 + 31 /* Not used */
 
+/* FLAGS FOR OS XSAVE/XRSTOR SUPPORT.
+ * These flags are to be set after checking XCR0 register flags.
+ */
+#define OMR_FEATURE_X86_XSAVE_SSE    64 + 0 /* OS Supports SSE (xmm) state */
+#define OMR_FEATURE_X86_XSAVE_AVX    64 + 1 /* OS Supports AVX (ymm) state */
+#define OMR_FEATURE_X86_XSAVE_AVX512 64 + 2 /* OS Supports AVX-512 (zmm, opmask) state */
+#define OMR_FEATURE_X86_XSAVE_APX    64 + 3 /* OS Supports APX (r16-r31) state */
+
+#define OMR_X86_XCR0_MASK_XMM        0x2      /* XCR0[1] - XMM state (SSE) */
+#define OMR_X86_XCR0_MASK_YMM        0x4      /* XCR0[2] - YMM state (AVX) */
+#define OMR_X86_XCR0_MASK_AVX512     0xe0     /* XCR0[7:5] - Opmask, ZMM_Hi256, Hi16_ZMM */
+#define OMR_X86_XCR0_MASK_APX_EGPR   0x80000  /* XCR0[19] - APX Extended GPRs */
+
 /* INTEL INSTRUCTION SET REFERENCE, A-L May 2019
  * Vol. 2 3-197 Table 3-8. Structured Feature Information Returned in the EBX Register by CPUID instruction
  */

--- a/port/common/omrsysinfo_helpers.h
+++ b/port/common/omrsysinfo_helpers.h
@@ -37,6 +37,9 @@ omrsysinfo_get_x86_processor_feature_name(uint32_t feature);
 extern intptr_t
 omrsysinfo_get_x86_description(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc);
 
+extern uint32_t
+omrsysinfo_get_x86_xsave_state();
+
 extern void
 omrsysinfo_get_x86_cpuid(uint32_t leaf, uint32_t *cpuInfo);
 


### PR DESCRIPTION
First attempt at adding OS support checks for x86 stored in extended control register 0 (xcr0).

We add support for the following:
 - xsave XMM 
 - xsave YMM
 - xsave ZMM (includes check for k0-k7, might want to separate into its own flag)
 - xsave EGPR (APX)

Control register flags are documented in the intel [manual](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html).