### PR TITLE
Remove redundant uses of cmake_minimum_required()

### DIFF
--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -19,8 +19,6 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 ###############################################################################
 
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-
 project(comptest LANGUAGES C CXX)
 
 set(OMR_WARNINGS_AS_ERRORS OFF)

--- a/fvtest/compilerunittest/CMakeLists.txt
+++ b/fvtest/compilerunittest/CMakeLists.txt
@@ -19,8 +19,6 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 ###############################################################################
 
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-
 project(compunittest LANGUAGES C CXX)
 
 set(OMR_WARNINGS_AS_ERRORS OFF)

--- a/fvtest/tril/examples/incordec/CMakeLists.txt
+++ b/fvtest/tril/examples/incordec/CMakeLists.txt
@@ -19,8 +19,6 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 ###############################################################################
 
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-
 project(tril_incordec LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/fvtest/tril/examples/mandelbrot/CMakeLists.txt
+++ b/fvtest/tril/examples/mandelbrot/CMakeLists.txt
@@ -19,8 +19,6 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 ###############################################################################
 
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-
 project(tril_mandelbrot LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/fvtest/tril/test/CMakeLists.txt
+++ b/fvtest/tril/test/CMakeLists.txt
@@ -19,8 +19,6 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 ###############################################################################
 
-# cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-#
 # project(triltest LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
Policy settings are inherited from parent folders.