### PR TITLE
Add kill switch for disabling the use of AVX instructions in arraycopies

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -272,6 +272,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableAVX",                         "C\tdisable avx and newer on x86",                   TR::Options::disableCPUFeatures, TR_DisableAVX, 0, "F"},
    {"disableAVX2",                        "C\tdisable avx2 and newer on x86",                  TR::Options::disableCPUFeatures, TR_DisableAVX2, 0, "F"},
    {"disableAVX512",                      "C\tdisable avx512 on x86",                          TR::Options::disableCPUFeatures, TR_DisableAVX512, 0, "F"},
+   {"disableAVXUseInArrayCopy",           "O\tdisable use of AVX instructions in arraycopies (x86 only)", SET_OPTION_BIT(TR_DisableAVXUseInArrayCopy), "F"},
    {"disableBasicBlockExtension",         "O\tdisable basic block extension",                  TR::Options::disableOptimization, basicBlockExtension, 0, "P"},
    {"disableBasicBlockPeepHole",          "O\tdisable basic blocks peepHole",                  SET_OPTION_BIT(TR_DisableBasicBlockPeepHole), "F"},
    {"disableBCDArithChildOrdering",       "O\tstress testing option -- do not reorder children of BCD arithmetic nodes", SET_OPTION_BIT(TR_DisableBCDArithChildOrdering), "F" },

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -410,7 +410,7 @@ enum TR_CompilationOptions
    TR_DisableNewX86VolatileSupport        = 0x04000000 + 10,
    TR_DisableZ17                          = 0x08000000 + 10,
    TR_EnableFileBackedCodeCacheDisclaiming = 0x10000000 + 10,
-   // Available                           = 0x20000000 + 10,
+   TR_DisableAVXUseInArrayCopy            = 0x20000000 + 10,
    // Available                           = 0x40000000 + 10,
    TR_DisableDirectToJNIInline            = 0x80000000 + 10,
 

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -2736,10 +2736,14 @@ static bool enablePrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS(uint8_t elemen
    if (!cg->comp()->target().cpu.supportsAVX() || !cg->comp()->target().is64Bit())
       return false;
 
+   static bool disableAVXUseInArrayCopy = feGetEnv("TR_DisableAVXUseInArrayCopy") != NULL;
    static bool disable8BitPrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS  = feGetEnv("TR_Disable8BitPrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS") != NULL;
    static bool disable16BitPrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS = feGetEnv("TR_Disable16BitPrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS") != NULL;
    static bool disable32BitPrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS = feGetEnv("TR_Disable32BitPrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS") != NULL;
    static bool disable64BitPrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS = feGetEnv("TR_Disable64BitPrimitiveArrayCopyInlineSmallSizeWithoutREPMOVS") != NULL;
+
+   if (disableAVXUseInArrayCopy || cg->comp()->getOption(TR_DisableAVXUseInArrayCopy))
+      return false;
 
    bool disableEnhancement = false;
 


### PR DESCRIPTION
Compiler option `disableAVXUseInArrayCopy` will prevent the use of AVX instructions when evaluating arraycopies on x86.