### PR TITLE
Conditionally retry code cache reservation ignoring the kind

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1107,6 +1107,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"reservingLocks",     "O\tenable reserving locks for hot methods on classes that can be reserved", SET_OPTION_BIT(TR_ReservingLocks), "F"},
    {"restrictInlinerDuringStartup", "O\trestrict trivial inliner during startup", SET_OPTION_BIT(TR_RestrictInlinerDuringStartup), "F", NOT_IN_SUBSET },
    {"restrictStaticFieldFolding", "O\trestrict instance field folding", SET_OPTION_BIT(TR_RestrictStaticFieldFolding), "F"},
+   {"retryCodeCacheAllocAndIgnoreKind",     "M\tRetry code cache allocation and ignore the kind on alloc failure", SET_OPTION_BIT(TR_RetryCodeCacheAllocAndIgnoreKind), "F", NOT_IN_SUBSET},
    {"rtGCMapCheck", "D\tEnable runtime GC Map checking at every async check.", SET_OPTION_BIT(TR_RTGCMapCheck), "F"},
    {"sampleDensityBaseThreshold=", "M<nnn>\t", TR::Options::setStaticNumeric, (intptr_t)&OMR::Options::_sampleDensityBaseThreshold, 0, "F%d", NOT_IN_SUBSET},
    {"sampleDensityIncrementThreshold=", "M<nnn>\t", TR::Options::setStaticNumeric, (intptr_t)&OMR::Options::_sampleDensityIncrementThreshold, 0, "F%d", NOT_IN_SUBSET},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -416,7 +416,7 @@ enum TR_CompilationOptions
 
    // Option word 11
    //
-   // Available                               = 0x00000020 + 11,
+   TR_RetryCodeCacheAllocAndIgnoreKind        = 0x00000020 + 11,
    // Available                               = 0x00000040 + 11,
    TR_EnableSelectiveEnterExitHooks           = 0x00000080 + 11,
    // Available                               = 0x00000100 + 11,

--- a/compiler/runtime/OMRCodeCacheManager.hpp
+++ b/compiler/runtime/OMRCodeCacheManager.hpp
@@ -342,6 +342,16 @@ public:
    size_t getCurrTotalUsedInBytes() const { return _currTotalUsedInBytes; }
    size_t getMaxUsedInBytes() const { return _maxUsedInBytes; }
 
+private:
+
+   TR::CodeCache * reserveCodeCacheImpl(bool compilationCodeAllocationsMustBeContiguous,
+                                        size_t sizeEstimate,
+                                        int32_t compThreadID,
+                                        int32_t *numReserved,
+                                        TR::CodeCacheKind kind,
+                                        bool ignoreKindAndSkipAllocate);
+
+
 protected:
 
    TR::RawAllocator               _rawAllocator;


### PR DESCRIPTION
If `TR_RetryCodeCacheAllocAndIgnoreKind` is set, retry reserving the code cache ignoring the kind. However, on the retry, skip trying to allocate a new code cache. On the first attempt, if a reservation attempt fails, the manager tries to allocate a new code cache; if the allocation also fails, there is only value in trying to reserve a code cache ignoring the kind.

Closes https://github.com/eclipse-omr/omr/issues/7779