### PR TITLE
Introduce getMaxPreferredVectorLength()

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1897,6 +1897,24 @@ public:
    void decOutOfLineColdPathNestedDepth(){_outOfLineColdPathNestedDepth--;}
 
    /**
+    * @brief Determines the maximum preferred vector length based on the target hardware.
+    *
+    * This function may query the underlying hardware capabilities and internal knowledge about
+    * CPU microarchitectures to recommend the optimal vector length (e.g., 128-bit, 256-bit, 512-bit)
+    * that is likely to yield the best performance. The default implementation returns
+    * TR::NoVectorLength. It is the responsibility of downstream projects to override and fine tune
+    * the behaviour of this function.
+    *
+    * @note All new vectorized intrinsics that support 256 or 512-bit vectorization should query this
+    * function instead of relying strictly on whether the CPU supports vectorization at a given vector
+    * length.
+    *
+    * @return The maximum preferred vector length in bits (e.g., none, 128, 256, 512).
+    * This function will return TR::NoVectorLength unless overridden.
+    */
+   TR::VectorLength getMaxPreferredVectorLength() { return TR::NoVectorLength; }
+
+   /**
     * @brief checks if instruction selection is in the state of generating
     *        instrucions for warm blocks in the case of warm and cold block splitting
     *

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -957,6 +957,24 @@ bool OMR::X86::CodeGenerator::supportsAddressRematerialization()         { stati
 #undef ALLOWED_TO_REMATERIALIZE
 #undef CAN_REMATERIALIZE
 
+TR::VectorLength
+OMR::X86::CodeGenerator::getMaxPreferredVectorLength()
+   {
+   TR::CPU *cpu = &self()->comp()->target().cpu;
+
+   if (cpu->supportsFeature(OMR_FEATURE_X86_AVX512F))
+      {
+      return TR::VectorLength512;
+      }
+
+   if (cpu->supportsFeature(OMR_FEATURE_X86_AVX2))
+      {
+      return TR::VectorLength256;
+      }
+
+   return TR::VectorLength128;
+   }
+
 bool OMR::X86::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::ILOpCode opcode)
    {
    TR_ASSERT_FATAL(opcode.isVectorOpCode(), "getSupportsOpCodeForAutoSIMD expects vector opcode\n");

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -533,6 +533,19 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    bool supportsAddressRematerialization();
    bool supportsXMMRRematerialization();
 
+   /**
+    * @brief Determines the maximum preferred vector length.
+    *
+    * The default implementation of this function returns the maximum vector length supported
+    * by the CPU. It does not consult microarchitecture information. It is the responsibility of
+    * downstream projects to implement this function for their desired behaviour and performance
+    * characteristics.
+    *
+    * @return The maximum preferred vector length in bits (e.g., 128, 256, 512).
+    * This function will return a minimum of TR::VectorLength128 on all target x86 hardware.
+    */
+   TR::VectorLength getMaxPreferredVectorLength();
+
    bool doIntMulDecompositionInCG() { return true; };
 
    TR::Instruction *setLastCatchAppendInstruction(TR::Instruction *i) {return (_lastCatchAppendInstruction=i);}


### PR DESCRIPTION
This commit introduces `getMaxPreferredVectorLength()` for detecting the optimal vector length for compiler intrinsics. The preferred VL may be more restrictive than what the CPU supports. Its purpose is to prevent vectorization related performance issues. New intrinsics that support vectorization should consult this function. A default implementation is provided on x86.