### PR TITLE
Set decimal precision when creating store for pdload

### DIFF
--- a/compiler/optimizer/PartialRedundancy.cpp
+++ b/compiler/optimizer/PartialRedundancy.cpp
@@ -1019,7 +1019,8 @@ TR::TreeTop *TR_PartialRedundancy::placeComputationsOptimally(TR::Block *block, 
                                 convertedOptimalNode, newSymbolReference);
 
 #ifdef J9_PROJECT_SPECIFIC
-                            correctDecimalPrecision(storeForCommonedNode, convertedOptimalNode, comp());
+                            if (convertedOptimalNode->hasDecimalPrecision())
+                                storeForCommonedNode->setDecimalPrecision(convertedOptimalNode->getDecimalPrecision());
 #endif
 
                             TR::TreeTop *duplicateOptimalTree = TR::TreeTop::create(comp(), storeForCommonedNode);


### PR DESCRIPTION
Partial redundancy optimizer add a store node for a load in some cases. If the load is pdload, it creates a pdstore but never set the precision. Later it call correctDecimalPrecision() which add a pdModifyPrecision node to truncate the precision to zero.
This change fix the store node precision if required.