### PR TITLE
Improve x86 arrayset

### DIFF
--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3854,6 +3854,174 @@ static void arraySetDefault(TR::Node* node, uint8_t elementSize, TR::Register* a
    cg->stopUsingRegister(EAX);
    }
 
+// Assumes valueReg is a GP register that contains a packed set of elements, and that sizeReg is within the range 1..3.
+static void arraySet1to3Bytes(TR::Node* node, uint8_t elementSize, TR::Register* addressReg, TR::Register* valueReg, TR::Register* sizeReg, TR::CodeGenerator* cg, TR::LabelSymbol *doneLabel = NULL)
+   {
+   bool localDoneLabel = doneLabel == NULL;
+   generateMemRegInstruction(TR::InstOpCode::S1MemReg, node, generateX86MemoryReference(addressReg, 0, cg), valueReg, cg);
+   generateMemRegInstruction(TR::InstOpCode::S1MemReg, node, generateX86MemoryReference(addressReg, sizeReg, 0, -1, cg), valueReg, cg);
+   generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, sizeReg, 2, cg);
+   if (localDoneLabel)
+      doneLabel = generateLabelSymbol(cg);
+   generateLabelInstruction(TR::InstOpCode::JBE4, node, doneLabel, cg);
+   generateMemRegInstruction(TR::InstOpCode::S1MemReg, node, generateX86MemoryReference(addressReg, 1, cg), valueReg, cg);
+   if (localDoneLabel)
+      generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, cg);
+   }
+
+// Assumes valueReg is a GP register that contains a packed set of elements, and that sizeReg is within the range 4..15.
+static void arraySet4to15Bytes(TR::Node* node, uint8_t elementSize, TR::Register* addressReg, TR::Register* valueReg, TR::Register* sizeReg, TR::Register *lastWordAddressReg, TR::Register *middleOffsetReg, TR::CodeGenerator* cg)
+   {
+   generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, lastWordAddressReg, generateX86MemoryReference(addressReg, sizeReg, 0, -4, cg), cg);
+   generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, sizeReg, middleOffsetReg, cg);
+   generateRegImmInstruction(TR::InstOpCode::ANDRegImms(), node, middleOffsetReg, 8, cg);
+   generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, generateX86MemoryReference(addressReg, 0, cg), valueReg, cg);
+   generateRegImmInstruction(TR::InstOpCode::SHRRegImm1(), node, middleOffsetReg, 1, cg);
+   generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, generateX86MemoryReference(lastWordAddressReg, 0, cg), valueReg, cg);
+   generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, generateX86MemoryReference(addressReg, middleOffsetReg, 0, cg), valueReg, cg);
+   generateRegInstruction(TR::InstOpCode::NEGReg(), node, middleOffsetReg, cg);
+   generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, generateX86MemoryReference(lastWordAddressReg, middleOffsetReg, 0, cg), valueReg, cg);
+   }
+
+// Assumes valueReg is an XMM register that contains a vector of elements, and that sizeReg is within the range 16..31.
+static void arraySet16to31Bytes(TR::Node* node, uint8_t elementSize, TR::Register* addressReg, TR::Register* xmmValueReg, TR::Register* sizeReg, TR::CodeGenerator* cg)
+   {
+   generateMemRegInstruction(TR::InstOpCode::MOVUPSMemReg, node, generateX86MemoryReference(addressReg, 0, cg), xmmValueReg, cg);
+   generateMemRegInstruction(TR::InstOpCode::MOVUPSMemReg, node, generateX86MemoryReference(addressReg, sizeReg, 0, -16, cg), xmmValueReg, cg);
+   }
+
+// Assumes valueReg is an XMM register that contains a vector of elements, and that sizeReg is within the range 32..63.
+static void arraySet32to63Bytes(TR::Node* node, uint8_t elementSize, TR::Register* addressReg, TR::Register* xmmValueReg, TR::Register* sizeReg, TR::CodeGenerator* cg)
+   {
+   generateMemRegInstruction(TR::InstOpCode::MOVUPSMemReg, node, generateX86MemoryReference(addressReg, 0, cg), xmmValueReg, cg);
+   generateMemRegInstruction(TR::InstOpCode::MOVUPSMemReg, node, generateX86MemoryReference(addressReg, 16, cg), xmmValueReg, cg);
+   generateMemRegInstruction(TR::InstOpCode::MOVUPSMemReg, node, generateX86MemoryReference(addressReg, sizeReg, 0, -32, cg), xmmValueReg, cg);
+   generateMemRegInstruction(TR::InstOpCode::MOVUPSMemReg, node, generateX86MemoryReference(addressReg, sizeReg, 0, -16, cg), xmmValueReg, cg);
+   }
+
+// Assumes valueReg is an XMM register that contains a vector of elements, and that sizeReg is >= 64.
+static void arraySet64ByteLoop(TR::Node* node, uint8_t elementSize, TR::Register* addressReg, TR::Register* xmmValueReg, TR::Register* sizeReg, TR::Register *scratch1Reg, TR::Register *scratch2Reg, TR::CodeGenerator* cg)
+   {
+   TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *residueLabel = generateLabelSymbol(cg);
+
+   // Unaligned store to the first 16 bytes
+   generateMemRegInstruction(TR::InstOpCode::MOVUPSMemReg, node, generateX86MemoryReference(addressReg, 0, cg), xmmValueReg, cg);
+   generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, scratch1Reg, addressReg, cg);
+   // Advance the address reg to the next 16-byte aligned address
+   generateRegImmInstruction(TR::InstOpCode::ADDRegImms(), node, addressReg, 15, cg);
+   generateRegImmInstruction(TR::InstOpCode::ANDRegImms(), node, addressReg, -16, cg);
+   // Calculate how many unaligned bytes were stored and subtract from the size
+   generateRegRegInstruction(TR::InstOpCode::SUBRegReg(), node, scratch1Reg, addressReg, cg);
+   generateRegRegInstruction(TR::InstOpCode::ADDRegReg(), node, sizeReg, scratch1Reg, cg);
+   // Check if we have at least 64 bytes left to store
+   // Enter the 64-byte per iteration aligned store loop if so
+   // Otherwise go to the residue loop
+   generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, sizeReg, 64, cg);
+   generateLabelInstruction(TR::InstOpCode::JB4, node, residueLabel, cg);
+   generateLabelInstruction(TR::InstOpCode::label, node, loopLabel, cg);
+   // 64-byte per iteration aligned store loop
+   generateMemRegInstruction(TR::InstOpCode::MOVAPSMemReg, node, generateX86MemoryReference(addressReg, 0, cg), xmmValueReg, cg);
+   generateMemRegInstruction(TR::InstOpCode::MOVAPSMemReg, node, generateX86MemoryReference(addressReg, 16, cg), xmmValueReg, cg);
+   generateMemRegInstruction(TR::InstOpCode::MOVAPSMemReg, node, generateX86MemoryReference(addressReg, 32, cg), xmmValueReg, cg);
+   generateMemRegInstruction(TR::InstOpCode::MOVAPSMemReg, node, generateX86MemoryReference(addressReg, 48, cg), xmmValueReg, cg);
+   generateRegImmInstruction(TR::InstOpCode::ADDRegImms(), node, addressReg, 64, cg);
+   generateRegImmInstruction(TR::InstOpCode::SUBRegImms(), node, sizeReg, 64, cg);
+   generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, sizeReg, 64, cg);
+   generateLabelInstruction(TR::InstOpCode::JAE4, node, loopLabel, cg);
+   // Residue
+   generateLabelInstruction(TR::InstOpCode::label, node, residueLabel, cg);
+   // At this point we have less than 64 bytes to store
+   // Calculate the address of the last 3 aligned stores
+   generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, scratch1Reg, generateX86MemoryReference(addressReg, sizeReg, 0, -48, cg), cg);
+   generateRegImmInstruction(TR::InstOpCode::ANDRegImms(), node, scratch1Reg, -16, cg);
+   // Calculate the address of the last (unaligned) store
+   generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, scratch2Reg, generateX86MemoryReference(addressReg, sizeReg, 0, -16, cg), cg);
+   // Do the stores
+   generateMemRegInstruction(TR::InstOpCode::MOVAPSMemReg, node, generateX86MemoryReference(scratch1Reg, 0, cg), xmmValueReg, cg);
+   generateMemRegInstruction(TR::InstOpCode::MOVAPSMemReg, node, generateX86MemoryReference(scratch1Reg, 16, cg), xmmValueReg, cg);
+   generateMemRegInstruction(TR::InstOpCode::MOVAPSMemReg, node, generateX86MemoryReference(scratch1Reg, 32, cg), xmmValueReg, cg);
+   generateMemRegInstruction(TR::InstOpCode::MOVUPSMemReg, node, generateX86MemoryReference(scratch2Reg, 0, cg), xmmValueReg, cg);
+   }
+
+static void arraySetXMM(TR::Node* node, uint8_t elementSize, TR::Register* addressReg, TR::Register* valueReg, TR::Register* sizeReg, const uintptr_t *size, TR::CodeGenerator* cg)
+   {
+   // This code is loosely based on the approach discussed in
+   // "Building Faster AMD64 Memset Routines" by Joe Bialek (January 11, 2021).
+   // https://msrc.microsoft.com/blog/2021/01/building-faster-amd64-memset-routines/
+   // We reduce path length and handle unaligned bytes more efficiently
+   // by setting some bytes multiple times, on the assumption
+   // that stores to overlapping memory ranges are cheaper than executing
+   // extra comparisons and branches to set each byte exactly once.
+   TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
+
+   TR::Register *scratch1Reg = cg->allocateRegister(TR_GPR);
+   TR::Register *scratch2Reg = cg->allocateRegister(TR_GPR);
+   TR::Register *xmmValueReg = cg->allocateRegister(TR_FPR);
+
+   generateRegRegInstruction(TR::InstOpCode::MOVDRegReg4, node, xmmValueReg, valueReg, cg);
+   generateRegRegInstruction(TR::InstOpCode::VPBROADCASTBRegReg, node, xmmValueReg, xmmValueReg, cg);
+
+   // If we don't know the size at compile-time or it's known to be less than 64 bytes, generate
+   // a series of tests for various sizes and branch to short, branch free sequences of stores.
+   // Currently `size` is expected to be NULL or >=64, since short compile-time sizes are handled
+   // in the main evaluator, otherwise we could avoid generating some of these tests for certain
+   // sizes.
+   if (size == NULL || *size < 64)
+   {
+      TR::LabelSymbol *ge64Label = generateLabelSymbol(cg);
+      TR::LabelSymbol *lt32Label = generateLabelSymbol(cg);
+      TR::LabelSymbol *lt16Label = generateLabelSymbol(cg);
+      TR::LabelSymbol *ge4lt16Label = generateLabelSymbol(cg);
+
+      generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, sizeReg, 64, cg);
+      generateLabelInstruction(TR::InstOpCode::JAE4, node, ge64Label, cg);
+      generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, sizeReg, 32, cg);
+      generateLabelInstruction(TR::InstOpCode::JB4, node, lt32Label, cg);
+
+      arraySet32to63Bytes(node, elementSize, addressReg, xmmValueReg, sizeReg, cg);
+      generateLabelInstruction(TR::InstOpCode::JMP4, node, doneLabel, cg);
+
+      generateLabelInstruction(TR::InstOpCode::label, node, lt32Label, cg);
+      generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, sizeReg, 16, cg);
+      generateLabelInstruction(TR::InstOpCode::JB4, node, lt16Label, cg);
+
+      arraySet16to31Bytes(node, elementSize, addressReg, xmmValueReg, sizeReg, cg);
+      generateLabelInstruction(TR::InstOpCode::JMP4, node, doneLabel, cg);
+
+      generateLabelInstruction(TR::InstOpCode::label, node, lt16Label, cg);
+      generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, sizeReg, 4, cg);
+      generateLabelInstruction(TR::InstOpCode::JAE4, node, ge4lt16Label, cg);
+      generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, sizeReg, sizeReg, cg);
+      generateLabelInstruction(TR::InstOpCode::JE4, node, doneLabel, cg);
+
+      arraySet1to3Bytes(node, elementSize, addressReg, valueReg, sizeReg, cg, doneLabel);
+
+      generateLabelInstruction(TR::InstOpCode::label, node, ge4lt16Label, cg);
+
+      arraySet4to15Bytes(node, elementSize, addressReg, valueReg, sizeReg, scratch1Reg, scratch2Reg, cg);
+      generateLabelInstruction(TR::InstOpCode::JMP4, node, doneLabel, cg);
+
+      generateLabelInstruction(TR::InstOpCode::label, node, ge64Label, cg);
+      }
+
+   arraySet64ByteLoop(node, elementSize, addressReg, xmmValueReg, sizeReg, scratch1Reg, scratch2Reg, cg);
+
+   TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(0, 6, cg);
+
+   deps->addPostCondition(addressReg, TR::RealRegister::NoReg, cg);
+   deps->addPostCondition(valueReg, TR::RealRegister::NoReg, cg);
+   deps->addPostCondition(sizeReg, TR::RealRegister::NoReg, cg);
+
+   deps->addPostCondition(scratch1Reg, TR::RealRegister::NoReg, cg);
+   deps->addPostCondition(scratch2Reg, TR::RealRegister::NoReg, cg);
+   deps->addPostCondition(xmmValueReg, TR::RealRegister::NoReg, cg);
+
+   deps->stopAddingConditions();
+
+   generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, deps, cg);
+   }
+
 TR::Register *OMR::X86::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    // arrayset
