### PR TITLE
Make optimization analysis phase enum extensible

### DIFF
--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -2824,6 +2824,27 @@ TR::Optimizer *OMR::Optimizer::self()
    return (static_cast<TR::Optimizer *>(this));
    }
 
+const char *
+OMR::Optimizer::getAnalysisPhaseName(OMR::Optimizer::AnalysisPhases phaseId)
+   {
+#define OPTIMIZER_ANALYSIS_PHASES_MACRO(\
+   analysis_phase, \
+   name, \
+   id, \
+   ...) \
+      case id: \
+         return name;
+
+   switch (phaseId)
+      {
+#include "optimizer/OptimizerAnalysisPhases.enum"
+      default:
+         break;
+      }
+
+      return "Unknown analysis phase";
+   }
+
 OMR_InlinerPolicy* OMR::Optimizer::getInlinerPolicy()
    {
    return new (comp()->allocator()) OMR_InlinerPolicy(comp());

--- a/compiler/optimizer/OMROptimizer.hpp
+++ b/compiler/optimizer/OMROptimizer.hpp
@@ -322,25 +322,19 @@ class Optimizer
 
    bool isEnabled(OMR::Optimizations i);
 
-   enum // RAS
-      {
-      // Analyses start with "A", but not "A0" because that's "After Optimization"
-      BUILDING_VALUE_NUMBERS          = 0xA1,
-      BUILDING_STRUCTURE              = 0xA5, // "5"tructure
-      BUILDING_ALIASES                = 0xAA, // "A"liases
-      BUILDING_ACCURATE_NODE_COUNT    = 0xAC, // "C"ount
-      BUILDING_USE_DEFS               = 0xAD, // "D"efs
-      BUILDING_FREQUENCIES            = 0xAF, // "F"requencies
+#include "optimizer/OptimizerAnalysisPhasesEnum.hpp"
 
-      // When no analysis is running
-      BEFORE_OPTIMIZATION             = 0xB0,
-      PERFORMING_OPTIMIZATION         = 0xFF,
-      AFTER_OPTIMIZATION              = 0xA0,
-
-      HWPROFILE_PEEPHOLE_BLOCKS       = 0xCB,
-      PERFORMING_CHECKS               = 0xCC,
-
-      } AnalysisPhases;
+   /**
+    * Given a \ref Optimizer::AnalysisPhase value, returns a descriptive name
+    * for the phase.  This method is intended to be used for RAS purposes.
+    *
+    * \parm[in] phaseId An optimizer \ref Optimizer::AnalysisPhases value
+    *
+    * \returns A NUL-terminated character string giving the name of the phase,
+    *          or the string "Unknown analysis phase" if the phase id value is
+    *          not recognized.
+    */
+   static const char *getAnalysisPhaseName(Optimizer::AnalysisPhases phaseId);
 
    protected:
    TR::OptimizationManager *      _opts[OMR::numGroups];

--- a/compiler/optimizer/OMROptimizerAnalysisPhases.enum
+++ b/compiler/optimizer/OMROptimizerAnalysisPhases.enum
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2000
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+      // Analyses start with "A", but not "A0" because that's "After Optimization"
+OPTIMIZER_ANALYSIS_PHASES_MACRO(\
+  /* analysis_phase   = */    BUILDING_VALUE_NUMBERS, \
+  /* name             = */    "Building value numbers", \
+  /* id               = */    0xA1, \
+)
+OPTIMIZER_ANALYSIS_PHASES_MACRO(\
+  /* analysis_phase   = */    BUILDING_STRUCTURE, \
+  /* name             = */    "Building structure", \
+  /* id               = */    0xA5, // "5"tructure
+)
+OPTIMIZER_ANALYSIS_PHASES_MACRO(\
+  /* analysis_phase   = */    BUILDING_ALIASES, \
+  /* name             = */    "Building aliases", \
+  /* id               = */    0xAA, // "A"liases
+)
+OPTIMIZER_ANALYSIS_PHASES_MACRO(\
+  /* analysis_phase   = */    BUILDING_ACCURATE_NODE_COUNT, \
+  /* name             = */    "Building accurate node count", \
+  /* id               = */    0xAC, // "C"ount
+)
+OPTIMIZER_ANALYSIS_PHASES_MACRO(\
+  /* analysis_phase   = */    BUILDING_USE_DEFS, \
+  /* name             = */    "Building Use-Defs", \
+  /* id               = */    0xAD, // "D"efs
+)
+OPTIMIZER_ANALYSIS_PHASES_MACRO(\
+  /* analysis_phase   = */    BUILDING_FREQUENCIES, \
+  /* name             = */    "Building frequencies", \
+  /* id               = */    0xAF, // "F"requencies
+)
+
+      // When no analysis is running
+OPTIMIZER_ANALYSIS_PHASES_MACRO(\
+  /* analysis_phase   = */    BEFORE_OPTIMIZATION, \
+  /* name             = */    "Before Optimization", \
+  /* id               = */    0xB0, \
+)
+OPTIMIZER_ANALYSIS_PHASES_MACRO(\
+  /* analysis_phase   = */    PERFORMING_OPTIMIZATION, \
+  /* name             = */    "Performing Optimization", \
+  /* id               = */    0xFF, \
+)
+OPTIMIZER_ANALYSIS_PHASES_MACRO(\
+  /* analysis_phase   = */    AFTER_OPTIMIZATION, \
+  /* name             = */    "After Optimization", \
+  /* id               = */    0xA0, \
+)
+
+      // Checks
+OPTIMIZER_ANALYSIS_PHASES_MACRO(\
+  /* analysis_phase   = */    HWPROFILE_PEEPHOLE_BLOCKS, \
+  /* name             = */    "Hardware Profile Peepholde Blocks", \
+  /* id               = */    0xCB, \
+)
+OPTIMIZER_ANALYSIS_PHASES_MACRO(\
+  /* analysis_phase   = */    PERFORMING_CHECKS, \
+  /* name             = */    "Performing checks", \
+  /* id               = */    0xCC, \
+)

--- a/compiler/optimizer/OMROptimizerAnalysisPhasesEnum.hpp
+++ b/compiler/optimizer/OMROptimizerAnalysisPhasesEnum.hpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+#ifndef OMR_OPTIMIZER_ANALYSIS_PHASES_ENUM_INCL
+#define OMR_OPTIMIZER_ANALYSIS_PHASES_ENUM_INCL
+
+#define OPTIMIZER_ANALYSIS_PHASES_MACRO(\
+   analysis_phase, \
+   name, \
+   id, \
+   ...) analysis_phase = id,
+
+enum AnalysisPhases {
+
+#include "optimizer/OptimizerAnalysisPhases.enum"
+
+   unknownAnalysisPhase = 0
+
+};
+
+#undef OPTIMIZER_ANALYSIS_PHASES_MACRO
+
+#endif

