### PR TITLE
Restore optimization for functions in omrzfs.c

### DIFF
--- a/port/zos390/omrzfs.c
+++ b/port/zos390/omrzfs.c
@@ -65,9 +65,6 @@ fillSyscallParamList(J9ZFSSyscallParamList *syscallParamListPtr, int32_t opcode,
  * @return 0 on success; negative value on failure.
  */
 static int32_t
-#if defined(__open_xl__)
-__attribute__((noinline))
-#endif /* defined(__open_xl__) */
 getZFSClientCacheSize(uint64_t *clientCacheSizePtr)
 {
 	uint64_t clientCacheSize = 0;
@@ -176,9 +173,6 @@ getZFSClientCacheSize(uint64_t *clientCacheSizePtr)
 
 /* Retrieve the amount of used ZFS file system user cache. */
 int32_t
-#if defined(__open_xl__)
-__attribute__((noinline))
-#endif /* defined(__open_xl__) */
 getZFSUserCacheUsed(uint64_t *userCacheUsedPtr)
 {
 


### PR DESCRIPTION
The noinline restrictions for getZFSClientCacheSize and getZFSUserCacheUsed are no longer required with Open XL 2.1.0.3+ on z/OS as the root issue has been fixed.

@babsingh @keithc-ca This is a revisit to our issue created a while back: https://github.com/eclipse-omr/omr/issues/7653
These optimizations are no longer needed and the root cause has been fixed.