### PR TITLE
Enable Power Instruction cnttzw for the CountPositives Instrinsic

### DIFF
--- a/compiler/p/codegen/OMRInstOpCode.enum
+++ b/compiler/p/codegen/OMRInstOpCode.enum
@@ -107,7 +107,7 @@
    cntlzd_r,         // Count leading zeros dword Rc=1
    cntlzw,           // Count leading zeros word
    cntlzw_r,         // Count leading zeros word Rc=1
-// cnttzw,           // Count Trailing Zeros Word
+   cnttzw,           // Count Trailing Zeros Word
 // cnttzw_r,         // Count Trailing Zeros Word Rc=1
 // cnttzd,           // Count Trailing Zeros Dword
 // cnttzd_r,         // Count Trailing Zeros Dword Rc=1

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -1074,17 +1074,17 @@
    /* .properties  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::cntlzw].properties & ~PPCOpProp_HasRecordForm | PPCOpProp_IsRecordForm,
    },
 
-   /* { */
-   /* .mnemonic    =    OMR::InstOpCode::cnttzw, */
-   /* .name        =    "cnttzw", */
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::cnttzw,
+   /* .name        = */ "cnttzw",
    /* .description =    "Count Trailing Zeros Word", */
-   /* .prefix      =    0x00000000, */
-   /* .opcode      =    0x7C000434, */
-   /* .format      =    FORMAT_UNKNOWN, */
-   /* .minimumALS  =    OMR_PROCESSOR_PPC_P9, */
-   /* .properties  =    PPCOpProp_HasRecordForm | */
-   /*                   PPCOpProp_SyncSideEffectFree, */
-   /* }, */
+   /* .prefix      = */ 0x00000000,
+   /* .opcode      = */ 0x7C000434,
+   /* .format      = */ FORMAT_RA_RS,
+   /* .minimumALS  = */ OMR_PROCESSOR_PPC_P9,
+   /* .properties  = */ PPCOpProp_HasRecordForm |
+                        PPCOpProp_SyncSideEffectFree,
+   },
 
    /* { */
    /* .mnemonic    =    OMR::InstOpCode::cnttzw_r, */


### PR DESCRIPTION
Enable cnttzw which is used by the CountPositives intrinsic for P9 and above.