@@ -3946,7 +4114,15 @@ TR::Register *OMR::X86::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::Cod
          }
       else
          {
-         arraySetDefault(node, elementSize, addressReg, valueReg, sizeReg, cg);
+         static bool disableArraySetXMM = feGetEnv("TR_disableArraySetXMM") != NULL;
+         if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX2) && elementSize == 1 && !disableArraySetXMM)
+            {
+            arraySetXMM(node, elementSize, addressReg, valueReg, sizeReg, isSizeConst ? &size : NULL, cg);
+            }
+         else
+            {
+            arraySetDefault(node, elementSize, addressReg, valueReg, sizeReg, cg);
+            }
          }
       cg->decReferenceCount(sizeNode);
       cg->decReferenceCount(valueNode);

--- a/compiler/x/codegen/X86Ops.ins
+++ b/compiler/x/codegen/X86Ops.ins
@@ -615,6 +615,15 @@ INSTRUCTION(VBROADCASTSDZmmXmm, vbroadcastsd,
             PROPERTY0(IA32OpProp_ModifiesTarget | IA32OpProp_SourceRegisterInModRM),
             PROPERTY1(IA32OpProp1_XMMSource | IA32OpProp1_XMMTarget | IA32OpProp1_SIMDSingleSource),
             FEATURES(X86FeatureProp_EVEX512Supported | X86FeatureProp_EVEX512RequiresAVX512F)),
