### PR TITLE
Revert "Re-enable allocation/initialization opt"

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2797,13 +2797,7 @@ OMR::Options::jitPreProcess()
 
       self()->setOption(TR_DisableThunkTupleJ2I); // JSR292:TODO: Figure out how to do this without confusing startPCIfAlreadyCompiled
 
-#ifdef J9_PROJECT_SPECIFIC
-      TR_J9VMBase *fej9 = (TR_J9VMBase *)_fe;
-      bool enableTLHBatchClearing = fej9->tlhHasBeenCleared();
-      if (enableTLHBatchClearing)
-         self()->setOption(TR_DisableSeparateInitFromAlloc);
-#endif
-
+      self()->setOption(TR_DisableSeparateInitFromAlloc);
 
    #ifdef J9ZOS390
    #if defined(TR_TARGET_32BIT)


### PR DESCRIPTION
Reverts eclipse-omr/omr#7704

Causes a downstream project build break.