### PR TITLE
Implement mAllTrue and mmAllTrue on PPC

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1884,6 +1884,12 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
             return true;
          else
             return false;
+      case TR::mAllTrue:
+      case TR::mmAllTrue:
+         if (cpu->isAtLeast(OMR_PROCESSOR_PPC_P8))
+            return true;
+         else
+            return false;
       case TR::vload:
       case TR::vloadi:
       case TR::vstore:

--- a/compiler/p/codegen/OMRInstOpCode.enum
+++ b/compiler/p/codegen/OMRInstOpCode.enum
@@ -814,7 +814,7 @@
 // vpopcntb,         // Vector Population Count Byte
    vpopcntd,         // Vector Population Count Dword
 // vpopcnth,         // Vector Population Count Hword
-// vpopcntw,         // Vector Population Count Word
+   vpopcntw,         // Vector Population Count Word
    vmrghb,           // vector merge high byte
    vmrghh,           // vector merge high half word
    vmrghw,           // vector merge high word

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -9613,17 +9613,17 @@
    /*                   PPCOpProp_SyncSideEffectFree, */
    /* }, */
 
-   /* { */
-   /* .mnemonic    =    OMR::InstOpCode::vpopcntw, */
-   /* .name        =    "vpopcntw", */
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::vpopcntw,
+   /* .name        = */ "vpopcntw",
    /* .description =    "Vector Population Count Word", */
-   /* .prefix      =    0x00000000, */
-   /* .opcode      =    0x10000783, */
-   /* .format      =    FORMAT_UNKNOWN, */
-   /* .minimumALS  =    OMR_PROCESSOR_PPC_P8, */
-   /* .properties  =    PPCOpProp_IsVMX | */
-   /*                   PPCOpProp_SyncSideEffectFree, */
-   /* }, */
+   /* .prefix      = */ 0x00000000,
+   /* .opcode      = */ 0x10000783,
+   /* .format      = */ FORMAT_VRT_VRB,
+   /* .minimumALS  = */ OMR_PROCESSOR_PPC_P8,
+   /* .properties  = */ PPCOpProp_IsVMX |
+                        PPCOpProp_SyncSideEffectFree,
+   },
 
    {
    /* .mnemonic    = */ OMR::InstOpCode::vmrghb,


### PR DESCRIPTION
Implement PPC codegen for `mAllTrue` and `mmAllTrue` for Byte, Short, Int, and LongVectors on P8+