### PR TITLE
AArch64: Use ldar/stlr for volatile loads/stores

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -6146,6 +6146,74 @@ TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, i
    return commonLoadEvaluator(node, op, size, tempReg, cg);
    }
 
+static TR::Register *
+loadAddress(TR::Node *node, TR::MemoryReference *mr, TR::CodeGenerator *cg)
+   {
+   TR::Register *targetReg = cg->allocateRegister();
+
+   // TODO: this probably exists somewhere else
+   TR::Register *baseReg = mr->getBaseRegister();
+   TR::Register *indexReg = mr->getIndexRegister();
+   intptr_t offset = mr->getOffset();
+
+   if (offset == 0)
+      {
+      if (baseReg != NULL && indexReg == NULL)
+         {
+         if (baseReg != targetReg)
+            generateMovInstruction(cg, node, targetReg, baseReg);
+         }
+      else if (indexReg != NULL && baseReg == NULL)
+         {
+         if (baseReg != targetReg)
+            generateMovInstruction(cg, node, targetReg, indexReg);
+         }
+      else
+         {
+         generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, targetReg, baseReg, indexReg);
+         }
+      }
+   else
+      {
+      if (baseReg == NULL)
+         {
+         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, node, targetReg, indexReg, offset);
+         }
+      else if (indexReg == NULL)
+         {
+         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, node, targetReg, baseReg, offset);
+         }
+      else
+         {
+         generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, targetReg, baseReg, indexReg);
+         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, node, targetReg, targetReg, offset);
+         }
+      }
+
+   return targetReg;
+   }
+
+static TR::InstOpCode::Mnemonic
+getAcquireReleaseOpCode(TR::DataType type, bool isLoad, bool compressed)
+   {
+   switch (type)
+      {
+      case TR::Double:
+      case TR::Int64: return isLoad ? TR::InstOpCode::ldarx : TR::InstOpCode::stlrx;
+      case TR::Float:
+      case TR::Int32: return isLoad ? TR::InstOpCode::ldarw : TR::InstOpCode::stlrw;
+      case TR::Int16: return isLoad ? TR::InstOpCode::ldarh : TR::InstOpCode::stlrh;
+      case TR::Int8:  return isLoad ? TR::InstOpCode::ldarb : TR::InstOpCode::stlrb;
+      case TR::Address:
+         if (compressed)
+            return isLoad ? TR::InstOpCode::ldarw : TR::InstOpCode::stlrw;
+         else
+            return isLoad ? TR::InstOpCode::ldarx : TR::InstOpCode::stlrx;
+
+      default: TR_ASSERT_FATAL(false, "Unrecognized type (%s) for getAcquireReleaseOpCode", TR::DataType::getName(type));
+      }
+   }
+
 TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t size, TR::Register *targetReg, TR::CodeGenerator *cg)
    {
    TR::Symbol *sym = node->getSymbolReference()->getSymbol();
@@ -6155,9 +6223,33 @@ TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, i
    TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node);
    tempMR->validateImmediateOffsetAlignment(node, size, cg);
 
-   generateTrg1MemInstruction(cg, op, node, targetReg, tempMR);
+   if (needSync && tempMR->getUnresolvedSnippet() == NULL)
+      {
+      TR::Register *addrReg = loadAddress(node, tempMR, cg);
 
-   if (needSync)
+      TR::Register *targetGPR = targetReg;
+      if (node->getDataType().isFloatingPoint())
+         {
+         // ldar only operates on GPRs, so we need to load into a GPR then shuffle into targetReg
+         targetGPR = cg->allocateRegister();
+         }
+
+      generateTrg1MemInstruction(cg, getAcquireReleaseOpCode(node->getDataType(), true, cg->comp()->useCompressedPointers()), node, targetGPR, TR::MemoryReference::createWithDisplacement(cg, addrReg, 0));
+
+      if (node->getDataType().isFloatingPoint())
+         {
+         generateTrg1Src1Instruction(cg, node->getDataType().isFloat() ? TR::InstOpCode::fmov_wtos : TR::InstOpCode::fmov_xtod, node, targetGPR, targetReg);
+         cg->stopUsingRegister(targetGPR);
+         }
+
+      cg->stopUsingRegister(addrReg);
+      }
+   else
+      {
+      generateTrg1MemInstruction(cg, op, node, targetReg, tempMR);
+      }
+
+   if (needSync && tempMR->getUnresolvedSnippet() != NULL)
       {
       generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, TR::InstOpCode::ishld);
       }
