### PR TITLE
Introduce hooks before and after binary encoding

### DIFF
--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -280,7 +280,9 @@ void OMR::CodeGenPhase::performBinaryEncodingPhase(TR::CodeGenerator *cg, TR::Co
     TR::LexicalMemProfiler mp(phase->getName(), comp->phaseMemProfiler());
     LexicalTimer pt(phase->getName(), comp->phaseTimer());
 
+    cg->preBinaryEncodingHook();
     cg->doBinaryEncoding();
+    cg->postBinaryEncodingHook();
 
     // Instructions have been emitted, and now we know what the entry point is, so update the compilation method symbol
     comp->getMethodSymbol()->setMethodAddress(cg->getCodeStart());

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -452,6 +452,16 @@ public:
     void doRegisterAssignment(TR_RegisterKinds kindsToAssign);
     void doBinaryEncoding();
 
+    /**
+     * @brief This function is a hook that executes immediately before Binary Encoding.
+     */
+    void preBinaryEncodingHook() {}
+
+    /**
+     * @brief This function is a hook that executes immediately after Binary Encoding.
+     */
+    void postBinaryEncodingHook() {}
+
     bool hasComplexAddressingMode() { return false; }
 
     void removeUnusedLocals();


### PR DESCRIPTION
This commit introduces two new hook functions that the execute immediately before and after binary encoding.