### PR TITLE
Add fields to J9SysinfoCPUTime and improve CPU load calculation

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -676,8 +676,11 @@ typedef struct J9SysinfoEnvIteratorState {
 /* Used by omrsysinfo_get_CPU_utilization() */
 typedef struct J9SysinfoCPUTime {
 	int64_t timestamp; /* time in nanoseconds from a fixed but arbitrary point in time */
-	int64_t cpuTime; /* cumulative CPU utilization (sum of system and user time in nanoseconds) of all CPUs on the system. */
+	int64_t cpuTime; /* cumulative CPU utilization (sum of system and user time in nanoseconds) of all CPUs on the system */
 	int32_t numberOfCpus; /* number of CPUs as reported by the operating system */
+	int64_t userTime; /* total user time (in CPU ticks) across all CPUs on the system */
+	int64_t systemTime; /* total kernel time (in CPU ticks) across all CPUs on the system */
+	int64_t idleTime; /* total idle time (in CPU ticks) across all CPUs on the system */
 } J9SysinfoCPUTime;
 
 /* Key memory categories are copied here for DDR access */

--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -625,8 +625,9 @@ omrsysinfo_get_load_average(struct OMRPortLibrary *portLibrary, struct J9PortSys
 
 /**
  * Obtain the cumulative CPU utilization of all CPUs on the system.
- * The cpuTime and timestamp values have no absolute significance: they should be used only to compute
- * differences from previous values.
+ * The cpuTime, timestamp, userTime, systemTime and idleTime values have no absolute significance.
+ * They should be used only to compute differences from previous values.
+ * userTime, systemTime and idleTime are set to -1 if they are unavailable.
  * On an N-processor  system, cpuTimeStats.cpuTime may increase up to N times faster than real time.
  *
  * @param[in] OMRPortLibrary portLibrary The port library.

--- a/port/common/omrsysinfo_helpers.h
+++ b/port/common/omrsysinfo_helpers.h
@@ -62,4 +62,6 @@ extern uint32_t
 omrsysinfo_get_cpu_extended_model(uint32_t processorSignature);
 #endif /* defined(OMR_OS_WINDOWS) || defined(J9X86) || defined(J9HAMMER) */
 
+extern double
+omrsysinfo_calculate_cpu_load(J9SysinfoCPUTime *new, J9SysinfoCPUTime *old);
 #endif /* SYSINFOHELPERS_H_ */

--- a/port/linuxs390/omrsysinfo_helpers.h
+++ b/port/linuxs390/omrsysinfo_helpers.h
@@ -38,6 +38,10 @@
  *
  * @return The index of the last valid uint64_t in the bits array.
  */
-extern int getstfle(int lastDoubleWord, uint64_t *bits);
+extern int
+getstfle(int lastDoubleWord, uint64_t *bits);
+
+extern double
+omrsysinfo_calculate_cpu_load(J9SysinfoCPUTime *new, J9SysinfoCPUTime *old);
 
 #endif /* SYSINFO_HELPERS_H_ */

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -4656,14 +4656,30 @@ omrsysinfo_get_CPU_utilization(struct OMRPortLibrary *portLibrary, struct J9Sysi
 		int64_t userTime = 0;
 		int64_t niceTime = 0;
 		int64_t systemTime = 0;
+		int64_t idleTime = 0;
+		int64_t iowaitTime = 0;
+		int64_t irqTime = 0;
+		int64_t softirqTime = 0;
+		int fieldsRead = 0;
 
 		buf[bytesRead] = '\0';
 		Trc_PRT_sysinfo_get_CPU_utilization_proc_stat_summary(buf);
-		if (0 == sscanf(buf, "cpu  %" SCNd64 " %" SCNd64 " %" SCNd64, &userTime, &niceTime, &systemTime)) {
+
+		fieldsRead = sscanf(
+				buf, "cpu  %" SCNd64 " %" SCNd64 " %" SCNd64 " %" SCNd64 " %" SCNd64 " %" SCNd64 " %" SCNd64,
+				&userTime, &niceTime, &systemTime, &idleTime, &iowaitTime, &irqTime, &softirqTime);
+
+		if (fieldsRead < 7) {
 			return OMRPORT_ERROR_SYSINFO_GET_STATS_FAILED;
 		}
-		cpuTime->cpuTime = (userTime + niceTime + systemTime) * NS_PER_CLK;
+
+		cpuTime->cpuTime = (userTime + niceTime + systemTime + irqTime + softirqTime) * NS_PER_CLK;
 		cpuTime->numberOfCpus = portLibrary->sysinfo_get_number_CPUs_by_type(portLibrary, OMRPORT_CPU_ONLINE);
+
+		cpuTime->userTime = userTime + niceTime;
+		cpuTime->systemTime = systemTime + irqTime + softirqTime;
+		cpuTime->idleTime = idleTime + iowaitTime;
+
 		status = 0;
 	}
 #elif defined(OSX)
@@ -4682,12 +4698,20 @@ omrsysinfo_get_CPU_utilization(struct OMRPortLibrary *portLibrary, struct J9Sysi
 		int64_t userTime = 0;
 		int64_t niceTime = 0;
 		int64_t systemTime = 0;
+		int64_t idleTime = 0;
+
 		for (i = 0; i < processorCount; i += 1) {
 			userTime += cpuLoadInfo[i].cpu_ticks[CPU_STATE_USER];
 			niceTime += cpuLoadInfo[i].cpu_ticks[CPU_STATE_NICE];
 			systemTime += cpuLoadInfo[i].cpu_ticks[CPU_STATE_SYSTEM];
+			idleTime += cpuLoadInfo[i].cpu_ticks[CPU_STATE_IDLE];
 		}
+
 		cpuTime->cpuTime = userTime + niceTime + systemTime;
+		cpuTime->userTime = userTime + niceTime;
+		cpuTime->systemTime = systemTime;
+		cpuTime->idleTime = idleTime;
+
 		status = 0;
 	} else {
 		return OMRPORT_ERROR_FILE_OPFAILED;
@@ -4697,12 +4721,16 @@ omrsysinfo_get_CPU_utilization(struct OMRPortLibrary *portLibrary, struct J9Sysi
 	cpuTime->numberOfCpus = Xj9GetEntitledProcessorCapacity() / 100;
 	/*Xj9GetSysCPUTime() is newly added to retrieve System CPU Time fromILE.*/
 	cpuTime->cpuTime = Xj9GetSysCPUTime();
+
+	cpuTime->userTime = -1;
+	cpuTime->systemTime = -1;
+	cpuTime->idleTime = -1;
 	status = 0;
 #elif defined(AIXPPC) /* AIX */
 	perfstat_cpu_total_t stats;
 	const uintptr_t NS_PER_CPU_TICK = 10000000L;
 
-	if (perfstat_cpu_total(NULL, &stats, sizeof(perfstat_cpu_total_t), 1) == -1) {
+	if (-1 == perfstat_cpu_total(NULL, &stats, sizeof(perfstat_cpu_total_t), 1)) {
 		Trc_PRT_sysinfo_get_CPU_utilization_perfstat_failed(errno);
 		return OMRPORT_ERROR_SYSINFO_GET_STATS_FAILED;
 	}
@@ -4710,6 +4738,11 @@ omrsysinfo_get_CPU_utilization(struct OMRPortLibrary *portLibrary, struct J9Sysi
 	Trc_PRT_sysinfo_get_CPU_utilization_perfstat(stats.user, stats.sys, stats.ncpus);
 	cpuTime->numberOfCpus = stats.ncpus; /* get the actual number of CPUs against which the time is reported */
 	cpuTime->cpuTime = (stats.user + stats.sys) * NS_PER_CPU_TICK;
+
+	cpuTime->userTime = stats.user;
+	cpuTime->systemTime = stats.sys;
+	cpuTime->idleTime = stats.idle + stats.wait;
+
 	status = 0;
 #endif
 	postTimestamp = portLibrary->time_nano_time(portLibrary);
@@ -4730,38 +4763,37 @@ omrsysinfo_get_CPU_utilization(struct OMRPortLibrary *portLibrary, struct J9Sysi
 intptr_t
 omrsysinfo_get_CPU_load(struct OMRPortLibrary *portLibrary, double *cpuLoad)
 {
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(AIXPPC) || defined(OSX)
 	J9SysinfoCPUTime currentCPUTime;
 	J9SysinfoCPUTime *oldestCPUTime = &portLibrary->portGlobals->oldestCPUTime;
 	J9SysinfoCPUTime *latestCPUTime = &portLibrary->portGlobals->latestCPUTime;
-
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(AIXPPC) || defined(OSX)
 	intptr_t portLibraryStatus = omrsysinfo_get_CPU_utilization(portLibrary, &currentCPUTime);
 
 	if (portLibraryStatus < 0) {
 		return portLibraryStatus;
 	}
 
-	if (oldestCPUTime->timestamp == 0) {
+	if (0 == oldestCPUTime->timestamp) {
 		*oldestCPUTime = currentCPUTime;
 		*latestCPUTime = currentCPUTime;
 		return OMRPORT_ERROR_INSUFFICIENT_DATA;
 	}
 
-	/* Calculate using the most recent value in the history */
+	/* Calculate using the most recent value in the history. */
 	if (((currentCPUTime.timestamp - latestCPUTime->timestamp) >= 10000000) && (currentCPUTime.numberOfCpus != 0)) {
-		*cpuLoad = OMR_MIN((currentCPUTime.cpuTime - latestCPUTime->cpuTime) / ((double)currentCPUTime.numberOfCpus * (currentCPUTime.timestamp - latestCPUTime->timestamp)), 1.0);
+		*cpuLoad = omrsysinfo_calculate_cpu_load(&currentCPUTime, latestCPUTime);
 		if (*cpuLoad >= 0.0) {
 			*oldestCPUTime = *latestCPUTime;
 			*latestCPUTime = currentCPUTime;
 			return 0;
 		} else {
-			/* Either the latest or the current time are bogus, so discard the latest value and try with the oldest value */
+			/* Discard the latest value and try with the oldest value, as either the latest or current time is invalid. */
 			*latestCPUTime = currentCPUTime;
 		}
 	}
 
 	if (((currentCPUTime.timestamp - oldestCPUTime->timestamp) >= 10000000) && (currentCPUTime.numberOfCpus != 0)) {
-		*cpuLoad = OMR_MIN((currentCPUTime.cpuTime - oldestCPUTime->cpuTime) / ((double)currentCPUTime.numberOfCpus * (currentCPUTime.timestamp - oldestCPUTime->timestamp)), 1.0);
+		*cpuLoad = omrsysinfo_calculate_cpu_load(&currentCPUTime, oldestCPUTime);
 		if (*cpuLoad >= 0.0) {
 			return 0;
 		} else {
@@ -4771,36 +4803,12 @@ omrsysinfo_get_CPU_load(struct OMRPortLibrary *portLibrary, double *cpuLoad)
 
 	return OMRPORT_ERROR_OPFAILED;
 #elif defined(J9ZOS390) /* (defined(LINUX) && !defined(OMRZTPF)) || defined(AIXPPC) || defined(OSX) */
-	currentCPUTime.timestamp = portLibrary->time_nano_time(portLibrary);
+	J9CVT* __ptr32 cvtp = ((J9PSA* __ptr32)0)->flccvt;
+	J9RMCT* __ptr32 rcmtp = cvtp->cvtopctp;
+	J9CCT* __ptr32 cctp = rcmtp->rmctcct;
 
-	if (oldestCPUTime->timestamp == 0) {
-		*oldestCPUTime = currentCPUTime;
-		*latestCPUTime = currentCPUTime;
-		return OMRPORT_ERROR_INSUFFICIENT_DATA;
-	}
-
-	/* Calculate using the most recent value in the history */
-	if ((currentCPUTime.timestamp - latestCPUTime->timestamp) >= 10000000) {
-		J9CVT* __ptr32 cvtp = ((J9PSA* __ptr32)0)->flccvt;
-		J9RMCT* __ptr32 rcmtp = cvtp->cvtopctp;
-		J9CCT* __ptr32 cctp = rcmtp->rmctcct;
-
-		*cpuLoad = (double)cctp->ccvutilp / 100.0;
-		*oldestCPUTime = *latestCPUTime;
-		*latestCPUTime = currentCPUTime;
-		return 0;
-	}
-
-	if ((currentCPUTime.timestamp - oldestCPUTime->timestamp) >= 10000000) {
-		J9CVT* __ptr32 cvtp = ((J9PSA* __ptr32)0)->flccvt;
-		J9RMCT* __ptr32 rcmtp = cvtp->cvtopctp;
-		J9CCT* __ptr32 cctp = rcmtp->rmctcct;
-
-		*cpuLoad = (double)cctp->ccvutilp / 100.0;
-		return 0;
-	}
-
-	return OMRPORT_ERROR_OPFAILED;
+	*cpuLoad = (double)cctp->ccvutilp / 100.0;
+	return 0;
 #else /* (defined(LINUX) && !defined(OMRZTPF)) || defined(AIXPPC) || defined(OSX) || defined(J9ZOS390) */
 	return OMRPORT_ERROR_SYSINFO_NOT_SUPPORTED;
 #endif


### PR DESCRIPTION
This change adds three new fields to J9SysinfoCPUTime: userTime,
systemTime, and idleTime. These fields support a more accurate
CPU load computation across platforms.

On Linux, the CPU load calculation now includes time spent servicing
hardware (irq) and software (softirq) interrupts as part of total
system usage. These components were previously omitted, which could
lead to underreporting CPU load. The update reflects improvements
in Linux kernel 5.x and later, where interrupt time tracking is more
accurate and consistently reported.

On z/OS, the dual timestamp logic is removed. The system provides
aggregate CPU time and entitlement capacity directly, allowing load
to be computed from a single snapshot. This simplifies the
implementation while preserving correctness.

The new calculation is:
```
  CPU load = (user time + system time) /
             (user time + system time + idle time)
```
This replaces the previous method:
```
  CPU load = (total CPU time delta) /
             (number of CPUs * timestamp delta)
```
The new approach improves alignment with what is observed using system
tools like htop.