### PR TITLE
Standardize vbitselect operand ordering across platforms

### DIFF
--- a/compiler/il/VectorOperations.enum
+++ b/compiler/il/VectorOperations.enum
@@ -933,7 +933,9 @@ VECTOR_OPERATION_MACRO(\
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
    /* .booleanCompareOpCode    = */ TR::BadILOp, \
    /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    vector bit-wise select operator */ \
+   /* .description             =    vector bit-wise select operator. \
+                                    For each bit that is 1 in the first child (selector) select from the second child, \
+                                    otherwise select from the third child. */ \
 )
 VECTOR_OPERATION_MACRO(\
    /* .operation               = */ vblend, \

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -757,7 +757,8 @@ public:
     static TR::Register *BBEndEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *inlineVectorUnaryOp(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op);
     static TR::Register *inlineVectorBinaryOp(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op);
-    static TR::Register *inlineVectorBitSelectOp(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op);
+    static TR::Register *inlineVectorBitSelectOp(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
+        bool isSelectOpcode = false);
     static TR::Register *PrefetchEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *i2aEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *iu2aEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -14173,25 +14173,24 @@ TR::Register *OMR::Z::TreeEvaluator::vstoreEvaluator(TR::Node *node, TR::CodeGen
 
 TR::Register *OMR::Z::TreeEvaluator::vbitselectEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    TR::Node *firstVecNode = node->getFirstChild();
-    TR::Node *secondVecNode = node->getSecondChild();
-    TR::Node *vecSelectNode = node->getThirdChild();
+    TR::Node *selectorChild = node->getFirstChild();
+    TR::Node *trueChild = node->getSecondChild();
+    TR::Node *falseChild = node->getThirdChild();
 
-    TR::Register *firstVecReg = cg->evaluate(firstVecNode);
-    TR::Register *secondVecReg = cg->evaluate(secondVecNode);
-    TR::Register *vecSelectReg = cg->evaluate(vecSelectNode);
+    TR::Register *falseVecReg = cg->evaluate(falseChild);
+    TR::Register *trueVecReg = cg->evaluate(trueChild);
+    TR::Register *vecSelectReg = cg->evaluate(selectorChild);
     TR::Register *returnVecReg = cg->allocateRegister(TR_VRF);
 
-    generateVRReInstruction(cg, TR::InstOpCode::VSEL, node, returnVecReg, firstVecReg, secondVecReg, vecSelectReg, 0,
-        0);
+    generateVRReInstruction(cg, TR::InstOpCode::VSEL, node, returnVecReg, trueVecReg, falseVecReg, vecSelectReg, 0, 0);
 
-    cg->stopUsingRegister(firstVecReg);
-    cg->stopUsingRegister(secondVecReg);
+    cg->stopUsingRegister(falseVecReg);
+    cg->stopUsingRegister(trueVecReg);
     cg->stopUsingRegister(vecSelectReg);
 
-    cg->decReferenceCount(firstVecNode);
-    cg->decReferenceCount(secondVecNode);
-    cg->decReferenceCount(vecSelectNode);
+    cg->decReferenceCount(falseChild);
+    cg->decReferenceCount(trueChild);
+    cg->decReferenceCount(selectorChild);
 
     node->setRegister(returnVecReg);
     return returnVecReg;

--- a/fvtest/compilertriltest/VectorTest.cpp
+++ b/fvtest/compilertriltest/VectorTest.cpp
@@ -782,15 +782,15 @@ TEST_F(VectorTest, VInt8BitSelect) {
     // This test currently assumes 128bit SIMD
 
     int8_t output[] =  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    int8_t inputA[] =  {8, -3, 62, 56, -108, -13, 114, -100, 69, -80, 6, 104, 67, 78, 12, -72};
-    int8_t inputB[] =  {55, 107, -12, 39, 77, 103, -3, 15, -17, -16, -62, -41, 71, 77, 111, -119};
-    int8_t inputC[] =  {-121, 28, -85, 63, 59, 19, 21, 95, -14, -21, 8, -41, 8, 103, -100, -16};
+    int8_t falseInput[] =  {8, -3, 62, 56, -108, -13, 114, -100, 69, -80, 6, 104, 67, 78, 12, -72};
+    int8_t trueInput[] =  {55, 107, -12, 39, 77, 103, -3, 15, -17, -16, -62, -41, 71, 77, 111, -119};
+    int8_t maskInput[] =  {-121, 28, -85, 63, 59, 19, 21, 95, -14, -21, 8, -41, 8, 103, -100, -16};
 
-    entry_point(output,inputA,inputB,inputC);
+    entry_point(output,maskInput,trueInput,falseInput);
 
     // The expected result is a^((a^b)&c), which extracts bits from b if the corresponding bit of c is 1.
     for (int i = 0; i < (sizeof(output) / sizeof(*output)); i++) {
-        EXPECT_EQ(inputA[i] ^ ((inputA[i] ^ inputB[i]) & inputC[i]), output[i]);
+        EXPECT_EQ(falseInput[i] ^ ((falseInput[i] ^ trueInput[i]) & maskInput[i]), output[i]);
     }
 }
 


### PR DESCRIPTION
Standardized the operand ordering for the vbitselect opcode to match
the convention used by other select opcodes across all supported
platforms. In the new schema, child 1 is the selector, child 2 is the
value selected when the selector is set, and child 3 is the value
selected when the selector is unset.