### PR TITLE
Modifications to logical vector operations on PPC

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1893,8 +1893,11 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
          else
             return false;
       case TR::vxor:
+      case TR::vmxor:
       case TR::vor:
+      case TR::vmor:
       case TR::vand:
+      case TR::vmand:
          if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64)
             return true;
          else

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -3542,11 +3542,11 @@ TR::Register *OMR::Power::TreeEvaluator::vandEvaluator(TR::Node *node, TR::CodeG
       case TR::Int8:
       case TR::Int16:
       case TR::Int32:
+      case TR::Int64:
          opCode = TR::InstOpCode::vand;
          break;
       default:
-         opCode = TR::InstOpCode::xxland;
-         break;
+         TR_ASSERT_FATAL(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
      }
 
    return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, opCode);
@@ -3564,11 +3564,11 @@ TR::Register *OMR::Power::TreeEvaluator::vorEvaluator(TR::Node *node, TR::CodeGe
       case TR::Int8:
       case TR::Int16:
       case TR::Int32:
+      case TR::Int64:
          opCode = TR::InstOpCode::vor;
          break;
       default:
-         opCode = TR::InstOpCode::xxlor;
-         break;
+         TR_ASSERT_FATAL(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
      }
    return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, opCode);
    }
@@ -3585,11 +3585,11 @@ TR::Register *OMR::Power::TreeEvaluator::vxorEvaluator(TR::Node *node, TR::CodeG
       case TR::Int8:
       case TR::Int16:
       case TR::Int32:
+      case TR::Int64:
          opCode = TR::InstOpCode::vxor;
          break;
       default:
-         opCode = TR::InstOpCode::xxlxor;
-         break;
+         TR_ASSERT_FATAL(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
      }
    return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, opCode);
    }

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -4717,7 +4717,7 @@ TR::Register* OMR::Power::TreeEvaluator::vmaddEvaluator(TR::Node *node, TR::Code
 
 TR::Register* OMR::Power::TreeEvaluator::vmandEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   return vandEvaluator(node, cg);
    }
 
 TR::Register* OMR::Power::TreeEvaluator::vmcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -4797,7 +4797,7 @@ TR::Register* OMR::Power::TreeEvaluator::vmnotEvaluator(TR::Node *node, TR::Code
 
 TR::Register* OMR::Power::TreeEvaluator::vmorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   return vorEvaluator(node, cg);
    }
 
 TR::Register* OMR::Power::TreeEvaluator::vmorUncheckedEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -4867,7 +4867,7 @@ TR::Register* OMR::Power::TreeEvaluator::vmsubEvaluator(TR::Node *node, TR::Code
 
 TR::Register* OMR::Power::TreeEvaluator::vmxorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   return vxorEvaluator(node, cg);
    }
 
 TR::Register* OMR::Power::TreeEvaluator::vmfirstNonZeroEvaluator(TR::Node *node, TR::CodeGenerator *cg)


### PR DESCRIPTION
This contribution includes the following changes:
- Masked logical vector operations (`vmxor`, `vmand`, `vmor`) have been enabled on PPC and their evaluators redirected to the corresponding non-masked implementations.
- For logical vector operations performed on LongVectors, the VMX instruction (i.e.: `vxor`/`vand`/`vor`) is used instead of the VSX one (i.e.: `xxlxor`/`xxland`/`xxlor`)