### PR TITLE
Remove TR_X87_Mask guarded code

### DIFF
--- a/compiler/codegen/RegisterConstants.hpp
+++ b/compiler/codegen/RegisterConstants.hpp
@@ -50,7 +50,6 @@ enum TR_RegisterKinds
    TR_GPR_Mask    = TO_KIND_MASK(TR_GPR),
    TR_FPR_Mask    = TO_KIND_MASK(TR_FPR),
    TR_CCR_Mask    = TO_KIND_MASK(TR_CCR),
-   TR_X87_Mask    = TO_KIND_MASK(TR_X87),
    TR_VRF_Mask    = TO_KIND_MASK(TR_VRF),
    TR_VSX_SCALAR_Mask    = TO_KIND_MASK(TR_VSX_SCALAR),
    TR_VSX_VECTOR_Mask    = TO_KIND_MASK(TR_VSX_VECTOR),

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -4614,7 +4614,6 @@ TR_Debug::traceRegisterAssignment(TR::Instruction *instr, bool insertedByRA, boo
             const bool isGPR = _registerKindsToAssign & TR_GPR_Mask;
             const bool isVRF = _registerKindsToAssign & TR_VRF_Mask;
             const bool isFPR = _registerKindsToAssign & TR_FPR_Mask;
-            const bool isX87 = _registerKindsToAssign & TR_X87_Mask;
 
             TR::RegisterIterator *gprIter = _comp->cg()->getGPRegisterIterator();
             TR::RegisterIterator *hprIter = _comp->cg()->getGPRegisterIterator();

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1715,9 +1715,6 @@ void OMR::X86::CodeGenerator::doBackwardsRegisterAssignment(
 
 void OMR::X86::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
    {
-   TR::Instruction *instructionCursor;
-   TR::Instruction *nextInstruction;
-
 #if defined(DEBUG)
    TR::Instruction *origPrevInstruction;
    bool            dumpPreFP = (debug("dumpFPRA") || debug("dumpFPRA0")) && self()->comp()->getOutFile() != NULL;
@@ -1727,48 +1724,6 @@ void OMR::X86::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssig
 #endif
 
    LexicalTimer pt1("total register assignment", self()->comp()->phaseTimer());
-
-   // Assign FPRs in a forward pass
-   //
-   if (kindsToAssign & TR_X87_Mask)
-      {
-      if (self()->getDebug())
-         self()->getDebug()->startTracingRegisterAssignment("forward", TR_X87_Mask);
-
-#if defined(DEBUG)
-      if (dumpPreFP || dumpPostFP)
-         diagnostic("\n\nFP Register Assignment (forward pass):\n");
-#endif
-
-      LexicalTimer pt2("FP register assignment", self()->comp()->phaseTimer());
-
-      self()->setAssignmentDirection(Forward);
-      instructionCursor = self()->getFirstInstruction();
-      while (instructionCursor)
-         {
-         self()->tracePreRAInstruction(instructionCursor);
-#if defined(DEBUG)
-         if (dumpPreFP)
-            {
-            origPrevInstruction = instructionCursor->getPrev();
-            self()->dumpPreFPRegisterAssignment(instructionCursor);
-            }
-#endif
-         nextInstruction = instructionCursor->getNext();
-         instructionCursor->assignRegisters(TR_X87_Mask);
-
-#if defined(DEBUG)
-         if (dumpPostFP)
-            self()->dumpPostFPRegisterAssignment(instructionCursor, origPrevInstruction);
-#endif
-         self()->tracePostRAInstruction(instructionCursor);
-
-         instructionCursor = nextInstruction;
-         }
-
-      if (self()->getDebug())
-         self()->getDebug()->stopTracingRegisterAssignment();
-      }
 
    // Use new float/double slots for XMMR spills, to avoid
    // interfering with existing FPR spills.

--- a/compiler/x/codegen/OMRRegisterDependency.cpp
+++ b/compiler/x/codegen/OMRRegisterDependency.cpp
@@ -498,16 +498,9 @@ void OMR::X86::RegisterDependencyConditions::assignPreConditionRegisters(TR::Ins
    {
    if (_preConditions != NULL)
       {
-      if ((kindsToBeAssigned & TR_X87_Mask))
-         {
-         _preConditions->assignFPRegisters(currentInstruction, kindsToBeAssigned, _numPreConditions, cg);
-         }
-      else
-         {
-         cg->clearRegisterAssignmentFlags();
-         cg->setRegisterAssignmentFlag(TR_PreDependencyCoercion);
-         _preConditions->assignRegisters(currentInstruction, kindsToBeAssigned, _numPreConditions, cg);
-         }
+      cg->clearRegisterAssignmentFlags();
+      cg->setRegisterAssignmentFlag(TR_PreDependencyCoercion);
+      _preConditions->assignRegisters(currentInstruction, kindsToBeAssigned, _numPreConditions, cg);
       }
    }
 
@@ -515,16 +508,9 @@ void OMR::X86::RegisterDependencyConditions::assignPostConditionRegisters(TR::In
    {
    if (_postConditions != NULL)
       {
-      if ((kindsToBeAssigned & TR_X87_Mask))
-         {
-         _postConditions->assignFPRegisters(currentInstruction, kindsToBeAssigned, _numPostConditions, cg);
-         }
-      else
-         {
-         cg->clearRegisterAssignmentFlags();
-         cg->setRegisterAssignmentFlag(TR_PostDependencyCoercion);
-         _postConditions->assignRegisters(currentInstruction, kindsToBeAssigned, _numPostConditions, cg);
-         }
+      cg->clearRegisterAssignmentFlags();
+      cg->setRegisterAssignmentFlag(TR_PostDependencyCoercion);
+      _postConditions->assignRegisters(currentInstruction, kindsToBeAssigned, _numPostConditions, cg);
       }
    }
 


### PR DESCRIPTION
X87 registers are no longer allocated.

Reimplementation of https://github.com/eclipse-omr/omr/pull/6380/commits/379ced3f0f671d3d0f8a40dc427d383e7cbd9b8d