### PR TITLE
Create option -Xjit:preferSwapForMemoryDisclaim

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1075,6 +1075,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"performLookaheadAtWarmCold", "O\tallow lookahead to be performed at cold and warm", SET_OPTION_BIT(TR_PerformLookaheadAtWarmCold), "F"},
    {"perfTool", "M\tenable PerfTool", SET_OPTION_BIT(TR_PerfTool), "F", NOT_IN_SUBSET },
    {"poisonDeadSlots",    "O\tpaints all dead slots with deadf00d", SET_OPTION_BIT(TR_PoisonDeadSlots), "F"},
+   {"preferSwapForMemoryDisclaim", "M\tIf possible, use swap file as a backup for disclaimed memory (linux only). Can be enabled internally by the JVM", SET_OPTION_BIT(TR_PreferSwapForMemoryDisclaim),"F", NOT_IN_SUBSET},
    {"prepareForOSREvenIfThatDoesNothing",   "O\temit the call to prepareForOSR even if there is no slot sharing", SET_OPTION_BIT(TR_EnablePrepareForOSREvenIfThatDoesNothing), "F"},
    {"printAbsoluteTimestampInVerboseLog", "O\tPrint Absolute Timestamp in vlog", SET_OPTION_BIT(TR_PrintAbsoluteTimestampInVerboseLog), "F", NOT_IN_SUBSET},
    {"printCodeCacheUsage",        "M\tPrint code cache usage at shutdown", SET_OPTION_BIT(TR_PrintCodeCacheUsage), "F", NOT_IN_SUBSET},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -411,7 +411,7 @@ enum TR_CompilationOptions
    TR_DisableZ17                          = 0x08000000 + 10,
    TR_EnableFileBackedCodeCacheDisclaiming = 0x10000000 + 10,
    TR_DontDisclaimMemoryOnSwap            = 0x20000000 + 10,
-   // Available                           = 0x40000000 + 10,
+   TR_PreferSwapForMemoryDisclaim         = 0x40000000 + 10,
    TR_DisableDirectToJNIInline            = 0x80000000 + 10,
 
    // Option word 11


### PR DESCRIPTION
This is supposed to replace the existing `-Xjit:disclaimMemoryOnSwap` option. 
The replacement will be done in stages to avoid omr/openj9 build breaks.