### PR TITLE
Correct description of SimpleRegex syntax

### DIFF
--- a/compiler/infra/SimpleRegex.cpp
+++ b/compiler/infra/SimpleRegex.cpp
@@ -35,23 +35,6 @@
 #include "ras/IgnoreLocale.hpp"
 
 
-/***
-    This is a mechanism to define a "filter."  A "filter" is basically
-    a (form of a) regular expression that allows one to specify a set
-    of class names, method names, etc.
-    <filter>:           <simple_pattern> | <simple_pattern> "[:|]" <filter>
-    <simple_pattern>:   <component> | <component> <simple_pattern>
-    <component>:        <str> | <wildcards> | <alternate>
-
-    for example, proc[d-g]:func*z will define a filter that matches
-    procd, proce, procf and procg as well as any string that begins
-    with func and ends with z.
-
-    If the first simple_pattern of a filter is a ^, the truth value
-    of the entire filter is inverted.
-***/
-
-
 namespace TR
 {
 
@@ -80,7 +63,7 @@ SimpleRegex *SimpleRegex::create(const char *& s)
 
 SimpleRegex::Regex *SimpleRegex::processRegex(const char *&s, bool &foundError)
    {
-   // First get rid of all + and |
+   // First get rid of all , and |
    //
    while (s[0] == ',' || s[0] == '|')
       ++s;

--- a/compiler/infra/SimpleRegex.hpp
+++ b/compiler/infra/SimpleRegex.hpp
@@ -41,8 +41,29 @@ class TR_ResolvedMethod;
 namespace TR
 {
 
-// Simple regular expression
-//
+/**
+ * This is a mechanism to define a \em filter.  A \em filter is basically
+ * a (form of a) regular expression that allows one to specify a set
+ * of class names, method names, etc.
+ *
+ \verbatim
+ <filter>:           <simple_pattern> | <simple_pattern> <separator> <filter>
+ <simple_pattern>:   <component> | <component> <simple_pattern>
+ <separator>:        "," | "|"
+ <component>:        <str> | <wildcard> | <character_choice>
+ <wildcard>:         "*" | "?"
+ <character_choice>: "[" "^"? <str> "]"
+ \endverbatim
+ *
+ * For example, <tt>proc[d-g],func*z</tt> will define a filter that matches
+ * \c procd, \c proce, \c procf and \c procg as well as any string that begins
+ * with \c func and ends with \c z.
+ *
+ * If the first \em simple_pattern of a filter is a caret &mdash; \c ^ &mdash; the truth value
+ * of the entire filter is inverted.  Similarly, if the first character of
+ * a \em character_choice is a caret, the truth value of that \em character_choice
+ * portion of the filter is inverted.
+ */
 class SimpleRegex
    {
    public:


### PR DESCRIPTION
The description of the `SimpleRegex` syntax indicated that each _simple_pattern_ of the _filter_ is separated by a colon or a vertical bar character.  In fact, they are separated by either a comma or a vertical bar.  Corrected the comment to reflect that.  Also moved the comment into a Doxygen comment.