### PR TITLE
Change original base-array when createStoresForVar only if refCount==1

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -3873,6 +3873,7 @@ OMR::Node::createStoresForVar(TR::SymbolReference * &nodeRef, TR::TreeTop *inser
          self()->setIsInternalPointer(true);
 
       TR::Node *child = NULL;
+      bool updateBaseArray = self()->getReferenceCount() == 1;
 
       if (isInternalPointer)
          {
@@ -3885,7 +3886,10 @@ OMR::Node::createStoresForVar(TR::SymbolReference * &nodeRef, TR::TreeTop *inser
             else
                {
                while (child->getOpCode().isArrayRef())
+                  {
+                  if (child->getReferenceCount() > 1) updateBaseArray = false;
                   child = child->getFirstChild();
+                  }
 
                if (child->getOpCode().isLoadVarDirect() &&
                    child->getSymbolReference()->getSymbol()->isAuto())
@@ -3913,7 +3917,7 @@ OMR::Node::createStoresForVar(TR::SymbolReference * &nodeRef, TR::TreeTop *inser
                   newArrayRef->getSymbol()->setPinningArrayPointer();
                   pinningArray = newArrayRef->getSymbol()->castToAutoSymbol();
 
-                  if (child->isDataAddrPointer())
+                  if (child->isDataAddrPointer() && updateBaseArray)
                      {
                      arrayLoadNode = TR::Node::createLoad(arrayObjectNode, newArrayRef);
                      child->setAndIncChild(0, arrayLoadNode);


### PR DESCRIPTION
When `createStoresForVar` is called on array references, the reference is stored into a temp and the temp is passed back (using reference passed argument). 
The base-array of the reference is also stored into a new temp, and the original usage of the base-array is swapped with a load of the new base-array temp if the `refCount==1` (line 3816), for OffHeap the original base-array change was without checking the refConut causing https://github.com/eclipse-openj9/openj9/issues/21378. 
Basically changing a child of a commoned tree to use a newly inserted temp might affect an earlier tree (before temp definition) to use that temp before it's defined/populated. 


This PR guards the orginial base-array change using a refCount check.
Original issue showed up in a 1/20 grinder, with fix it didn't show in 100x runs. 

Closes: https://github.com/eclipse-openj9/openj9/issues/21378 