### PR TITLE
Accelerate new converter method SingleByte$Encoder.encodeFromLatin1Impl

### DIFF
--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -2208,6 +2208,7 @@ void OMR::ValuePropagation::generateArrayTranslateNode(TR::TreeTop *callTree, TR
     bool isISO88591Decoder = (rm == TR::sun_nio_cs_ISO_8859_1_Decoder_decodeISO8859_1);
     bool isSBCSEncoder = (rm == TR::sun_nio_cs_ext_SBCS_Encoder_encodeSBCS) ? true : false;
     bool isSBCSDecoder = (rm == TR::sun_nio_cs_ext_SBCS_Decoder_decodeSBCS) ? true : false;
+    bool isEncodeFromLatin1 = (rm == TR::sun_nio_cs_SingleByteEncoder_encodeFromLatin1Impl) ? true : false;
     bool isDecodeToLatin1 = (rm == TR::sun_nio_cs_SingleByteDecoder_decodeToLatin1Impl) ? true : false;
     bool isEncodeUtf16
         = (rm == TR::sun_nio_cs_UTF16_Encoder_encodeUTF16Big || rm == TR::sun_nio_cs_UTF16_Encoder_encodeUTF16Little);
@@ -2271,7 +2272,7 @@ void OMR::ValuePropagation::generateArrayTranslateNode(TR::TreeTop *callTree, TR
     } else
         strideNode = TR::Node::create(callNode, TR::iconst, 0, 2);
 
-    if (isISO88591Encoder || isAsciiEncoder || isSBCSEncoder || isEncodeUtf16
+    if (isISO88591Encoder || isAsciiEncoder || isSBCSEncoder || isEncodeFromLatin1 || isEncodeUtf16
         || (rm == TR::sun_nio_cs_US_ASCII_Encoder_encodeASCII) || (rm == TR::sun_nio_cs_UTF_8_Encoder_encodeUTF_8))
         encode = true;
 
@@ -2280,7 +2281,7 @@ void OMR::ValuePropagation::generateArrayTranslateNode(TR::TreeTop *callTree, TR
         if (encode) {
             srcOff = TR::TransformUtil::generateConvertArrayElementIndexToOffsetTrees(comp(), srcOff, strideNode, 0,
                 false);
-            arrayTranslateNode->setSourceIsByteArrayTranslate(false);
+            arrayTranslateNode->setSourceIsByteArrayTranslate(isEncodeFromLatin1);
             arrayTranslateNode->setTargetIsByteArrayTranslate(true);
         } else {
             dstOff = TR::TransformUtil::generateConvertArrayElementIndexToOffsetTrees(comp(), dstOff, strideNode, 0,
@@ -2299,7 +2300,7 @@ void OMR::ValuePropagation::generateArrayTranslateNode(TR::TreeTop *callTree, TR
             src = TR::Node::create(is64BitTarget ? TR::aladd : TR::aiadd, 2, srcObj, node);
             node = TR::Node::create(is64BitTarget ? TR::ladd : TR::iadd, 2, dstOff, hdrSize);
             dst = TR::Node::create(is64BitTarget ? TR::aladd : TR::aiadd, 2, dstObj, node);
-            arrayTranslateNode->setSourceIsByteArrayTranslate(false);
+            arrayTranslateNode->setSourceIsByteArrayTranslate(isEncodeFromLatin1);
             arrayTranslateNode->setTargetIsByteArrayTranslate(true);
         } else {
             node = TR::Node::create(is64BitTarget ? TR::ladd : TR::iadd, 2, srcOff, hdrSize);
@@ -2312,7 +2313,7 @@ void OMR::ValuePropagation::generateArrayTranslateNode(TR::TreeTop *callTree, TR
         }
     }
 
-    if (encode && !isSBCSEncoder) {
+    if (encode && !isSBCSEncoder && !isEncodeFromLatin1) {
         arrayTranslateNode->setTableBackedByRawStorage(true);
         if (isISO88591Encoder) {
             arrayTranslateNode->setTermCharNodeIsHint(true);
@@ -2381,7 +2382,7 @@ void OMR::ValuePropagation::generateArrayTranslateNode(TR::TreeTop *callTree, TR
         }
 
         termCharNode = TR::Node::create(callNode, TR::iconst, 0, termchar);
-    } else if (isSBCSEncoder) // only z
+    } else if (isSBCSEncoder || isEncodeFromLatin1) // only z
     {
         arrayTranslateNode->setTermCharNodeIsHint(false);
         arrayTranslateNode->setSourceCellIsTermChar(false);
@@ -4057,7 +4058,8 @@ void OMR::ValuePropagation::transformConverterCall(TR::TreeTop *callTree)
         len = callNode->getChild(childId++); //->createLongIfNeeded();
 
     if ((rm == TR::sun_nio_cs_ext_SBCS_Encoder_encodeSBCS) || (rm == TR::sun_nio_cs_ext_SBCS_Decoder_decodeSBCS)
-        || (rm == TR::sun_nio_cs_SingleByteDecoder_decodeToLatin1Impl)) {
+        || (rm == TR::sun_nio_cs_SingleByteDecoder_decodeToLatin1Impl)
+        || (rm == TR::sun_nio_cs_SingleByteEncoder_encodeFromLatin1Impl)) {
         hasTable = true;
         tableNode = callNode->getChild(childId++);
     }
@@ -4187,6 +4189,7 @@ void OMR::ValuePropagation::transformConverterCall(TR::TreeTop *callTree)
             case TR::sun_nio_cs_UTF_8_Decoder_decodeUTF_8:
             case TR::sun_nio_cs_UTF_8_Encoder_encodeUTF_8:
             case TR::sun_nio_cs_SingleByteDecoder_decodeToLatin1Impl:
+            case TR::sun_nio_cs_SingleByteEncoder_encodeFromLatin1Impl:
             default:
                 threshold = 0;
                 break;


### PR DESCRIPTION
This commit accelerates a new converter method in
Java 11+ - SingleByte$Encoder.encodeFromLatin1Impl. The new method is analagous to an existing Java 8 converter method so the previous acceleration work in VP is leveraged to accelerate the new routine as well.