### PR TITLE
Disable reassociate for dataAddr access arrays for OffHeap

### DIFF
--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -3607,6 +3607,7 @@ bool TR_LoopStrider::reassociateAndHoistComputations(TR::Block *loopInvariantBlo
          int32_t hdrSize = (int32_t)TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
          if ((isInternalPointer &&
               (comp()->getSymRefTab()->getNumInternalPointers() < maxInternalPointers()) &&
+              (!originalNode->getFirstChild()->isDataAddrPointer()) &&
               ((isAdd && (constValue == hdrSize)) ||
                (!isAdd && constValue == -hdrSize))) &&
               (!_registersScarce || (node->getReferenceCount() > 1) || _reassociatedNodes.find(node)) &&


### PR DESCRIPTION
This is a follow from https://github.com/eclipse-omr/omr/commit/c7f89a0e96106fbd52a9c65b640d2d923cac9386 where disabling storing dataAddr in temps in loopStrider for offheap was committed but change wasn't complete.

The prior change disables recognizing array access with dataAddrPtr of the form Array+X, but for Array+X+C where `C == header-size`, it triggers a different path for non-offheap accesses that wasn't specifically checked against offheap by the prior commit. This change adds that check.

Closes: https://github.com/eclipse-openj9/openj9/issues/21352

The test rarity of `C == 24 == header-size` caused this issue to be hardly reproducible and in this case only with `noCompressedRefs`.

Will be ported to 0.53

WIP: Testing 