### PR TITLE
Fix spelling of "supress"

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -4055,7 +4055,7 @@ void TR_InlinerBase::getSymbolAndFindInlineTargets(TR_CallStack *callStack, TR_C
    if (callsite->_initialCalleeSymbol)
       {
       callsite->assertInitialCalleeConsistency();
-      if (getPolicy()->supressInliningRecognizedInitialCallee(callsite, comp()))
+      if (getPolicy()->suppressInliningRecognizedInitialCallee(callsite, comp()))
          isInlineable = Recognized_Callee;
 
       if (isInlineable != InlineableTarget)
@@ -6420,7 +6420,7 @@ OMR_InlinerUtil::refineInlineGuard(TR::Node *callNode, TR::Block *&block1, TR::B
  * stop inlining for this callsite if TR_CallSite#_initialCalleeSymbol is certain specific method
  */
 bool
-OMR_InlinerPolicy::supressInliningRecognizedInitialCallee(TR_CallSite* callsite, TR::Compilation* comp)
+OMR_InlinerPolicy::suppressInliningRecognizedInitialCallee(TR_CallSite* callsite, TR::Compilation* comp)
    {
    return false;
    }

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -667,7 +667,7 @@ class OMR_InlinerPolicy : public TR::OptimizationPolicy, public OMR_InlinerHelpe
        *
        * \return true if the method shouldn't be inlined in inliner
        */
-      virtual bool supressInliningRecognizedInitialCallee(TR_CallSite* callsite, TR::Compilation* comp);
+      virtual bool suppressInliningRecognizedInitialCallee(TR_CallSite* callsite, TR::Compilation* comp);
 
    protected:
       virtual bool tryToInlineTrivialMethod (TR_CallStack* callStack, TR_CallTarget* calltarget);


### PR DESCRIPTION
This commit fixes the misspelled function name
supressInliningRecognizedInitialCallee().