### PR TITLE
Infrastructure to segregate code caches

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1962,13 +1962,12 @@ OMR::CodeGenerator::reserveCodeCache()
    {
    int32_t numReserved = 0;
    int32_t compThreadID = 0;
+   TR::Compilation *comp = self()->comp();
 
-   _codeCache = TR::CodeCacheManager::instance()->reserveCodeCache(false, 0, compThreadID, &numReserved);
+   _codeCache = TR::CodeCacheManager::instance()->reserveCodeCache(false, 0, compThreadID, &numReserved, comp->codeCacheKind());
 
    if (!_codeCache) // Cannot reserve a cache; all are used
       {
-      TR::Compilation *comp = self()->comp();
-
       // We may reach this point if all code caches have been used up.
       // If some code caches have some space but cannot be used because they are reserved
       // we will throw an exception in the call to TR::CodeCacheManager::reserveCodeCache

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -485,6 +485,12 @@ OMR::Compilation::maxInternalPointers()
    return 0;
    }
 
+TR::CodeCacheKind
+OMR::Compilation::codeCacheKind()
+   {
+   return _options->getCodeCacheKind();
+   }
+
 bool
 OMR::Compilation::isOutermostMethod()
    {

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -354,6 +354,11 @@ public:
    //
    bool compilePortableCode() { return false; }
 
+   // The kind of code cache to be allocated for the compiled body generated
+   // by this compilation unit
+   //
+   TR::CodeCacheKind codeCacheKind();
+
    // Maximum number of internal pointers that can be managed.
    //
    int32_t maxInternalPointers();

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1858,7 +1858,8 @@ OMR::Options::Options(
       int32_t compThreadID) :
    _optionSets(NULL),
    _postRestoreOptionSets(NULL),
-   _logListForOtherCompThreads(0)
+   _logListForOtherCompThreads(0),
+   _codeCacheKind(TR::CodeCacheKind::DEFAULT_CC)
    {
    TR_ASSERT(optimizationPlan, "Must have an optimization plan when calling this method");
 

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1349,6 +1349,9 @@ protected:
 public:
    TR_ALLOC(TR_Memory::Options)
 
+   TR::CodeCacheKind getCodeCacheKind() { return _codeCacheKind; }
+   void setCodeCacheKind(TR::CodeCacheKind kind) { _codeCacheKind = kind; }
+
    void init()
    {
       _optionSets = NULL;
@@ -1505,6 +1508,7 @@ public:
       _arraycopyRepMovsIntArrayThreshold = 32;
       _arraycopyRepMovsLongArrayThreshold = 32;
       _arraycopyRepMovsReferenceArrayThreshold = 32;
+      _codeCacheKind = TR::CodeCacheKind::DEFAULT_CC;
 
       memset(_options, 0, sizeof(_options));
       memset(_disabledOptimizations, false, sizeof(_disabledOptimizations));
@@ -2547,6 +2551,7 @@ protected:
    int32_t                     _arraycopyRepMovsLongArrayThreshold; // Long array copy threshold for using REP MOVS instructions. Only supports 32, 64, or 128 bytes
    int32_t                     _arraycopyRepMovsReferenceArrayThreshold; // Reference array copy threshold for using REP MOVS instructions. Only supports 32, 64, or 128 bytes
 
+   TR::CodeCacheKind           _codeCacheKind;
    }; // TR::Options
 
 }

--- a/compiler/control/OptionsUtil.hpp
+++ b/compiler/control/OptionsUtil.hpp
@@ -180,6 +180,13 @@ private:
    const char *_optionString;
    };
 
+// An enum to indcate the type of code cache a compiled body will be placed into
+//
+enum CodeCacheKind
+   {
+   DEFAULT_CC = 0,
+   };
+
 }
 
 #endif

