### PR TITLE
Apply throw() for signal functions with Open XL

### DIFF
--- a/include_core/omrsig.h
+++ b/include_core/omrsig.h
@@ -32,13 +32,13 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#if defined(AIXPPC) || defined(OSX) || defined(J9ZOS390) || !defined(__cplusplus)
+#if defined(AIXPPC) || defined(OSX) || (defined(J9ZOS390) && !defined(__open_xl__)) || !defined(__cplusplus)
 #define OMRSIG_NO_THROW
-#elif __cplusplus < 201103L /* defined(AIXPPC) || defined(OSX) || defined(J9ZOS390) || !defined(__cplusplus) */
+#elif __cplusplus < 201103L /* defined(AIXPPC) || defined(OSX) || (defined(J9ZOS390) && !defined(__open_xl__)) || !defined(__cplusplus) */
 #define OMRSIG_NO_THROW throw()
 #else /* __cplusplus < 201103L */
 #define OMRSIG_NO_THROW noexcept
-#endif /* defined(AIXPPC) || defined(OSX) || defined(J9ZOS390) || !defined(__cplusplus) */
+#endif /* defined(AIXPPC) || defined(OSX) || (defined(J9ZOS390) && !defined(__open_xl__)) || !defined(__cplusplus) */
 
 #if defined(LINUXPPC)
 typedef __sighandler_t sighandler_t;


### PR DESCRIPTION
Apply throw() for signal functions with Open XL

https://github.com/eclipse-omr/omr/pull/7807 introduced OMRSIG_NO_THROW,
which is non-empty for C++ contexts, with exceptions for AIX, macOS and
z/OS.

Open XL on z/OS still requires these methods declare that they do not throw
exceptions, this rectifies the conditional to do so

-----------------


Related/Original issue: https://github.com/eclipse-omr/omr/pull/7320

@keithc-ca I have separated out the remaining problem from the original PR, and created a draft PR while I investigate the changes here closer.
Here I have removed all the `throw()` references, and will attempt to recompile and go through the errors.