### PR TITLE
Fix clobber evaluation of Node's register

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -988,11 +988,11 @@ bool OMR::CodeGenerator::isRegisterClobberable(TR::Register *reg, uint16_t count
 bool OMR::CodeGenerator::canClobberNodesRegister(TR::Node *node, uint16_t count, TR_ClobberEvalData *data,
     bool ignoreRefCount)
 {
-    if (!ignoreRefCount && node->getReferenceCount() > count)
+    if (self()->comp()->getOption(TR_DisableEnhancedClobberEval))
         return false;
 
-    if (self()->useClobberEvaluate())
-        return true;
+    if (!ignoreRefCount && node->getReferenceCount() > count)
+        return false;
 
     TR::Register *reg = node->getRegister();
     TR::RegisterPair *regPair = reg->getRegisterPair();


### PR DESCRIPTION
This changes prevents the illegal clobbering of a
node's register without checking if the register
is clobberable.

Issue: eclipse-openj9/openj9#18834