+INSTRUCTION(VPBROADCASTBRegReg, vpbroadcastb,
+            BINARY(VEX_L128, VEX_vNONE, PREFIX_66, REX__, ESCAPE_0F38, 0x78, 0, ModRM_RM__, Immediate_0),
+            PROPERTY0(IA32OpProp_ModifiesTarget | IA32OpProp_SourceRegisterInModRM),
+            PROPERTY1(IA32OpProp1_XMMSource | IA32OpProp1_XMMTarget | IA32OpProp1_SIMDSingleSource),
+            FEATURES(X86FeatureProp_VEX128Supported | X86FeatureProp_VEX128RequiresAVX2 | X86FeatureProp_VEX256Supported | X86FeatureProp_VEX256RequiresAVX2 |
+                     X86FeatureProp_EVEX128Supported | X86FeatureProp_EVEX128RequiresAVX512F | X86FeatureProp_EVEX128RequiresAVX512VL |
+                     X86FeatureProp_EVEX256Supported | X86FeatureProp_EVEX256RequiresAVX512F | X86FeatureProp_EVEX256RequiresAVX512VL |
+                     X86FeatureProp_EVEX512Supported | X86FeatureProp_EVEX512RequiresAVX512F)
+            ),
 INSTRUCTION(BSF2RegReg, bsf,
             BINARY(VEX_L___, VEX_vNONE, PREFIX___, REX__, ESCAPE_0F__, 0xbc, 0, ModRM_RM__, Immediate_0),
             PROPERTY0(IA32OpProp_ModifiesTarget | IA32OpProp_ShortTarget | IA32OpProp_ShortSource | IA32OpProp_SourceRegisterInModRM | IA32OpProp_ModifiesZeroFlag),


### PR DESCRIPTION
Improve x86 arrayset

For cases where the length of an arrayset is not known at compile-time,
or known to be >= 256 bytes, we generate a REP STOS sequence. This
is sub-optimal for small lengths as REP STOS has a relatively high
setup cost.

This patch implements a different sequence for a subset of the cases
that are currently handled by REP STOS. Specifically, if the arrayset
element size is 1 byte, it generates sequences to handle
the following lengths:

0 bytes
1-3 bytes, 2-3 stores, 1 branch
4-15 bytes, 4 stores, branch-free
16-31 bytes, 2 unaligned 16-byte stores, branch-free
32-63 bytes, 4 unaligned 16-byte stores, branch-free
>=64 bytes,
  1 unaligned 16-byte store,
  4 aligned 16-byte stores in a loop,
  3 aligned 16-byte stores in the residue
  1 unaligned 16-byte store in the residue

If the length is known to be >=64 only the loop will be generated.

This code is loosely based on the approach discussed in
"Building Faster AMD64 Memset Routines" by Joe Bialek (January 11, 2021).
https://msrc.microsoft.com/blog/2021/01/building-faster-amd64-memset-routines/
We reduce path length and handle unaligned bytes more efficiently
by setting some bytes multiple times, on the assumption
that stores to overlapping memory ranges are cheaper than executing
extra comparisons and branches to set each byte exactly once.

Add x86 vpbroadcastb instruction

Add support for the following AVX2 x86 instruction:

VEX.128.66.0F38.W0 78 /r VPBROADCASTB xmm1, xmm2/m8

Broadcast a byte integer in the source
operand to sixteen locations in xmm1.

This PR should allow https://github.com/eclipse-omr/omr/pull/7704 to be merged.