### PR TITLE
Inline single call to Region::round() private function

### DIFF
--- a/compiler/env/Region.cpp
+++ b/compiler/env/Region.cpp
@@ -75,7 +75,7 @@ Region::~Region() throw()
 void *
 Region::allocate(size_t const size, void *hint)
    {
-   size_t const roundedSize = round(size);
+   size_t const roundedSize = (size+15) & (~15);
    if (_currentSegment.get().remaining() >= roundedSize)
       {
       _bytesAllocated += roundedSize;
@@ -92,11 +92,5 @@ Region::allocate(size_t const size, void *hint)
 void
 Region::deallocate(void * allocation, size_t) throw()
    {
-   }
-
-size_t
-Region::round(size_t bytes)
-   {
-   return (bytes+15) & (~15);
    }
 }

--- a/compiler/env/Region.hpp
+++ b/compiler/env/Region.hpp
@@ -166,8 +166,6 @@ public:
 private:
    friend class TR::RegionProfiler;
 
-   size_t round(size_t bytes);
-
    size_t _bytesAllocated;
    TR::SegmentProvider &_segmentProvider;
    TR::RawAllocator _rawAllocator;


### PR DESCRIPTION
In a Quarkus app I've been studying, Region::allocate() is consistently the hottest method in the JIT compiler with a bunch of ticks landing inside and in the call to the very simple private Region::round() function that is not being inlined into Region::allocate(). Since it's only called from one place and the code is pretty obvious, we can remove the overhead of the call/return here and potentially improve JIT compile time a bit.