### PR TITLE
Identify `MutableCallSite` for guards based on known object index

### DIFF
--- a/compiler/compile/VirtualGuard.cpp
+++ b/compiler/compile/VirtualGuard.cpp
@@ -56,7 +56,8 @@ TR_VirtualGuard::TR_VirtualGuard(TR_VirtualGuardTestType test, TR_VirtualGuardKi
 #ifdef J9_PROJECT_SPECIFIC
      _sites(comp->trMemory()),
 #endif
-     _mutableCallSiteObject(0),_mutableCallSiteEpoch(0),
+     _mutableCallSiteObject(TR::KnownObjectTable::UNKNOWN),
+     _mutableCallSiteEpoch(TR::KnownObjectTable::UNKNOWN),
      _evalChildren(true), _mergedWithHCRGuard(false), _mergedWithOSRGuard(false),
      _guardNode(guardNode), _currentInlinedSiteIndex(currentSiteIndex)
    {
@@ -373,7 +374,7 @@ TR_VirtualGuard::createNonoverriddenGuard
 
 
 TR::Node *
-TR_VirtualGuard::createMutableCallSiteTargetGuard(TR::Compilation * comp, int16_t calleeIndex, TR::Node * node, TR::TreeTop * destination, uintptr_t *mcsObject, TR::KnownObjectTable::Index mcsEpoch)
+TR_VirtualGuard::createMutableCallSiteTargetGuard(TR::Compilation * comp, int16_t calleeIndex, TR::Node * node, TR::TreeTop * destination, TR::KnownObjectTable::Index mcsObject, TR::KnownObjectTable::Index mcsEpoch)
    {
    TR::SymbolReferenceTable *symRefTab = comp->getSymRefTab();
    TR::SymbolReference *addressSymRef = symRefTab->createKnownStaticDataSymbolRef(0, TR::Address, mcsEpoch);

--- a/compiler/compile/VirtualGuard.hpp
+++ b/compiler/compile/VirtualGuard.hpp
@@ -148,7 +148,7 @@ class TR_VirtualGuard
          int16_t calleeIndex,
          TR::Node * node,
          TR::TreeTop * destination,
-         uintptr_t *mcsObject,
+         TR::KnownObjectTable::Index mcsObject,
          TR::KnownObjectTable::Index mcsEpoch);
 
    static TR::Node *createDummyOrSideEffectGuard(TR::Compilation *, TR::Node *, TR::TreeTop *);
@@ -224,7 +224,7 @@ class TR_VirtualGuard
    TR_OpaqueClassBlock    *getThisClass()   { return _thisClass; }
    void                    setThisClass(TR_OpaqueClassBlock *thisClass)   { _thisClass = thisClass; }
 
-   uintptr_t *mutableCallSiteObject()
+   TR::KnownObjectTable::Index mutableCallSiteObject()
       {
       TR_ASSERT(_kind == TR_MutableCallSiteTargetGuard, "mutableCallSiteObject only defined for TR_MutableCallSiteTargetGuard");
       return _mutableCallSiteObject;
@@ -294,7 +294,7 @@ class TR_VirtualGuard
    bool                      _mergedWithOSRGuard;
 
    // These reference locations are non-null only for MutableCallSiteGuards
-   uintptr_t                *_mutableCallSiteObject;
+   TR::KnownObjectTable::Index _mutableCallSiteObject;
    TR::KnownObjectTable::Index _mutableCallSiteEpoch;
    TR_ByteCodeInfo           _bcInfo;
    };

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1518,7 +1518,7 @@ TR_InlinerBase::createVirtualGuard(
          {
          heuristicTrace(
             tracer(),
-            "  createVirtualGuard: MutableCallSite %p epoch is obj%d",
+            "  createVirtualGuard: MutableCallSite obj%d epoch is obj%d",
             guard->_mutableCallSiteObject,
             guard->_mutableCallSiteEpoch);
          }

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -243,7 +243,7 @@ struct TR_VirtualGuardSelection
    TR_OpaqueClassBlock *_thisClass;
 
    // only for a MutableCallSiteTargetGuard
-   uintptr_t                *_mutableCallSiteObject;
+   TR::KnownObjectTable::Index _mutableCallSiteObject;
    TR::KnownObjectTable::Index _mutableCallSiteEpoch;
 
    // this flag is used to signify a profiled guard for which


### PR DESCRIPTION
...instead of based on reference location.