### PR TITLE
Update zos target level + fixes for Open XL z/OS

### DIFF
--- a/cmake/modules/platform/toolcfg/openxl.cmake
+++ b/cmake/modules/platform/toolcfg/openxl.cmake
@@ -21,9 +21,9 @@
 
 if(OMR_OS_ZOS)
 	set(OMR_ZOS_COMPILE_ARCHITECTURE "arch10" CACHE STRING "z/OS compile machine architecture" FORCE)
-	set(OMR_ZOS_COMPILE_TARGET "ZOSV2R4" CACHE STRING "z/OS compile target operating system" FORCE)
+	set(OMR_ZOS_COMPILE_TARGET "ZOSV2R5" CACHE STRING "z/OS compile target operating system" FORCE)
 	set(OMR_ZOS_COMPILE_TUNE "12" CACHE STRING "z/OS compile machine architecture tuning" FORCE)
-	set(OMR_ZOS_LINK_COMPAT "ZOSV2R4" CACHE STRING "z/OS link compatible operating system" FORCE)
+	set(OMR_ZOS_LINK_COMPAT "ZOSV2R5" CACHE STRING "z/OS link compatible operating system" FORCE)
 	set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "--shared")
 	set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "--shared")
 

--- a/util/omrutil/j9memclr.cpp
+++ b/util/omrutil/j9memclr.cpp
@@ -32,8 +32,8 @@
 #if defined(J9ZOS39064)
 #include "omrgcconsts.h"
 #include "omriarv64.h"
-#pragma map (getUserExtendedPrivateAreaMemoryType,"GETTTT")
-UDATA getUserExtendedPrivateAreaMemoryType(void);
+extern "C" UDATA getUserExtendedPrivateAreaMemoryType(void);
+#pragma map (getUserExtendedPrivateAreaMemoryType, "GETTTT")
 #endif /* defined(J9ZOS39064) */
 
 #if defined(LINUX) && defined(S390)


### PR DESCRIPTION
Some miscellaneous changes and updates required in support of compilation with the latest version of Open XL on z/OS.

---

- Target Level needs to be z/OS V2R5. Seem to be having errors unless this is updated even with Open XL 2.1.0.3 after all my cleanup and rebasing of repos.
- Pragma map error, cpp team has recommended encompassing the pragma map method within `extern C` , this is required due to ambiguous resolution of the parameter (int or void)
@keithc-ca 