### PR TITLE
Correct declarations of signal-related functions

### DIFF
--- a/include_core/omrsig.h
+++ b/include_core/omrsig.h
@@ -32,9 +32,13 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#if defined(OSX)
-#define __THROW
-#endif /* defined(OSX) */
+#if defined(AIXPPC) || defined(OSX) || defined(J9ZOS390) || !defined(__cplusplus)
+#define OMRSIG_NO_THROW
+#elif __cplusplus < 201103L /* defined(AIXPPC) || defined(OSX) || defined(J9ZOS390) || !defined(__cplusplus) */
+#define OMRSIG_NO_THROW throw()
+#else /* __cplusplus < 201103L */
+#define OMRSIG_NO_THROW noexcept
+#endif /* defined(AIXPPC) || defined(OSX) || defined(J9ZOS390) || !defined(__cplusplus) */
 
 #if defined(LINUXPPC)
 typedef __sighandler_t sighandler_t;
@@ -42,10 +46,8 @@ typedef __sighandler_t sighandler_t;
 typedef void (*sighandler_t)(int sig);
 #elif defined(J9ZOS390) || defined(AIXPPC)
 typedef void (*sighandler_t)(int sig);
-#define __THROW
 #elif defined(OMR_OS_WINDOWS)
 typedef void (__cdecl *sighandler_t)(int sig);
-#define __THROW
 #endif /* defined(OMR_OS_WINDOWS) */
 
 #define OMRSIG_RC_ERROR -1
@@ -97,18 +99,18 @@ _CRTIMP void (__cdecl * __cdecl signal(_In_ int _SigNum, _In_opt_ void (__cdecl 
  */
 int omrsig_primary_sigaction(int signum, const struct sigaction *act, struct sigaction *oldact);
 
-int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact) __THROW;
-sighandler_t signal(int signum, sighandler_t handler) __THROW;
+int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact) OMRSIG_NO_THROW;
+sighandler_t signal(int signum, sighandler_t handler) OMRSIG_NO_THROW;
 
-sighandler_t sigset(int sig, sighandler_t disp) __THROW;
-int sigignore(int sig) __THROW;
-sighandler_t bsd_signal(int signum, sighandler_t handler) __THROW;
+sighandler_t sigset(int sig, sighandler_t disp) OMRSIG_NO_THROW;
+int sigignore(int sig) OMRSIG_NO_THROW;
+sighandler_t bsd_signal(int signum, sighandler_t handler) OMRSIG_NO_THROW;
 #if !defined(J9ZOS390)
-sighandler_t sysv_signal(int signum, sighandler_t handler) __THROW;
+sighandler_t sysv_signal(int signum, sighandler_t handler) OMRSIG_NO_THROW;
 #endif /* !defined(J9ZOS390) */
 #if defined(LINUX)
-__sighandler_t __sysv_signal(int sig, __sighandler_t handler) __THROW;
-sighandler_t ssignal(int sig, sighandler_t handler) __THROW;
+__sighandler_t __sysv_signal(int sig, __sighandler_t handler) OMRSIG_NO_THROW;
+sighandler_t ssignal(int sig, sighandler_t handler) OMRSIG_NO_THROW;
 #endif /* defined(LINUX) */
 
 

--- a/omrsigcompat/omrsig.cpp
+++ b/omrsigcompat/omrsig.cpp
@@ -238,7 +238,7 @@ void (__cdecl * __cdecl
 signal(_In_ int signum, _In_opt_ void (__cdecl * handler)(int)))(int)
 #else /* defined(OMR_OS_WINDOWS) */
 sighandler_t
-signal(int signum, sighandler_t handler) __THROW
+signal(int signum, sighandler_t handler) OMRSIG_NO_THROW
 #endif /* defined(OMR_OS_WINDOWS) */
 {
 	return omrsig_signal_internal(signum, handler);
@@ -290,7 +290,7 @@ omrsig_signal_internal(int signum, sighandler_t handler)
 
 #if defined(POSIX_SIGNAL)
 int
-sigaction(int signum, const struct sigaction *act, struct sigaction *oldact) __THROW
+sigaction(int signum, const struct sigaction *act, struct sigaction *oldact) OMRSIG_NO_THROW
 {
 	return omrsig_sigaction_internal(signum, act, oldact, false);
 }
@@ -462,13 +462,13 @@ omrsig_sigaction_internal(int signum, const struct sigaction *act, struct sigact
 #if defined(LINUX)
 
 __sighandler_t
-__sysv_signal(int sig, __sighandler_t handler) __THROW
+__sysv_signal(int sig, __sighandler_t handler) OMRSIG_NO_THROW
 {
 	return omrsig_signal_internal(sig, handler);
 }
 
 sighandler_t
-ssignal(int sig, sighandler_t handler) __THROW
+ssignal(int sig, sighandler_t handler) OMRSIG_NO_THROW
 {
 	return omrsig_signal_internal(sig, handler);
 }
@@ -572,7 +572,7 @@ failed:
 #if !defined(OMR_OS_WINDOWS)
 
 sighandler_t
-sigset(int sig, sighandler_t disp) __THROW
+sigset(int sig, sighandler_t disp) OMRSIG_NO_THROW
 {
 	sighandler_t ret = SIG_ERR;
 #if defined(OSX) || defined(OMRZTPF)
@@ -620,7 +620,7 @@ sigset(int sig, sighandler_t disp) __THROW
 }
 
 int
-sigignore(int sig) __THROW
+sigignore(int sig) OMRSIG_NO_THROW
 {
 	/* Unregister the secondary handler for sig if there is one. */
 	SIGLOCK(sigMutex);
@@ -631,7 +631,7 @@ sigignore(int sig) __THROW
 }
 
 sighandler_t
-bsd_signal(int signum, sighandler_t handler) __THROW
+bsd_signal(int signum, sighandler_t handler) OMRSIG_NO_THROW
 {
 	struct sigaction act = {{0}};
 	struct sigaction oldact = {{0}};
@@ -652,7 +652,7 @@ bsd_signal(int signum, sighandler_t handler) __THROW
 #if !defined(J9ZOS390)
 
 sighandler_t
-sysv_signal(int signum, sighandler_t handler) __THROW
+sysv_signal(int signum, sighandler_t handler) OMRSIG_NO_THROW
 {
 	return omrsig_signal_internal(signum, handler);
 }


### PR DESCRIPTION
For C++ contexts, they must declare that they don't throw exceptions.

Define and use `OMRSIG_NO_THROW` instead of `__THROW`.