### PR TITLE
Add "TR_IPBCDataDirectCall" memory object type

### DIFF
--- a/compiler/env/TRMemory.cpp
+++ b/compiler/env/TRMemory.cpp
@@ -260,6 +260,7 @@ const char * objectName[] =
    "TR_IPBCDataEightWords",
    "TR_IPBCDataPointer",
    "TR_IPBCDataCallGraph",
+   "TR_IPBCDataDirectCall",
    "TR_ICallingContext",
 
    "TR_IPMethodTable",

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -404,6 +404,7 @@ public:
       IPBCDataEightWords,
       IPBCDataPointer,
       IPBCDataCallGraph,
+      IPBCDataDirectCall,
       IPCallingContext,
       IPMethodTable,
       IPCCNode,


### PR DESCRIPTION
This commit adds a new type of memory object, called "TR_IPBCDataDirectCall". 
This is used for tracking persistent memory allocations made by the interpreter profiler in a downstream project.