### PR TITLE
Add GC reason for use in JFR

### DIFF
--- a/gc/base/CycleState.hpp
+++ b/gc/base/CycleState.hpp
@@ -63,12 +63,17 @@ public:
 		state_final_roots_complete,
 	} _markDelegateState; /**< The state of the MarkDelegate's incremental state machine (part of the cycle since multiple cycles could be in different places in the machine) */
 
+	enum CollectionReason {
+		gc_reason_other = 0,
+		gc_reason_alloc_failure = 1,
+		gc_reason_system_gc = 2,
+	} _collectionReason; /**< The reason for the collection (used for event reporting [JFR]) */
+
 	struct {
 		uintptr_t _survivorSetRegionCount; /**< Count of regions Copy Forward used as destination. Effective usage of regions is accounted, thus the count is not a cardinal number. */
 	} _pgcData;
 
 	uintptr_t _currentIncrement; /**< The index of the current increment within the cycle, starting at 0 (used for event reporting) */
-
 	bool _shouldRunCopyForward; /**< True if this cycle is to run a copy-forward-based attempt at reclaiming memory, false if mark-compact is to be used */
 
 	enum ReasonForMarkCompactPGC {
@@ -105,6 +110,7 @@ public:
 		, _noCompactionAfterSweep(false)
 		, _collectionType(CT_GLOBAL_GARBAGE_COLLECTION)
 		, _markDelegateState(state_mark_idle)
+		, _collectionReason(gc_reason_other)
 		, _currentIncrement(0)
 		, _shouldRunCopyForward(false)
 		, _reasonForMarkCompactPGC(reason_not_exceptional)


### PR DESCRIPTION
This change adds a new value and variable to cycle state to be used later on for jfr logging.