### PR TITLE
Z: Add a debugCounter with register argument option

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -3120,7 +3120,7 @@ TR::Instruction *OMR::CodeGenerator::generateDebugCounter(TR::Instruction *curso
    return self()->generateDebugCounterBump(cursor, counter, deltaReg, NULL);
    }
 
-TR::Instruction *OMR::CodeGenerator::generateDebugCounter(const char *name, TR::RegisterDependencyConditions &cond, int32_t delta, int8_t fidelity, int32_t staticDelta, TR::Instruction *cursor)
+TR::Instruction *OMR::CodeGenerator::generateDebugCounter(const char *name, TR::RegisterDependencyConditions &cond, int32_t delta, int8_t fidelity, int32_t staticDelta, TR::Instruction *cursor, TR::Register *addressRegister)
    {
    if (!cursor)
       cursor = self()->getAppendInstruction();
@@ -3141,7 +3141,7 @@ TR::Instruction *OMR::CodeGenerator::generateDebugCounter(const char *name, TR::
    if (TR::DebugCounter::relocatableDebugCounter(self()->comp()))
       self()->comp()->mapStaticAddressToCounter(symref, aggregatedCounters);
 
-   return self()->generateDebugCounterBump(cursor, aggregatedCounters, 1, &cond);
+   return self()->generateDebugCounterBump(cursor, aggregatedCounters, 1, &cond, addressRegister);
    }
 
 TR::Instruction *OMR::CodeGenerator::generateDebugCounter(const char *name, TR::Register *deltaReg, TR::RegisterDependencyConditions &cond, int8_t fidelity, int32_t staticDelta, TR::Instruction *cursor)

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -630,12 +630,12 @@ public:
    TR::Instruction *generateDebugCounter(const char *name, TR::Register *deltaReg, int8_t fidelity = TR::DebugCounter::Undetermined);
    TR::Instruction *generateDebugCounter(TR::Instruction *cursor, const char *name, int32_t delta = 1, int8_t fidelity = TR::DebugCounter::Undetermined, int32_t staticDelta = 1);
    TR::Instruction *generateDebugCounter(TR::Instruction *cursor, const char *name, TR::Register *deltaReg, int8_t fidelity = TR::DebugCounter::Undetermined, int32_t staticDelta = 1);
-   TR::Instruction *generateDebugCounter(const char *name, TR::RegisterDependencyConditions &cond, int32_t delta = 1, int8_t fidelity = TR::DebugCounter::Undetermined, int32_t staticDelta = 1, TR::Instruction *cursor = NULL);
+   TR::Instruction *generateDebugCounter(const char *name, TR::RegisterDependencyConditions &cond, int32_t delta = 1, int8_t fidelity = TR::DebugCounter::Undetermined, int32_t staticDelta = 1, TR::Instruction *cursor = NULL, TR::Register *addressRegister = NULL);
    TR::Instruction *generateDebugCounter(const char *name, TR::Register *deltaReg, TR::RegisterDependencyConditions &cond, int8_t fidelity = TR::DebugCounter::Undetermined, int32_t staticDelta = 1, TR::Instruction *cursor = NULL);
    TR::Instruction *generateDebugCounter(const char *name, TR_ScratchRegisterManager &srm, int32_t delta = 1, int8_t fidelity = TR::DebugCounter::Undetermined, int32_t staticDelta = 1, TR::Instruction *cursor = NULL);
    TR::Instruction *generateDebugCounter(const char *name, TR::Register *deltaReg, TR_ScratchRegisterManager &srm, int8_t fidelity = TR::DebugCounter::Undetermined, int32_t staticDelta = 1, TR::Instruction *cursor = NULL);
 
-   TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, int32_t delta, TR::RegisterDependencyConditions *cond){ return cursor; }
+   TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, int32_t delta, TR::RegisterDependencyConditions *cond, TR::Register *addressRegister = NULL){ return cursor; }
    TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, TR::Register *deltaReg, TR::RegisterDependencyConditions *cond){ return cursor; }
    TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, int32_t delta, TR_ScratchRegisterManager &srm){ return cursor; }
    TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, TR::Register *deltaReg, TR_ScratchRegisterManager &srm){ return cursor; }

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4779,10 +4779,10 @@ bool OMR::Z::CodeGenerator::IsInMemoryType(TR::DataType type)
  * @param delta      Integer amount to increment the debug counter
  * @param cond       Register conditions for debug counters are now deprecated on z should be phased out when P architecture eliminates them
  */