@@ -6285,7 +6377,7 @@ TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, 
       valueChild = node->getFirstChild();
       }
 
-   if (cg->comp()->target().isSMP() && sym->isAtLeastOrStrongerThanAcquireRelease())
+   if (cg->comp()->target().isSMP() && sym->isAtLeastOrStrongerThanAcquireRelease() && tempMR->getUnresolvedSnippet() != NULL)
       {
       generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, TR::InstOpCode::ishst);
       }
@@ -6326,21 +6418,53 @@ TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, 
     * if valueChild is a compressed refs sequence of address constant NULL,
     * or valueChild is a zero constant integer.
     */
+   bool inZeroReg = false;
+   TR::Register *srcReg;
    if ((valueChildRoot != NULL) || (valueChild->getDataType().isIntegral() && valueChild->isConstZeroValue() && (valueChild->getRegister() == NULL)))
       {
-      TR::Register *zeroReg = cg->allocateRegister();
-      generateMemSrc1Instruction(cg, op, node, tempMR, zeroReg);
-      TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 1, cg->trMemory());
-      deps->addPostCondition(zeroReg, TR::RealRegister::xzr);
-      generateLabelInstruction(cg, TR::InstOpCode::label, node, generateLabelSymbol(cg), deps);
-      cg->stopUsingRegister(zeroReg);
+      srcReg = cg->allocateRegister();
+      inZeroReg = true;
       }
    else
       {
-      generateMemSrc1Instruction(cg, op, node, tempMR, cg->evaluate(valueChild));
+      srcReg = cg->evaluate(valueChild);
       }
 
-   if (cg->comp()->target().isSMP() && sym->isVolatile())
+   if (sym->isAtLeastOrStrongerThanAcquireRelease() && tempMR->getUnresolvedSnippet() == NULL)
+      {
+      TR::Register *addrReg = loadAddress(node, tempMR, cg);
+
+      TR::Register *srcGPR = srcReg;
+      if (node->getDataType().isFloatingPoint())
+         {
+         // stlr only operates on GPRs, so we need to shuffle srcReg into a GPR before store
+         srcGPR = cg->allocateRegister();
+         generateTrg1Src1Instruction(cg, node->getDataType().isFloat() ? TR::InstOpCode::fmov_stow : TR::InstOpCode::fmov_dtox, node, srcGPR, srcReg);
+         }
+
+      generateMemSrc1Instruction(cg, getAcquireReleaseOpCode(node->getDataType(), false, cg->comp()->useCompressedPointers()), node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 0), srcGPR);
+
+      if (node->getDataType().isFloatingPoint())
+         {
+         cg->stopUsingRegister(srcGPR);
+         }
+
+      cg->stopUsingRegister(addrReg);
+      }
+   else
+      {
+      generateMemSrc1Instruction(cg, op, node, tempMR, srcReg);
+      }
+
+   if (inZeroReg)
+      {
+      TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 1, cg->trMemory());
+      deps->addPostCondition(srcReg, TR::RealRegister::xzr);
+      generateLabelInstruction(cg, TR::InstOpCode::label, node, generateLabelSymbol(cg), deps);
+      cg->stopUsingRegister(srcReg);
+      }
+
+   if (cg->comp()->target().isSMP() && sym->isVolatile() && tempMR->getUnresolvedSnippet() != NULL)
       {
       generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, TR::InstOpCode::ish);
       }


### PR DESCRIPTION
Use stlr and ldar instructions instead of dmb and normal load/store instructions for volatile and acquire/release loads and stores.