### PR TITLE
Add support for downstream Code Cache segregation

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2061,6 +2061,9 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
     { "transactionalMemoryRetryCount=", "R<nnn>\tthe time of retries when transactions get abort",
      TR::Options::setStaticNumeric, (intptr_t)&OMR::Options::_TransactionalMemoryRetryCount, 0, "F%d",
      NOT_IN_SUBSET },
+    { "transientCodeRegex=",
+     "O{regex}\tRegex to specify classes that are likely to be unloaded during runtime lifetime. Jitted code for "
+        "methods belonging to such classes will be stored in dedicated code caches.", TR::Options::setRegex, offsetof(OMR::Options, _transientClassRegex), 0, "P" },
 #if defined(DEBUG)
     { "trdebug=", "D{option,option,...}\tadd debug_options to the debug list", TR::Options::setDebug },
 #endif

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1398,6 +1398,8 @@ public:
 
     TR::CodeCacheKind getCodeCacheKind() { return _codeCacheKind; }
 
+    TR::SimpleRegex *getTransientClassRegex() { return _transientClassRegex; }
+
     void setCodeCacheKind(TR::CodeCacheKind kind) { _codeCacheKind = kind; }
 
     void init()
@@ -1560,6 +1562,7 @@ public:
         _arraycopyRepMovsLongArrayThreshold = 128;
         _arraycopyRepMovsReferenceArrayThreshold = 128;
         _codeCacheKind = TR::CodeCacheKind::DEFAULT_CC;
+        _transientClassRegex = NULL;
 
         memset(_options, 0, sizeof(_options));
         memset(_disabledOptimizations, false, sizeof(_disabledOptimizations));
@@ -2840,6 +2843,7 @@ protected:
                                                       // Only supports 32, 64, or 128 bytes
 
     TR::CodeCacheKind _codeCacheKind;
+    TR::SimpleRegex *_transientClassRegex;
 }; // TR::Options
 
 } // namespace OMR

--- a/compiler/control/OptionsUtil.hpp
+++ b/compiler/control/OptionsUtil.hpp
@@ -208,6 +208,9 @@ private:
 //
 enum CodeCacheKind {
     DEFAULT_CC = 0,
+    TRANSIENT_CODE_CC, // To prevent fragmentation, we allow the user to indicate that certain classes are
+                       // transient, this allows us to place the code for these classes in a distinct code
+                       // cache which prevents fragmentation.
     FILE_BACKED_CC,
 };
 


### PR DESCRIPTION
Adjust the CodeCacheKind enum to add support for OpenJ9 code cache segregation.