### PR TITLE
Allocate Vector registers before GPRs

### DIFF
--- a/compiler/p/codegen/OMRMachine.cpp
+++ b/compiler/p/codegen/OMRMachine.cpp
@@ -490,7 +490,7 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction *current
             }
         }
 
-        TR_ASSERT(numCandidates != 0, "All %s registers are blocked\n", virtReg->getRegisterKindName(comp, rk));
+        TR_ASSERT_FATAL(numCandidates != 0, "All %s registers are blocked\n", virtReg->getRegisterKindName(comp, rk));
 
         cursor = currentInstruction;
         while (numCandidates > 1 && cursor != NULL && cursor->getOpCodeValue() != TR::InstOpCode::label

--- a/compiler/p/codegen/PPCDebug.cpp
+++ b/compiler/p/codegen/PPCDebug.cpp
@@ -279,6 +279,10 @@ void TR_Debug::print(TR::FILE *pOutFile, TR::PPCLabelInstruction *instr)
         }
     }
     printInstructionComment(pOutFile, 1, instr);
+
+    if (instr->getDependencyConditions())
+        print(pOutFile, instr->getDependencyConditions());
+
     trfflush(_comp->getOutFile());
 }
 


### PR DESCRIPTION
- While allocating a free vector register it might require a spill
  and, therefore, a temporary GPR as an index register (due to the alignment issues)
- To avoid all GPRs being blocked, allocate vector registers first