### PR TITLE
x86: Expand cpuid support in port library

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1770,15 +1770,29 @@ typedef struct OMRProcessorDesc {
 /* FLAGS FOR OS XSAVE/XRSTOR SUPPORT.
  * These flags are to be set after checking XCR0 register flags.
  */
-#define OMR_FEATURE_X86_XSAVE_SSE    64 + 0 /* OS Supports SSE (xmm) state */
-#define OMR_FEATURE_X86_XSAVE_AVX    64 + 1 /* OS Supports AVX (ymm) state */
-#define OMR_FEATURE_X86_XSAVE_AVX512 64 + 2 /* OS Supports AVX-512 (zmm, opmask) state */
-#define OMR_FEATURE_X86_XSAVE_APX    64 + 3 /* OS Supports APX (r16-r31) state */
+#define OMR_FEATURE_X86_XSAVE_SSE    64 + 0 /* OS Supports SSE (xmm) state. */
+#define OMR_FEATURE_X86_XSAVE_AVX    64 + 1 /* OS Supports AVX (ymm) state. */
+#define OMR_FEATURE_X86_XSAVE_AVX512 64 + 2 /* OS Supports AVX-512 (zmm, opmask) state. */
+#define OMR_FEATURE_X86_XSAVE_APX    64 + 3 /* OS Supports APX (r16-r31) state. */
 
-#define OMR_X86_XCR0_MASK_XMM        0x2      /* XCR0[1] - XMM state (SSE) */
-#define OMR_X86_XCR0_MASK_YMM        0x4      /* XCR0[2] - YMM state (AVX) */
-#define OMR_X86_XCR0_MASK_AVX512     0xe0     /* XCR0[7:5] - Opmask, ZMM_Hi256, Hi16_ZMM */
-#define OMR_X86_XCR0_MASK_APX_EGPR   0x80000  /* XCR0[19] - APX Extended GPRs */
+/* FLAGS FOR AVX 10.X SUPPORT.
+ * These flags are to be set after checking for AVX10 and XCR0 register flags.
+ */
+#define OMR_FEATURE_X86_AVX10_1      64 + 4 /* AVX 10.1 support. */
+#define OMR_FEATURE_X86_AVX10_2      64 + 5 /* AVX 10.2 support. */
+
+/* Bits 7-15 are reserved. */
+
+/* AVX 10 vector length support from CPUID.(EAX=24H, ECX=00H):EBX[16-18]. */
+#define OMR_FEATURE_X86_AVX10_128    64 + 16 /* Indicates 128-bit vector support. */
+#define OMR_FEATURE_X86_AVX10_256    64 + 17 /* Indicates 256-bit vector support. */
+#define OMR_FEATURE_X86_AVX10_512    64 + 18 /* Indicates 512-bit vector support. */
+/* Bits 19+ are reserved. */
+
+#define OMR_X86_XCR0_MASK_XMM        0x2      /* XCR0[1] - XMM state (SSE). */
+#define OMR_X86_XCR0_MASK_YMM        0x4      /* XCR0[2] - YMM state (AVX). */
+#define OMR_X86_XCR0_MASK_AVX512     0xe0     /* XCR0[7:5] - Opmask, ZMM_Hi256, Hi16_ZMM. */
+#define OMR_X86_XCR0_MASK_APX_EGPR   0x80000  /* XCR0[19] - APX Extended GPRs. */
 
 /* INTEL INSTRUCTION SET REFERENCE, A-L May 2019
  * Vol. 2 3-197 Table 3-8. Structured Feature Information Returned in the EBX Register by CPUID instruction
@@ -1851,6 +1865,79 @@ typedef struct OMRProcessorDesc {
 #define OMR_FEATURE_X86_ENQCMD              128 + 29
 #define OMR_FEATURE_X86_SGX_LC              128 + 30
 #define OMR_FEATURE_X86_PKS                 128 + 31
+
+/*
+ * Structured Feature Information Returned in the EAX Register by CPUID instruction when EAX = 7, ECX = 1
+ */
+#define OMR_FEATURE_X86_SHA512                       160 + 0   /* SHA512. */
+#define OMR_FEATURE_X86_SM3                          160 + 1   /* SM3. */
+#define OMR_FEATURE_X86_SM4                          160 + 2   /* SM4. */
+#define OMR_FEATURE_X86_5_3                          160 + 3   /* Reserved. */
+#define OMR_FEATURE_X86_AVX_VNNI                     160 + 4   /* AVX-VNNI. */
+#define OMR_FEATURE_X86_AVX512_BF16                  160 + 5   /* AVX512-BF16. */
+#define OMR_FEATURE_X86_LASS                         160 + 6   /* LASS. */
+#define OMR_FEATURE_X86_CMPCCXADD                    160 + 7   /* CMPCCXADD. */
+#define OMR_FEATURE_X86_ARCHPERFMONEXT               160 + 8   /* ArchPerfMonExt. */
+#define OMR_FEATURE_X86_INDEX9                       160 + 9   /* Reserved. */
+#define OMR_FEATURE_X86_FASTREP_MOVSB_ZERO           160 + 10  /* Fast zero-length REP MOVSB. */
+#define OMR_FEATURE_X86_FASTREP_STOSB_SHORT          160 + 11  /* Fast short REP STOSB. */
+#define OMR_FEATURE_X86_FASTREP_CMPSB_SCASB_SHORT    160 + 12  /* Fast short REP CMPSB, SCASB. */
+#define OMR_FEATURE_X86_5_13                         160 + 13  /* Reserved. */
+#define OMR_FEATURE_X86_5_14                         160 + 14  /* Reserved. */
+#define OMR_FEATURE_X86_5_15                         160 + 15  /* Reserved. */
+#define OMR_FEATURE_X86_5_16                         160 + 16  /* Reserved. */
+#define OMR_FEATURE_X86_5_17                         160 + 17  /* Reserved. */
+#define OMR_FEATURE_X86_5_18                         160 + 18  /* Reserved. */
+#define OMR_FEATURE_X86_WRMSRNS                      160 + 19  /* WRMSRNS. */
+#define OMR_FEATURE_X86_INDEX20                      160 + 20  /* Reserved. */
+#define OMR_FEATURE_X86_AMX_FP16                     160 + 21  /* AMX-FP16. */
+#define OMR_FEATURE_X86_HRESET                       160 + 22  /* HRESET. */
+#define OMR_FEATURE_X86_AVX_IFMA                     160 + 23  /* AVX-IFMA. */
+#define OMR_FEATURE_X86_INDEX24                      160 + 24  /* Reserved. */
+#define OMR_FEATURE_X86_INDEX25                      160 + 25  /* Reserved. */
+#define OMR_FEATURE_X86_LAM                          160 + 26  /* LAM. */
+#define OMR_FEATURE_X86_MSRLIST                      160 + 27  /* MSRLIST. */
+#define OMR_FEATURE_X86_5_28                         160 + 28  /* Reserved. */
+#define OMR_FEATURE_X86_5_29                         160 + 29  /* Reserved. */
+#define OMR_FEATURE_X86_INVD_DISABLE_POST_BIOS_DONE  160 + 30  /* INVD_DISABLE_POST_BIOS_DONE. */
+#define OMR_FEATURE_X86_5_MOVRS                      160 + 31  /* MOVRS. */
+
+/*
+ * Structured Feature Information Returned in the EDX Register by CPUID instruction when EAX = 7, ECX = 1
+ */
+#define OMR_FEATURE_X86_6_0                   192 + 0   /* Reserved. */
+#define OMR_FEATURE_X86_6_1                   192 + 1   /* Reserved. */
+#define OMR_FEATURE_X86_6_2                   192 + 2   /* Reserved. */
+#define OMR_FEATURE_X86_6_3                   192 + 3   /* Reserved. */
+#define OMR_FEATURE_X86_AVX_VNNI_INT8         192 + 4   /* AVX-VNNI-INT8. */
+#define OMR_FEATURE_X86_AVX_NE_CONVERT        192 + 5   /* AVX-NE-CONVERT. */
+#define OMR_FEATURE_X86_6_6                   192 + 6   /* Reserved. */
+#define OMR_FEATURE_X86_6_7                   192 + 7   /* Reserved. */
+#define OMR_FEATURE_X86_AMX_COMPLEX           192 + 8   /* AMX-COMPLEX. */
+#define OMR_FEATURE_X86_6_9                   192 + 9   /* Reserved. */
+#define OMR_FEATURE_X86_AVX_VNNI_INT16        192 + 10  /* AVX-VNNI-INT16. */
+#define OMR_FEATURE_X86_6_11                  192 + 11  /* Reserved. */
+#define OMR_FEATURE_X86_6_12                  192 + 12  /* Reserved. */
+#define OMR_FEATURE_X86_6_13                  192 + 13  /* Reserved. */
+#define OMR_FEATURE_X86_PREFETCHI             192 + 14  /* PREFETCHI. */
+#define OMR_FEATURE_X86_6_15                  192 + 15  /* Reserved. */
+#define OMR_FEATURE_X86_6_16                  192 + 16  /* Reserved. */
+#define OMR_FEATURE_X86_UIRET_UIF             192 + 17  /* UIRET_UIF. */
+#define OMR_FEATURE_X86_CET_SSS               192 + 18  /* CET_SSS. */
+#define OMR_FEATURE_X86_AVX10                 192 + 19  /* AVX10. */
+#define OMR_FEATURE_X86_6_20                  192 + 20  /* Reserved. */
+#define OMR_FEATURE_X86_APX                   192 + 21  /* Advanced Performance Extensions (APX). */
+#define OMR_FEATURE_X86_6_22                  192 + 22  /* Reserved. */
+#define OMR_FEATURE_X86_6_23                  192 + 23  /* Reserved. */
+#define OMR_FEATURE_X86_6_24                  192 + 24  /* Reserved. */
+#define OMR_FEATURE_X86_6_25                  192 + 25  /* Reserved. */
+#define OMR_FEATURE_X86_6_26                  192 + 26  /* Reserved. */
+#define OMR_FEATURE_X86_6_27                  192 + 27  /* Reserved. */
+#define OMR_FEATURE_X86_6_28                  192 + 28  /* Reserved. */
+#define OMR_FEATURE_X86_6_29                  192 + 29  /* Reserved. */
+#define OMR_FEATURE_X86_6_30                  192 + 30  /* Reserved. */
+#define OMR_FEATURE_X86_6_31                  192 + 31  /* Reserved. */
+
 
 /*  AArch64 Linux features
  *  See https://www.kernel.org/doc/html/latest/arm64/elf_hwcaps.html.

--- a/port/common/omrsysinfo_helpers.c
+++ b/port/common/omrsysinfo_helpers.c
@@ -47,6 +47,7 @@
 #define CPUID_VENDOR_INFO                                 0
 #define CPUID_FAMILY_INFO                                 1
 #define CPUID_STRUCTURED_EXTENDED_FEATURE_INFO            7
+#define CPUID_AVX10_ENUMERATION_FEATURE_INFO              0x24
 
 #define CPUID_VENDOR_INTEL                                "GenuineIntel"
 #define CPUID_VENDOR_AMD                                  "AuthenticAMD"
@@ -188,8 +189,8 @@ static const char* const OMR_FEATURE_X86_NAME[] = {
 	"null",             /* 2 * 32 + 1 */
 	"null",             /* 2 * 32 + 2 */
 	"null",             /* 2 * 32 + 3 */
-	"null",             /* 2 * 32 + 4 */
-	"null",             /* 2 * 32 + 5 */
+	"avx10.1",          /* 2 * 32 + 4 */
+	"avx10.2",          /* 2 * 32 + 5 */
 	"null",             /* 2 * 32 + 6 */
 	"null",             /* 2 * 32 + 7 */
 	"null",             /* 2 * 32 + 8 */
@@ -200,9 +201,9 @@ static const char* const OMR_FEATURE_X86_NAME[] = {
 	"null",             /* 2 * 32 + 13 */
 	"null",             /* 2 * 32 + 14 */
 	"null",             /* 2 * 32 + 15 */
-	"null",             /* 2 * 32 + 16 */
-	"null",             /* 2 * 32 + 17 */
-	"null",             /* 2 * 32 + 18 */
+	"avx10/128",        /* 2 * 32 + 16 */
+	"avx10/256",        /* 2 * 32 + 17 */
+	"avx10/512",        /* 2 * 32 + 18 */
 	"null",             /* 2 * 32 + 19 */
 	"null",             /* 2 * 32 + 20 */
 	"null",             /* 2 * 32 + 21 */
@@ -279,7 +280,71 @@ static const char* const OMR_FEATURE_X86_NAME[] = {
 	"movdir64b",        /* 4 * 32 + 28 */
 	"enqcmd",           /* 4 * 32 + 29 */
 	"sgx_lc",           /* 4 * 32 + 30 */
-	"pks"               /* 4 * 32 + 31 */
+	"pks",              /* 4 * 32 + 31 */
+	"sha512",           /* 5 * 32 + 0 */
+	"sm3",              /* 5 * 32 + 1 */
+	"sm4",              /* 5 * 32 + 2 */
+	"null",             /* 5 * 32 + 3 */
+	"avx_vnni",         /* 5 * 32 + 4 */
+	"avx512_bf16",      /* 5 * 32 + 5 */
+	"lass",             /* 5 * 32 + 6 */
+	"cmpccxadd",        /* 5 * 32 + 7 */
+	"archperfmonext",   /* 5 * 32 + 8 */
+	"null",             /* 5 * 32 + 9 */
+	"fastrep_movsb_zero",        /* 5 * 32 + 10 */
+	"fastrep_stosb_short",       /* 5 * 32 + 11 */
+	"fastrep_cmpsb_scasb_short", /* 5 * 32 + 12 */
+	"null",             /* 5 * 32 + 13 */
+	"null",             /* 5 * 32 + 14 */
+	"null",             /* 5 * 32 + 15 */
+	"null",             /* 5 * 32 + 16 */
+	"null",             /* 5 * 32 + 17 */
+	"null",             /* 5 * 32 + 18 */
+	"wrmsrns",          /* 5 * 32 + 19 */
+	"null",             /* 5 * 32 + 20 */
+	"amx_fp16",         /* 5 * 32 + 21 */
+	"hreset",           /* 5 * 32 + 22 */
+	"avx_ifma",         /* 5 * 32 + 23 */
+	"null",             /* 5 * 32 + 24 */
+	"null",             /* 5 * 32 + 25 */
+	"lam",              /* 5 * 32 + 26 */
+	"msrlist",          /* 5 * 32 + 27 */
+	"null",             /* 5 * 32 + 28 */
+	"null",             /* 5 * 32 + 29 */
+	"invd_disable_post_bios_done", /* 5 * 32 + 30 */
+	"movrs",            /* 5 * 32 + 31 */
+	"null",             /* 6 * 32 + 0  */
+	"null",             /* 6 * 32 + 1  */
+	"null",             /* 6 * 32 + 2  */
+	"null",             /* 6 * 32 + 3  */
+	"avx_vnni_int8",    /* 6 * 32 + 4  */
+	"avx_ne_convert",   /* 6 * 32 + 5  */
+	"null",             /* 6 * 32 + 6  */
+	"null",             /* 6 * 32 + 7  */
+	"amx_complex",      /* 6 * 32 + 8  */
+	"null",             /* 6 * 32 + 9  */
+	"avx_vnni_int16",   /* 6 * 32 + 10 */
+	"null",             /* 6 * 32 + 11 */
+	"null",             /* 6 * 32 + 12 */
+	"null",             /* 6 * 32 + 13 */
+	"prefetchi",        /* 6 * 32 + 14 */
+	"null",             /* 6 * 32 + 15 */
+	"null",             /* 6 * 32 + 16 */
+	"uiretuif",         /* 6 * 32 + 17 */
+	"cet_sss",          /* 6 * 32 + 18 */
+	"avx10",            /* 6 * 32 + 19 */
+	"null",             /* 6 * 32 + 20 */
+	"apx",              /* 6 * 32 + 21 */
+	"null",             /* 6 * 32 + 22 */
+	"null",             /* 6 * 32 + 23 */
+	"null",             /* 6 * 32 + 24 */
+	"null",             /* 6 * 32 + 25 */
+	"null",             /* 6 * 32 + 26 */
+	"null",             /* 6 * 32 + 27 */
+	"null",             /* 6 * 32 + 28 */
+	"null",             /* 6 * 32 + 29 */
+	"null",             /* 6 * 32 + 30 */
+	"null"              /* 6 * 32 + 31 */
 };
 
 const char *
@@ -433,15 +498,37 @@ omrsysinfo_get_x86_description(struct OMRPortLibrary *portLibrary, OMRProcessorD
 	desc->features[1] = CPUInfo[CPUID_ECX];
 	desc->features[2] = 0;
 
-	/* If OSXSAVE is supported, populate the XSAVE state in desc->features[2]. Unused bits (4-31) are reserved for future expansion. */
-	if (OMR_ARE_ANY_BITS_SET(desc->features[(OMR_FEATURE_X86_OSXSAVE) / 32], INDEX_TO_MASK(OMR_FEATURE_X86_OSXSAVE))) {
+	/* Extended features.
+	 * CPUID(EAX=0x7,ECX=0x0)
+	 */
+	omrsysinfo_get_x86_cpuid_ext(CPUID_STRUCTURED_EXTENDED_FEATURE_INFO, 0, CPUInfo);
+	desc->features[3] = CPUInfo[CPUID_EBX]; /* Structured Extended Feature Flags in EBX. */
+	desc->features[4] = CPUInfo[CPUID_ECX]; /* Structured Extended Feature Flags in ECX. */
+
+	/* CPUID(EAX=0x7,ECX=0x1) */
+	omrsysinfo_get_x86_cpuid_ext(CPUID_STRUCTURED_EXTENDED_FEATURE_INFO, 1, CPUInfo);
+	desc->features[5] = CPUInfo[CPUID_EAX]; /* Structured Extended Feature Flags in EAX. */
+	desc->features[6] = CPUInfo[CPUID_EDX]; /* Structured Extended Feature Flags in EDX. */
+
+	/* Populate special-case features in desc->features[2]. */
+
+	/* If OSXSAVE is supported, populate the XSAVE state in desc->features[2], bits 0-3. */
+	if (OMR_ARE_ANY_BITS_SET(
+			desc->features[(OMR_FEATURE_X86_OSXSAVE) / 32],
+			INDEX_TO_MASK(OMR_FEATURE_X86_OSXSAVE))
+	) {
 		desc->features[2] |= omrsysinfo_get_x86_xsave_state();
 	}
 
-	/* extended features */
-	omrsysinfo_get_x86_cpuid_ext(CPUID_STRUCTURED_EXTENDED_FEATURE_INFO, 0, CPUInfo); /* 0x0 is the only valid subleaf value for this leaf */
-	desc->features[3] = CPUInfo[CPUID_EBX]; /* Structured Extended Feature Flags in EBX */
-	desc->features[4] = CPUInfo[CPUID_ECX]; /* Structured Extended Feature Flags in ECX */
+	/* If AVX 10 is supported, populate the AVX 10.X sub version flags in desc->features[2],
+	 * bits 4-6, 16-18. Unused bits (7-15, 19-31) are reserved for future expansion.
+	 */
+	if (OMR_ARE_ANY_BITS_SET(
+			desc->features[(OMR_FEATURE_X86_AVX10) / 32],
+			INDEX_TO_MASK(OMR_FEATURE_X86_AVX10))
+	) {
+		desc->features[2] |= omrsysinfo_get_x86_avx10_subversion();
+	}
 
 	return 0;
 }
@@ -491,6 +578,50 @@ omrsysinfo_get_x86_xsave_state()
 	if (OMR_ARE_ANY_BITS_SET(xcr0, OMR_X86_XCR0_MASK_APX_EGPR)) {
 		state |= INDEX_TO_MASK(OMR_FEATURE_X86_XSAVE_APX);
 	}
+
+	return state;
+}
+
+/**
+ * @brief Queries the AVX10 sub-version and supported vector lengths on x86 CPUs.
+ *
+ * This function retrieves information about the AVX10 instruction set extensions
+ * supported by the processor using the CPUID leaf EAX=0x24, sub-leaf ECX=0. The AVX10 sub-version
+ * is stored in EBX[7:0] and is used to determine which AVX10.X features are available.
+ * Additionally, vector length support (128-bit, 256-bit, 512-bit) is also reported via flags.
+ *
+ * The returned value is a bitmask composed of `OMR_FEATURE_X86_AVX10_*` flags indicating:
+ * - AVX10 sub-version support (AVX10.1, AVX10.2, AVX10.3)
+ * - Vector length support (128/256/512-bit)
+ *
+ * @return A bitmask indicating the AVX10 features and vector lengths supported by the CPU.
+ */
+uint32_t
+omrsysinfo_get_x86_avx10_subversion()
+{
+	/* AVX 10.X support is stored in CPUID(EAX=0x24,ECX=0). EBX[7:0] as an enumeration. */
+	uint32_t state = 0;
+	uint32_t subVersion = 0;
+	uint32_t CPUInfo[4] = {0};
+
+	/* CPUID(EAX=0x24,ECX=0x0) */
+	omrsysinfo_get_x86_cpuid_ext(CPUID_AVX10_ENUMERATION_FEATURE_INFO, 0, CPUInfo);
+	subVersion = CPUInfo[CPUID_EBX] & 0xff;
+
+	if (subVersion >= 1) {
+		state |= INDEX_TO_MASK(OMR_FEATURE_X86_AVX10_1);
+	}
+
+	if (subVersion >= 2) {
+		state |= INDEX_TO_MASK(OMR_FEATURE_X86_AVX10_2);
+	}
+
+	/* Set more flags as new sub versions arrive. */
+
+	/* Check vector length support. */
+	state |= CPUInfo[CPUID_EBX] & INDEX_TO_MASK(OMR_FEATURE_X86_AVX10_128);
+	state |= CPUInfo[CPUID_EBX] & INDEX_TO_MASK(OMR_FEATURE_X86_AVX10_256);
+	state |= CPUInfo[CPUID_EBX] & INDEX_TO_MASK(OMR_FEATURE_X86_AVX10_512);
 
 	return state;
 }

--- a/port/common/omrsysinfo_helpers.h
+++ b/port/common/omrsysinfo_helpers.h
@@ -40,6 +40,9 @@ omrsysinfo_get_x86_description(struct OMRPortLibrary *portLibrary, OMRProcessorD
 extern uint32_t
 omrsysinfo_get_x86_xsave_state();
 
+extern uint32_t
+omrsysinfo_get_x86_avx10_subversion();
+
 extern void
 omrsysinfo_get_x86_cpuid(uint32_t leaf, uint32_t *cpuInfo);
 


### PR DESCRIPTION
x86: Expand cpuid support in port library
    
This commit adds CPUD queries to check for new CPU features, specifically APX and AVX 10. The following CPUD queries are introduced:
    
 - `CPUID.(0x7.0x1).EAX`
 - `CPUID.(0x7.0x1).EDX`
 - `CPUID.(0x24.0x0).EBX[7:0]` - AVX 10 sub-version
 - `CPUID.(0x24.0x0).EBX[16-18]` - AVX 10 VL support
    
New AVX 10 feature flags are added:
 - `OMR_FEATURE_X86_AVX10_1`: AVX 10.1
 - `OMR_FEATURE_X86_AVX10_2`: AVX 10.2
 - `OMR_FEATURE_X86_AVX10_128`: AVX 10 128-bit support
 - `OMR_FEATURE_X86_AVX10_256`: AVX 10 256-bit support
 - `OMR_FEATURE_X86_AVX10_512`: AVX 10 512-bit support
