### PR TITLE
Duplicate unmentioned receiver to privatize when versioning a guard

### DIFF
--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -6029,8 +6029,9 @@ void TR_LoopVersioner::buildConditionalTree(
              && requiresPrivatization(unmentionedReceiver))
             {
             chainPrep = true;
-            prep =
-               createLoopEntryPrep(LoopEntryPrep::PRIVATIZE, unmentionedReceiver);
+            prep = createLoopEntryPrep(
+               LoopEntryPrep::PRIVATIZE,
+               unmentionedReceiver->duplicateTreeWithCommoning(comp()->allocator()));
             }
          }
 


### PR DESCRIPTION
The original node was passed directly to `createLoopEntryPrep()`, which could cause incorrect increases to the reference counts of some of its descendants if speculative evaluation required additional versioning tests to ensure that safety preconditions would hold.