-TR::Instruction* OMR::Z::CodeGenerator::generateDebugCounterBump(TR::Instruction* cursor, TR::DebugCounterBase* counter, int32_t delta, TR::RegisterDependencyConditions* cond)
+TR::Instruction* OMR::Z::CodeGenerator::generateDebugCounterBump(TR::Instruction* cursor, TR::DebugCounterBase* counter, int32_t delta, TR::RegisterDependencyConditions* cond, TR::Register *addressRegister)
    {
    TR::Snippet *constant = self()->Create8ByteConstant(cursor->getNode(), reinterpret_cast<intptr_t> (counter->getBumpCountSymRef(self()->comp())->getSymbol()->getStaticSymbol()->getStaticAddress()), false);
-   return generateS390DebugCounterBumpInstruction(self(), TR::InstOpCode::DCB, cursor->getNode(), constant, delta, cursor);
+   return generateS390DebugCounterBumpInstruction(self(), TR::InstOpCode::DCB, cursor->getNode(), constant, delta, cursor, addressRegister);
    }
 
 TR::Instruction* OMR::Z::CodeGenerator::generateDebugCounterBump(TR::Instruction* cursor, TR::DebugCounterBase* counter, TR::Register* deltaReg, TR::RegisterDependencyConditions* cond)

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -616,7 +616,7 @@ public:
 
 
 
-   TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, int32_t delta, TR::RegisterDependencyConditions *cond);
+   TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, int32_t delta, TR::RegisterDependencyConditions *cond, TR::Register *addressRegister = 0);
    TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, TR::Register *deltaReg, TR::RegisterDependencyConditions *cond);
    TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, int32_t delta, TR_ScratchRegisterManager &srm);
    TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, TR::Register *deltaReg, TR_ScratchRegisterManager &srm);

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -2108,10 +2108,14 @@ generateS390PseudoInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic o
  * @param preced  A pointer to the preceding instruction. It is required if this is called after register assignment
  */
 TR::Instruction *
-generateS390DebugCounterBumpInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Snippet* cs, int32_t delta, TR::Instruction * preced)
+generateS390DebugCounterBumpInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Snippet* cs, int32_t delta, TR::Instruction * preced, TR::Register *addressRegister)
    {
    if (preced)
       {
+         if(addressRegister)
+            {
+               return new (INSN_HEAP) TR::S390DebugCounterBumpInstruction(op, n, cs, cg, delta, preced, addressRegister);
+            }
          return new (INSN_HEAP) TR::S390DebugCounterBumpInstruction(op, n, cs, cg, delta, preced);
       }
    return new (INSN_HEAP) TR::S390DebugCounterBumpInstruction(op, n, cs, cg, delta);

--- a/compiler/z/codegen/S390GenerateInstructions.hpp
+++ b/compiler/z/codegen/S390GenerateInstructions.hpp
@@ -1306,7 +1306,8 @@ TR::Instruction *generateS390DebugCounterBumpInstruction(
                    TR::Node * n,
                    TR::Snippet* cas,
                    int32_t d = 1,
-                   TR::Instruction *preced = 0);
+                   TR::Instruction *preced = 0,
+                   TR::Register *addressRegister = 0);
 
 TR::Instruction *generateShiftRightImmediate(
                   TR::CodeGenerator *cg,

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -1026,6 +1026,8 @@ TR::S390PseudoInstruction::estimateBinaryLength(int32_t currentEstimate)
 void
 TR::S390DebugCounterBumpInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
+   if (getRegisterOperand(1))
+      return Instruction::assignRegisters(kindToBeAssigned);
    // Find a free real register for DCB to use during binary encoding to avoid spilling scratch registers
    for (auto i = TR::RealRegister::FirstGPR + 1; i <= TR::RealRegister::LastAssignableGPR; i++)
       {
@@ -1065,11 +1067,14 @@ TR::S390DebugCounterBumpInstruction::generateBinaryEncoding()
 
    int32_t offsetToLongDispSlot = (cg()->getLinkage())->getOffsetToLongDispSlot();
 
-   TR::RealRegister * scratchReg  = getAssignableReg();
+   TR::Register * assignableRegister = getRegisterOperand(1);
+   if (assignableRegister == NULL)
+      assignableRegister = getAssignableReg();
+   TR::RealRegister * scratchReg  = toRealRegister(assignableRegister);
    bool spillNeeded = true;
 
    // If we found a free register during RA, we don't need to spill
-   if (scratchReg)
+   if (assignableRegister)
       {
       spillNeeded = false;
       }


### PR DESCRIPTION
Dynamic debug counters use a free register on the go since the value is not needed after bump operation and add spill if required. This cause issues in parts of code with special register requirements like linkage. This PR add possibility to pass registers from constructor for better control.