--- a/compiler/optimizer/OptimizerAnalysisPhases.enum
+++ b/compiler/optimizer/OptimizerAnalysisPhases.enum
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+#include "optimizer/OMROptimizerAnalysisPhases.enum"

--- a/compiler/optimizer/OptimizerAnalysisPhasesEnum.hpp
+++ b/compiler/optimizer/OptimizerAnalysisPhasesEnum.hpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+#ifndef OPTIMIZER_ANALYSIS_PHASES_ENUM_INCL
+#define OPTIMIZER_ANALYSIS_PHASES_ENUM_INCL
+
+#include "optimizer/OMROptimizerAnalysisPhasesEnum.hpp"
+
+#endif


### PR DESCRIPTION
This change moves the definition of the `Optimizer::AnalysisPhases enum` values into a new file, `OMROptimizerAnalysisPhases.enum`.

The values are used in a macro `OPTIMIZER_ANALYSIS_PHASES_MACRO` which allows files that ultimately include `OMROptimizerAnalysisPhases.enum` to define the enum type, `Optimizer::AnalysisPhases`, using those values and to define a new method, `Optimizer::getOptimizationAnalysisPhaseName` that, given one of the enum values, will return the analysis phase name for debugging purposes.

This change also allows for the possibility that a downstream project might need to define additional optimizer analysis phases.