### PR TITLE
cmake: add option to enable link-time optimization

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -236,6 +236,8 @@ set(OMR_OPT_CUDA OFF CACHE BOOL "Enable CUDA support in OMR. See also: OMR_CUDA_
 
 set(OMR_SANITIZE OFF CACHE STRING "Sanitizer selection. Only has an effect on GNU or Clang")
 
+set(OMR_LINK_OPT OFF CACHE BOOL "Enable link-time optimization (for toolchains that support it)")
+
 if(OMR_OS_WINDOWS)
 	set(OMR_WINDOWS_NOMINMAX ON CACHE BOOL "Define NOMINMAX in every compilation unit; prevents Windows headers from polluting the global namespace with 'min' and 'max' macros.")
 endif()

--- a/cmake/modules/platform/toolcfg/gnu.cmake
+++ b/cmake/modules/platform/toolcfg/gnu.cmake
@@ -103,6 +103,16 @@ if(OMR_OS_AIX AND CMAKE_C_COMPILER_IS_OPENXL)
 	endif()
 endif()
 
+if(OMR_LINK_OPT)
+	if (OMR_TOOLCONFIG STREQUAL "gnu")
+		omr_append_flags(CMAKE_C_FLAGS "-flto")
+		omr_append_flags(CMAKE_CXX_FLAGS "-flto")
+		omr_append_flags(CMAKE_SHARED_LINKER_FLAGS "-flto")
+	else()
+		message(WARNING "Link-time optimization requested, but not supported by ${OMR_TOOLCONFIG} toolchain.")
+	endif()
+endif()
+
 # Testarossa build variables. Longer term the distinction between TR and the rest
 # of the OMR code should be heavily reduced. In the meantime, we keep the distinction.
 


### PR DESCRIPTION
Currently just for the gnu toolchain.