### PR TITLE
Apply OMR coding standard fixes for PRs #7795 and #7796

### DIFF
--- a/port/linux/omrvmem.c
+++ b/port/linux/omrvmem.c
@@ -1774,12 +1774,11 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 	if (0 != validPageSize) {
 #if defined(LINUXPPC)
 #if !defined(OMR_ENV_DATA64)
-		/* On 32-bit Linux PPC, for executable pages,
-		 * search through the list of supported page sizes only if
-		 * - request is for 64K pages, or
-		 * - request is for 16M pages AND CodeCacheConsolidation is enabled
+		/* On 32-bit Linux PPC, for executable pages, search the list of supported page sizes only if:
+		 * - The request is for 64K pages, or
+		 * - The request is for 16M pages and CodeCacheConsolidation is enabled.
 		 *
-		 * for 64-bit, accept any request supported by the OS
+		 * For 64-bit, accept any request supported by the OS.
 		 */
 		BOOLEAN codeCacheConsolidationEnabled = FALSE;
 
@@ -1787,12 +1786,13 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 		 * TR_ppcCodeCacheConsolidationEnabled is a manually set env variable used to indicate
 		 * that Code Cache Consolidation is enabled in the JIT.
 		 */
-		if (OMRPORT_VMEM_MEMORY_MODE_EXECUTE == (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode)) {
-			if (portLibrary->sysinfo_get_env(portLibrary, "TR_ppcCodeCacheConsolidationEnabled", NULL, 0) != -1) {
-				codeCacheConsolidationEnabled = TRUE;
-			}
+		if (OMR_ARE_ANY_BITS_SET(mode, OMRPORT_VMEM_MEMORY_MODE_EXECUTE)
+			&& (-1 != portLibrary->sysinfo_get_env(portLibrary, "TR_ppcCodeCacheConsolidationEnabled", NULL, 0))
+		) {
+			codeCacheConsolidationEnabled = TRUE;
 		}
-		if ((OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode))
+
+		if (OMR_ARE_NO_BITS_SET(mode, OMRPORT_VMEM_MEMORY_MODE_EXECUTE)
 			|| (codeCacheConsolidationEnabled && (SIXTEEN_M == validPageSize))
 			|| (SIXTY_FOUR_K == validPageSize))
 #endif /* !defined(OMR_ENV_DATA64) */


### PR DESCRIPTION
This commit corrects formatting and condition structure to comply
with the OMR coding standard:
https://github.com/eclipse-omr/omr/blob/master/doc/CodingStandard.md

Related: #7795
Related: #7796