### PR TITLE
Change LOW_FREQ to 1

### DIFF
--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -86,7 +86,7 @@ template<class T> class TR_Array;
 
 #define MAX_REMOVE_EDGE_NESTING_DEPTH 125
 
-#define LOW_FREQ 5
+#define LOW_FREQ 1
 #define AVG_FREQ 150
 
 namespace OMR {


### PR DESCRIPTION
LOW_FREQ is used to indicate the lower bound for the frequency of a block. However, in cases where a method may have a small number of absolute samples, this can cause blocks that aren't actually low frequency to be interpreted as such.

Changing the value to 1 ensures that the compiler considers more blocks than it used to in the past.