### PR TITLE
Avoid uncaught exception in `Checklist` destructor

### DIFF
--- a/compiler/infra/Checklist.cpp
+++ b/compiler/infra/Checklist.cpp
@@ -32,7 +32,15 @@ Checklist::Checklist(TR::Compilation *c)
     , _v(allocBV())
 {}
 
-Checklist::~Checklist() { _comp->getBitVectorPool().release(_v); }
+Checklist::~Checklist()
+{
+    try {
+        _comp->getBitVectorPool().release(_v);
+    } catch (const std::bad_alloc &) {
+        // Prevent uncaught exception in destructor from causing termination.
+        // Okay to ignore as we will only fail to add to BitVectorPool.
+    }
+}
 
 Checklist::Checklist(const Checklist &other)
     : _comp(other._comp)


### PR DESCRIPTION
There was a rare scenario in which a memory allocation failed and as part of handling the OOM the destructor for `Checklist` was called. Calling `BitVectorPool.release()` required a memory allocation which failed due to being out of memory. This throw inside a destructor resulted in the program terminating. This is similar to the scenario described in issue #3083. 

Wrapped the call to `BitVectorPool.release()` in `if (!std::uncaught_exception())` to avoid this double throw scenario. 