### PR TITLE
Add option to dump trees after specified optimizations

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1254,6 +1254,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceOpts",                        "L\tdump each optimization name",                 SET_OPTION_BIT(TR_TraceOpts), "P" },
    {"traceOpts=",                       "L{regex}\tlist of optimizations to trace", TR::Options::setRegex, offsetof(OMR::Options, _optsToTrace), 0, "P"},
    {"traceOptTreeLowering",             "L\ttrace tree lowering optimization",             TR::Options::traceOptimization, treeLowering,   0, "P"},
+   {"traceOptTrees=",                   "L{regex}\tlist of optimizations after which to dump trees", TR::Options::setRegex, offsetof(OMR::Options, _optsToDumpTrees), 0, "P"},
    {"traceOSR",                         "L\ttrace OSR",                                    SET_OPTION_BIT(TR_TraceOSR), "P"},
    {"traceOSRDefAnalysis",              "L\ttrace OSR reaching definitions analysis",       TR::Options::traceOptimization, osrDefAnalysis, 0, "P"},
 #ifdef J9_PROJECT_SPECIFIC
@@ -3907,7 +3908,7 @@ OMR::Options::jitPostProcess()
 bool
 OMR::Options::requiresLogFile()
    {
-   if (self()->getOptsToTrace())
+   if (self()->getOptsToTrace() || self()->getOptsToDumpTrees())
       return true;
 
    // note: enumerators with different word maps can't be or'ed together

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1390,6 +1390,7 @@ public:
       _disabledInlineSites = NULL;
       _disabledOpts = NULL;
       _optsToTrace = NULL;
+      _optsToDumpTrees = NULL;
       _dontInline = NULL;
       _onlyInline = NULL;
       _tryToInline = NULL;
@@ -1724,6 +1725,7 @@ public:
    TR::SimpleRegex * getDisabledOpts()                 {return _disabledOpts; }
    TR::SimpleRegex * getDisabledInlineSites()          {return _disabledInlineSites; }
    TR::SimpleRegex * getOptsToTrace()                  {return _optsToTrace; }
+   TR::SimpleRegex * getOptsToDumpTrees()              {return _optsToDumpTrees; }
    TR::SimpleRegex * getDontInline()                   {return _dontInline; }
    TR::SimpleRegex * getOnlyInline()                   {return _onlyInline; }
    TR::SimpleRegex * getTryToInline()                  {return _tryToInline; }
@@ -2393,6 +2395,7 @@ protected:
    TR::SimpleRegex *            _disabledInlineSites;
    TR::SimpleRegex *            _disabledOpts;
    TR::SimpleRegex *            _optsToTrace;
+   TR::SimpleRegex *            _optsToDumpTrees;
    TR::SimpleRegex *            _dontInline;
    TR::SimpleRegex *            _onlyInline;
    TR::SimpleRegex *            _tryToInline;


### PR DESCRIPTION
Enabling full optimization tracing can sometimes affect the timing of a compilation within a test run, affecting the ability to reproduce a problem.  Further, requesting tracing of a single optimization will not cause it to dump method trees in general.  This change introduces a new `traceOptTrees` option with which a glob filter is specified to select optimizations after which method trees should be dumped.  Optimizations can be matched by either their names or their optimization index.

For example, the following invocation

```
java -Xjit:{Foo.sub*}\(log=foo.traceopttrees.log,traceOptTrees={globalDeadStoreElimination\,coldBlockOutlining},traceOpts\),initialOptLevel=hot,count=1,disableAsyncCompilation,verbose,limit={Foo.sub*} Foo
```

results in the following (partial) log:

<details>
<Summary>Log with method trees dumped after coldBlockOutlining and globablDeadStoreElimination optimizations</Summary>

```
<strategy hotness="hot">
   osrLiveRangeAnalysis
   methodHandleTransformer
   varHandleTransformer
   handleRecompilationOps
   unsafeFastPath
   recognizedCallTransformer
   coldBlockMarker
   CFGSimplification
   invariantArgumentPreexistence
</strategy>
<strategy hotness="hot">
   coldBlockOutlining
<trees  
        title="Trees after coldBlockOutlining"
        method="Foo.sub()V"
        hotness="hot">

Trees after coldBlockOutlining: for Foo.sub()V

------------------------------------------------------------------------------------------------------------------------------------------------------------------------
n5n       BBStart <block_2>                                                                   [0x7fe306495880] bci=[-1,0,5] rc=0 vc=3 vn=- li=- udi=- nc=0
n8n       istore  <auto slot 0>[#419  Auto] [flags 0x3 0x0 ]                                  [0x7fe306495970] bci=[-1,1,5] rc=0 vc=4 vn=- li=- udi=- nc=1
n7n         iconst 0 (X==0 X>=0 X<=0 )                                                        [0x7fe306495920] bci=[-1,0,5] rc=1 vc=4 vn=- li=- udi=- nc=0 flg=0x302
n6n       BBEnd </block_2> =====                               

...

   <optgroup name=expensiveGlobalValuePropagationGroup>
      globalValuePropagation
      treeSimplification
      deadTreesElimination
      <optgroup name=expensiveObjectAllocationGroup>
      </optgroup>
      osrExceptionEdgeRemoval
      CFGSimplification
   </optgroup>
   dataAccessAccelerator
   <optgroup name=globalDeadStoreGroup>
      globalDeadStoreElimination
<trees  
        title="Trees after globalDeadStoreElimination"
        method="Foo.sub()V"
        hotness="hot">

Trees after globalDeadStoreElimination: for Foo.sub()V

------------------------------------------------------------------------------------------------------------------------------------------------------------------------
n5n       BBStart <block_2> (freq 1258)                                                       [0x7fe306495880] bci=[-1,1,5] rc=0 vc=96 vn=- li=- udi=- nc=0
n8n       istore  <auto slot 0>[#419  Auto] [flags 0x3 0x0 ]                                  [0x7fe306495970] bci=[-1,1,5] rc=0 vc=96 vn=- li=1 udi=1 nc=1
n7n         iconst 0 (X==0 X>=0 X<=0 )                                                        [0x7fe306495920] bci=[-1,0,5] rc=1 vc=96 vn=- li=- udi=- nc=0 flg=0x302

...

      treeSimplification
      treesCleansing
      redundantGotoElimination
      loopReduction
      localCSE
      globalDeadStoreElimination
<trees  
        title="Trees after globalDeadStoreElimination"
        method="Foo.sub()V"
        hotness="hot">

Trees after globalDeadStoreElimination: for Foo.sub()V

------------------------------------------------------------------------------------------------------------------------------------------------------------------------
n5n       BBStart <block_2> (freq 1258)                                                       [0x7fe306495880] bci=[-1,1,5] rc=0 vc=623 vn=- li=- udi=- nc=0
n8n       istore  <auto slot 0>[#419  Auto] [flags 0x3 0x0 ]                                  [0x7fe306495970] bci=[-1,1,5] rc=0 vc=623 vn=- li=4 udi=1 nc=1
n7n         iconst 0 (X==0 X>=0 X<=0 )                                                        [0x7fe306495920] bci=[-1,0,5] rc=2 vc=623 vn=- li=- udi=- nc=0 flg=0x302
n12n      NULLCHK on n10n [#32]                                  

...
```

</details>

Similarly, specifying a value to match an opt index:

```
java -Xjit:{Foo.sub*}\(log=foo.traceopttrees.log,traceOptTrees={13[567]},traceOpts\),initialOptLevel=hot,count=1,disableAsyncCompilation,verbose,limit={Foo.sub*} Foo
```

results in the following (partial) log file:

<details>
<Summary>Log with method trees dumped after optimizations with indices 135, 136 and 137</Summary>

```
      redundantGotoElimination
      loopReduction
      localCSE
      globalDeadStoreElimination
      deadTreesElimination
      loopReduction
      idiomRecognition
      <optgroup name=lastLoopVersionerGroup>
         inductionVariableAnalysis
         loopCanonicalization
         loopVersioner
      </optgroup>
      treeSimplification
      deadTreesElimination
      inductionVariableAnalysis
      SPMDKernelParallelization
Checking data locality in loop 4 piv = 419
      loopStrider
      treeSimplification
      <optgroup name=lastLoopVersionerGroup>
         inductionVariableAnalysis
         loopCanonicalization
<trees  
        title="Trees after loopCanonicalization"
        method="Foo.sub()V"
        hotness="hot">

Trees after loopCanonicalization: for Foo.sub()V

------------------------------------------------------------------------------------------------------------------------------------------------------------------------
n5n       BBStart <block_2> (freq 1258)                                                       [0x7f4650c95880] bci=[-1,1,5] rc=0 vc=742 vn=- li=- udi=- nc=0
n8n       istore  <auto slot 0>[#419  Auto] [flags 0x3 0x0 ]                                  [0x7f4650c95970] bci=[-1,1,5] rc=0 vc=742 vn=- li=- udi=1 nc=1
n7n         iconst 0 (X==0 X>=0 X<=0 )                                                        [0x7f4650c95920] bci=[-1,0,5] rc=2 vc=742 vn=- li=- udi=- nc=0 flg=0x302
n12n      NULLCHK on n10n [#32]                                                               [0x7f4650c95ab0] bci=[-1,6,5] rc=0 vc=742 vn=- li=- udi=- nc=1
n11n        arraylength (stride 4) (X>=0 cannotOverflow )                                     [0x7f4650c95a60] bci=[-1,6,5] rc=2 vc=742 vn=- li=- udi=- nc=1 flg=0x1100
n10n          aload  Foo.arr [I[#420  Static] [flags 0x307 0x0 ]                              [0x7f4650c95a10] bci=[-1,3,5] rc=1 vc=742 vn=- li=- udi=- nc=0
n15n      ificmple --> block_5 BBStart at n1n (swappedChildren )                              [0x7f4650c95ba0] bci=[-1,7,5] rc=0 vc=742 vn=- li=- udi=- nc=2 flg=0x20020
n11n        ==>arraylength
n7n         ==>iconst 0
n4n       BBEnd </block_2> =====                                                              [0x7f4650c95830] bci=[-1,7,5] rc=0 vc=742 vn=- li=- udi=- nc=0

n299n     BBStart <block_21> (freq 629)                                                       [0x7f4650d15d30] bci=[-1,1,5] rc=0 vc=742 vn=- li=- udi=- nc=0

...

<trees  
        title="Trees after loopVersioner"
        method="Foo.sub()V"
        hotness="hot">

Trees after loopVersioner: for Foo.sub()V

------------------------------------------------------------------------------------------------------------------------------------------------------------------------
n5n       BBStart <block_2> (freq 1258)                                                       [0x7f4650c95880] bci=[-1,1,5] rc=0 vc=751 vn=- li=- udi=- nc=0
n8n       istore  <auto slot 0>[#419  Auto] [flags 0x3 0x0 ]                                  [0x7f4650c95970] bci=[-1,1,5] rc=0 vc=751 vn=- li=7 udi=1 nc=1
n7n         iconst 0 (X==0 X>=0 X<=0 )                                                        [0x7f4650c95920] bci=[-1,0,5] rc=2 vc=751 vn=- li=- udi=- nc=0 flg=0x302
@                                                              
n12n      NULLCHK on n10n [#32]                                                               [0x7f4650c95ab0] bci=[-1,6,5] rc=0 vc=751 vn=- li=- udi=- nc=1
n11n        arraylength (stride 4) (X>=0 cannotOverflow )                                     [0x7f4650c95a60] bci=[-1,6,5] rc=2 vc=751 vn=- li=- udi=- nc=1 flg=0x1100
n10n          aload  Foo.arr [I[#420  Static] [flags 0x307 0x0 ]                              [0x7f4650c95a10] bci=[-1,3,5] rc=1 vc=751 vn=- li=- udi=- nc=0
n15n      ificmple --> block_5 BBStart at n1n (swappedChildren )                              [0x7f4650c95ba0] bci=[-1,7,5] rc=0 vc=751 vn=- li=- udi=- nc=2 flg=0x20020
n11n        ==>arraylength
n7n         ==>iconst 0
n4n       BBEnd </block_2> =====                                                              [0x7f4650c95830] bci=[-1,7,5] rc=0 vc=751 vn=- li=- udi=- nc=0

n299n     BBStart <block_21> (freq 629)                                                       [0x7f4650d15d30] bci=[-1,1,5] rc=0 vc=751 vn=- li=- udi=- nc=0
n221n     astore  <pinning array temp slot 2>[#423  Auto] [flags 0x10000007 0x0 ]             [0x7f4650d144d0] bci=[-1,3,5] rc=0 vc=751 vn=- li=8 udi=2 nc=1

...

<trees  
        title="Trees after treeSimplification"
        method="Foo.sub()V"
        hotness="hot">

Trees after treeSimplification: for Foo.sub()V

------------------------------------------------------------------------------------------------------------------------------------------------------------------------
n5n       BBStart <block_2> (freq 1258)                                                       [0x7f4650c95880] bci=[-1,1,5] rc=0 vc=766 vn=- li=- udi=- nc=0
n8n       istore  <auto slot 0>[#419  Auto] [flags 0x3 0x0 ]                                  [0x7f4650c95970] bci=[-1,1,5] rc=0 vc=766 vn=- li=- udi=1 nc=1
n7n         iconst 0 (X==0 X>=0 X<=0 )                                                        [0x7f4650c95920] bci=[-1,0,5] rc=2 vc=766 vn=- li=- udi=- nc=0 flg=0x302
n12n      NULLCHK on n10n [#32]                                                               [0x7f4650c95ab0] bci=[-1,6,5] rc=0 vc=766 vn=- li=- udi=- nc=1
n11n        arraylength (stride 4) (X>=0 cannotOverflow )                                     [0x7f4650c95a60] bci=[-1,6,5] rc=2 vc=766 vn=- li=- udi=- nc=1 flg=0x1100
n10n          aload  Foo.arr [I[#420  Static] [flags 0x307 0x0 ]                              [0x7f4650c95a10] bci=[-1,3,5] rc=1 vc=766 vn=- li=- udi=- nc=0
n15n      ificmple --> block_5 BBStart at n1n (swappedChildren )                              [0x7f4650c95ba0] bci=[-1,7,5] rc=0 vc=766 vn=- li=- udi=- nc=2 flg=0x20020
n11n        ==>arraylength
n7n         ==>iconst 0
n4n       BBEnd </block_2> =====                                                              [0x7f4650c95830] bci=[-1,7,5] rc=0 vc=766 vn=- li=- udi=- nc=0

n299n     BBStart <block_21> (freq 629)                                                       [0x7f4650d15d30] bci=[-1,1,5] rc=0 vc=766 vn=- li=- udi=- nc=0
n221n     astore  <pinning array temp slot 2>[#423  Auto] [flags 0x10000007 0x0 ]             [0x7f4650d144d0] bci=[-1,3,5] rc=0 vc=766 vn=- li=- udi=2 nc=1
n220n       aload  Foo.arr [I[#420  Static] [flags 0x307 0x0 ]                                [0x7f4650d14480] bci=[-1,3,5] rc=2 vc=766 vn=- li=- udi=- nc=0

...

      localCSE
      deadTreesElimination
      loopStrider
      treeSimplification
      loopInversion
   </optgroup>
   globalDeadStoreElimination
   inductionVariableAnalysis
   <optgroup name=loopSpecializerGroup>
      inductionVariableAnalysis
      loopCanonicalization
      loopSpecializer
   </optgroup>
   inductionVariableAnalysis
   generalLoopUnroller
   recognizedCallTransformer

...

```

</details>

Specifying the `traceOpts` option along with this new option helps to provide some context into which particular pass of an optimization was involved for those optimizations that run several times.
