### PR TITLE
Provide compiler option to disregard CPU store ordering requirements

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -162,7 +162,7 @@ void OMR::ARM64::CodeGenerator::initialize()
 
     cg->getLinkage()->setParameterLinkageRegisterIndex(comp->getJittedMethodSymbol());
 
-    if (comp->target().isSMP())
+    if (comp->target().isSMP() && !comp->getOption(TR_DisregardCPUStoreOrdering))
         cg->setEnforceStoreOrder();
 
     cg->setSupportsAutoSIMD();

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -989,6 +989,8 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
     { "disableZImplicitNullChecks", "O\tdisable implicit null checks on 390",
      SET_OPTION_BIT(TR_DisableZImplicitNullChecks), "F" },
     { "disableZNext", "O\tdisable zNext support", SET_OPTION_BIT(TR_DisableZNext), "F" },
+    { "disregardCPUStoreOrdering", "O\tdisregard any CPU store ordering requirements",
+     SET_OPTION_BIT(TR_DisregardCPUStoreOrdering), "F" },
     { "dltMostOnce", "O\tprevent DLT compilation of a method at more than one bytecode index.",
      SET_OPTION_BIT(TR_DLTMostOnce), "F" },
     { "dltOptLevel=cold", "O\tforce DLT compilation at cold level", TR::Options::set32BitValue,

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -584,7 +584,7 @@ enum TR_CompilationOptions {
     // Option word 16
     TR_ForceNonSMP                                           = 0x00000020 + 16,
     TR_jitAllAtMain                                          = 0x00000040 + 16,
-    // Available                                             = 0x00000080 + 16,
+    TR_DisregardCPUStoreOrdering                             = 0x00000080 + 16,
     // Available                                             = 0x00000100 + 16,
     TR_EnableAOTMethodExit                                   = 0x00000200 + 16,
     // Available                                             = 0x00000400 + 16,

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -276,7 +276,7 @@ void OMR::Power::CodeGenerator::initialize()
     }
 
     // TODO: distinguishing among OOO and non-OOO implementations
-    if (comp->target().isSMP())
+    if (comp->target().isSMP() && !comp->getOption(TR_DisregardCPUStoreOrdering))
         cg->setEnforceStoreOrder();
 
     if (!comp->getOption(TR_DisableTraps) && TR::Compiler->vm.hasResumableTrapHandler(comp))


### PR DESCRIPTION
This option is primarily useful for diagnostic investigations and provides a means to prevent the use of mechanisms (such as allocation fences) to enforce store ordering.

This option should NOT be enabled in any production environments by default.