### PR TITLE
Stop loading fixed refs without known object indices at compile time

### DIFF
--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -7679,10 +7679,6 @@ void TR_InvariantArgumentPreexistence::processIndirectLoad(TR::Node *node, TR::T
       {
       somethingMayHaveChanged = TR::TransformUtil::transformIndirectLoadChain(comp(), node, addressChild, addressChild->getSymbolReference()->getKnownObjectIndex(), &removedNode);
       }
-   else if (addressChild->getSymbol()->isFixedObjectRef())
-      {
-      somethingMayHaveChanged = TR::TransformUtil::transformIndirectLoadChainAt(comp(), node, addressChild, (uintptr_t*)addressChild->getSymbol()->castToStaticSymbol()->getStaticAddress(), &removedNode);
-      }
    else if (addressChild->getSymbol()->isParm())
       {
       int32_t index = addressChild->getSymbol()->castToParmSymbol()->getOrdinal();

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -1717,9 +1717,9 @@ static bool addKnownObjectConstraints(
 
    uintptr_t *objectReferenceLocation = NULL;
    if (symRef->hasKnownObjectIndex())
+      {
       objectReferenceLocation = symRef->getKnownObjectReferenceLocation(vp->comp());
-   else if (symRef->getSymbol()->isFixedObjectRef())
-      objectReferenceLocation = (uintptr_t*)symRef->getSymbol()->castToStaticSymbol()->getStaticAddress();
+      }
 
 #ifdef J9_PROJECT_SPECIFIC
    if (objectReferenceLocation)

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1051,6 +1051,7 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
       symRefObjIndex.appendf( " (obj%d)", (int)symRef->getKnownObjectIndex());
    else if (sym && sym->isFixedObjectRef() && comp()->getKnownObjectTable() && !symRef->isUnresolved())
       {
+      symRefObjIndex.appends( " (fixed obj ref missing known object index)");
       TR::KnownObjectTable::Index i = comp()->getKnownObjectTable()->getExistingIndexAt((uintptr_t*)sym->castToStaticSymbol()->getStaticAddress());
       if (i != TR::KnownObjectTable::UNKNOWN)
          symRefObjIndex.appendf( " (==obj%d)", (int)i);


### PR DESCRIPTION
All resolved fixed object refs now also have known object indices, so the clauses deleted here are currently dead anyway.