### PR TITLE
Remove Hard-Coded Restrictions to CodeCache Page Sizes on P

### DIFF
--- a/port/aix/omrvmem.c
+++ b/port/aix/omrvmem.c
@@ -948,16 +948,13 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 	Assert_PRT_true_wrapper(OMRPORT_VMEM_PAGE_FLAG_NOT_USED == validPageFlags);
 
 	if (0 != validPageSize) {
-		/* For executable pages search through the list of supported page sizes only if
+		/* for 32-bit executable pages, search through the list of page sizes only if
 		 * - request is for 64K pages, or
-		 * - request is for 16M pages, and
-		 * - 64 bit system OR (32 bit system AND CodeCacheConsolidation is enabled)
+		 * - request is for 16M pages AND CodeCacheConsolidation is enabled
+		 *
+		 * for 64-bit, accept any request supported by the OS
 		 */
-#if defined(OMR_ENV_DATA64)
-		if ((OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode))
-			|| (SIXTY_FOUR_K == validPageSize)
-			|| (SIXTEEN_M == validPageSize)
-#else
+#if !defined(OMR_ENV_DATA64)
 		BOOLEAN codeCacheConsolidationEnabled = FALSE;
 
 		/* Check if the TR_ppcCodeCacheConsolidationEnabled env variable is set.
@@ -971,9 +968,9 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 		}
 		if ((OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode))
 			|| ((TRUE == codeCacheConsolidationEnabled) && (SIXTEEN_M == validPageSize))
-			|| (SIXTY_FOUR_K == validPageSize)
-#endif /* defined(OMR_ENV_DATA64) */
-		) {
+			|| (SIXTY_FOUR_K == validPageSize))
+#endif /* !defined(OMR_ENV_DATA64) */
+		{
 			uintptr_t pageIndex = 0;
 			uintptr_t *supportedPageSizes = portLibrary->vmem_supported_page_sizes(portLibrary);
 			uintptr_t *supportedPageFlags = portLibrary->vmem_supported_page_flags(portLibrary);


### PR DESCRIPTION
Instead of only accepting 64K and 16M as valid page sizes, accept any page size matching the valid size list from the OS.

Except for 32-bit archs where 16M will only be enabled along with consolidatedCodeCache to save on address space.