--- a/compiler/runtime/OMRCodeCache.cpp
+++ b/compiler/runtime/OMRCodeCache.cpp
@@ -269,7 +269,8 @@ OMR::CodeCache::trimCodeMemoryAllocation(void *codeMemoryStart, size_t actualSiz
 bool
 OMR::CodeCache::initialize(TR::CodeCacheManager *manager,
                            TR::CodeCacheMemorySegment *codeCacheSegment,
-                           size_t allocatedCodeCacheSizeInBytes)
+                           size_t allocatedCodeCacheSizeInBytes,
+                           TR::CodeCacheKind kind)
    {
    _manager = manager;
 
@@ -278,6 +279,8 @@ OMR::CodeCache::initialize(TR::CodeCacheManager *manager,
    // instead of _jitConfig->codeCachePadKB * 1024 bytes
    // If codeCachePadKB is not set, heapSize is segmentSize anyway
    _segment = codeCacheSegment;
+
+   _kind = kind;
 
    // helperTop is heapTop, usually
    // When codeCachePadKB > segmentSize, the helperTop is not at the very end of the segemnt
@@ -1758,7 +1761,8 @@ OMR::CodeCache::getCCPreLoadedCodeAddress(TR_CCPreLoadedCode h, TR::CodeGenerato
 TR::CodeCache *
 OMR::CodeCache::allocate(TR::CodeCacheManager *manager,
                          size_t segmentSize,
-                         int32_t reservingCompThreadID)
+                         int32_t reservingCompThreadID,
+                         TR::CodeCacheKind kind)
    {
-   return manager->allocateCodeCacheFromNewSegment(segmentSize, reservingCompThreadID);
+   return manager->allocateCodeCacheFromNewSegment(segmentSize, reservingCompThreadID, kind);
    }

--- a/compiler/runtime/OMRCodeCache.hpp
+++ b/compiler/runtime/OMRCodeCache.hpp
@@ -34,6 +34,7 @@ namespace OMR { typedef CodeCache CodeCacheConnector; }
 
 #include <stddef.h>
 #include <stdint.h>
+#include "control/OptionsUtil.hpp"
 #include "env/defines.h"
 #include "il/DataTypes.hpp"
 #include "infra/CriticalSection.hpp"
@@ -87,7 +88,7 @@ public:
 
    TR::CodeCache * getNextCodeCache()  { return _next; }
 
-   static TR::CodeCache *allocate(TR::CodeCacheManager *manager, size_t segmentSize, int32_t reservingCompThreadID);
+   static TR::CodeCache *allocate(TR::CodeCacheManager *manager, size_t segmentSize, int32_t reservingCompThreadID, TR::CodeCacheKind kind);
    void destroy(TR::CodeCacheManager *manager);
 
    uint8_t *allocateCodeMemory(size_t warmCodeSize,
@@ -213,12 +214,14 @@ public:
     * @param[in] manager : the TR::CodeCacheManager
     * @param[in] codeCacheSegment : the code cache memory segment that has been allocated
     * @param[in] allocatedCodeCacheSizeInBytes : the size (in bytes) of the allocated code cache
+    * @param[in] kind : the kind of this code cache
     *
     * @return true on a successful initialization; false otherwise.
     */
    bool                       initialize(TR::CodeCacheManager *manager,
                                          TR::CodeCacheMemorySegment *codeCacheSegment,
-                                         size_t allocatedCodeCacheSizeInBytes);
+                                         size_t allocatedCodeCacheSizeInBytes,
+                                         TR::CodeCacheKind kind);
 
 private:
    void                       updateMaxSizeOfFreeBlocks(CodeCacheFreeCacheBlock *blockPtr, size_t blockSize);
@@ -406,6 +409,8 @@ public:
    uint8_t * _warmCodeAlloc;
 
    uint8_t * _coldCodeAlloc;
+
+   TR::CodeCacheKind _kind;
 
    TR::CodeCacheManager *_manager;
 

--- a/compiler/runtime/OMRCodeCacheManager.hpp
+++ b/compiler/runtime/OMRCodeCacheManager.hpp
@@ -24,6 +24,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "control/OptionsUtil.hpp"
 #include "il/DataTypes.hpp"
 #include "infra/CriticalSection.hpp"
 #include "runtime/CodeCacheConfig.hpp"
@@ -157,7 +158,8 @@ public:
    void  freeMemory(void *memoryToFree);
 
    TR::CodeCache * allocateCodeCacheObject(TR::CodeCacheMemorySegment *codeCacheSegment,
-                                           size_t codeCacheSize);
+                                           size_t codeCacheSize,
+                                           TR::CodeCacheKind kind);
    void * chooseCacheStartAddress(size_t repositorySize);
 
    TR::CodeCache * getFirstCodeCache()            { return _codeCacheList._head; }
@@ -172,8 +174,10 @@ public:
    TR::CodeCache * reserveCodeCache(bool compilationCodeAllocationsMustBeContiguous,
                                     size_t sizeEstimate,
                                     int32_t compThreadID,
-                                    int32_t *numReserved);
-   TR::CodeCache * getNewCodeCache(int32_t reservingCompThreadID);
+                                    int32_t *numReserved,
+                                    TR::CodeCacheKind kind);
+   TR::CodeCache * getNewCodeCache(int32_t reservingCompThreadID,
+                                   TR::CodeCacheKind kind);
 
    uint8_t * allocateCodeMemory(size_t warmCodeSize,
                                 size_t coldCodeSize,
@@ -191,13 +195,15 @@ public:
     *                  <= -2 : no reservation is requested
     *                  == -1 : the application thread is requesting the allocation; new code cache will be reserved
     *                  >=  0 : a compilation thread is requesting the allocation; new code cache will be reserved
+    * @param[in] kind : the kind of code cache to allocate
     *
     * @return if allocation is successful, the allocated TR::CodeCache object from
     *           the new segment; NULL otherwise.
     */
    TR::CodeCache * allocateCodeCacheFromNewSegment(
       size_t segmentSizeInBytes,
-      int32_t reservingCompilationTID);
+      int32_t reservingCompilationTID,
+      TR::CodeCacheKind kind);
 
    TR::CodeCache * findCodeCacheFromPC(void *inCacheAddress);
 


### PR DESCRIPTION
Add infrastructure to allow the compiler component to distinguish between different code caches. This infrastructure can be used to facilitate features such as file-backed code caches.

See https://github.com/eclipse-omr/omr/issues/7779

Needs to be merged in tandem with https://github.com/eclipse-openj9/openj9/pull/22045