### PR TITLE
Off-heap related update

### DIFF
--- a/gc/base/AllocateDescription.hpp
+++ b/gc/base/AllocateDescription.hpp
@@ -75,6 +75,7 @@ protected:
 	bool  _climb;				/* indicates that current attempt to allocate should try parent, if current subspace failed */
 	bool  _completedFromTlh;
 
+	bool _sharedReserved;
 public:
 
 	/**
@@ -218,6 +219,9 @@ public:
 	 */
 	MMINLINE bool getAllocationSucceeded() {return _allocationSucceeded;}
 
+	MMINLINE void setSharedReserved(bool _sharedReserved) {_sharedReserved = _sharedReserved;}
+	MMINLINE bool getSharedReserved() {return _sharedReserved;}
+
 	/**
 	 * Create an AllocateDescriptionCore object.
 	 */
@@ -245,6 +249,7 @@ public:
 		, _collectAndClimb(collectAndClimb)
 		, _climb(false)
 		, _completedFromTlh(false)
+		, _sharedReserved(false)
 	{}
 };
 

--- a/gc/base/SparseVirtualMemory.cpp
+++ b/gc/base/SparseVirtualMemory.cpp
@@ -76,7 +76,17 @@ MM_SparseVirtualMemory::initialize(MM_EnvironmentBase *env, uint32_t memoryCateg
 		off_heap_size = MM_Math::roundToCeiling(regionSize, (in_heap_size / 100) * ext->sparseHeapSizeRatio);
 	}
 
-	bool success = MM_VirtualMemory::initialize(env, off_heap_size, NULL, NULL, 0, memoryCategory);
+	bool success = false;
+
+	uintptr_t size = sizeof(void *) * (off_heap_size / regionSize);
+	_allocationContextArray = (void **)env->getForge()->allocate(size, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	if (NULL != _allocationContextArray) {
+		memset(_allocationContextArray, 0, size);
+	} else {
+		return success;
+	}
+
+	success = MM_VirtualMemory::initialize(env, off_heap_size, NULL, NULL, 0, memoryCategory);
 
 	if (success) {
 		void *sparseHeapBase = getHeapBase();
@@ -98,6 +108,11 @@ MM_SparseVirtualMemory::initialize(MM_EnvironmentBase *env, uint32_t memoryCateg
 void
 MM_SparseVirtualMemory::tearDown(MM_EnvironmentBase *env)
 {
+	if (NULL != _allocationContextArray) {
+		env->getForge()->free(_allocationContextArray);
+		_allocationContextArray = NULL;
+	}
+
 	if (NULL != _sparseDataPool) {
 		_sparseDataPool->kill(env);
 		_sparseDataPool = NULL;
@@ -174,6 +189,9 @@ MM_SparseVirtualMemory::freeSparseRegionAndUnmapFromHeapObject(MM_EnvironmentBas
 
 	if ((NULL != dataPtr) && (0 != dataSize)) {
 		uintptr_t adjustedSize = adjustSize(dataSize);
+
+		resetAllocationContextForAddress(dataPtr, dataSize);
+
 		ret = decommitMemory(env, dataPtr, adjustedSize);
 		if (ret) {
 			omrthread_monitor_enter(_largeObjectVirtualMemoryMutex);

--- a/gc/base/SparseVirtualMemory.hpp
+++ b/gc/base/SparseVirtualMemory.hpp
@@ -63,6 +63,8 @@ private:
 	MM_Heap *_heap; /**< reference to in-heap */
 	MM_SparseAddressOrderedFixedSizeDataPool *_sparseDataPool; /**< Structure that manages data and free region of sparse virtual memory */
 	omrthread_monitor_t _largeObjectVirtualMemoryMutex; /**< Monitor that manages access to sparse virtual memory */
+
+	void **_allocationContextArray;
 protected:
 public:
 /*
@@ -84,6 +86,7 @@ protected:
 		, _heap(in_heap)
 		, _sparseDataPool(NULL)
 		, _largeObjectVirtualMemoryMutex(NULL)
+		, _allocationContextArray(NULL)
 	{
 		_typeId = __FUNCTION__;
 	}
@@ -156,6 +159,39 @@ public:
 	MMINLINE MM_SparseAddressOrderedFixedSizeDataPool *getSparseDataPool()
 	{
 		return _sparseDataPool;
+	}
+
+	MMINLINE uintptr_t getAllocationContextIndexForAddress(const void *address)
+	{
+		const uintptr_t regionSize = _heap->getHeapRegionManager()->getRegionSize();
+		return ((uintptr_t)address - (uintptr_t)getHeapBase()) / regionSize;
+	}
+
+	MMINLINE uintptr_t getAllocationContextCount(uintptr_t size)
+	{
+		const uintptr_t regionSize = _heap->getHeapRegionManager()->getRegionSize();
+		return size / regionSize;
+	}
+
+	MMINLINE void* getAllocationContextForAddress(const void *address, uintptr_t index)
+	{
+		uintptr_t offset = getAllocationContextIndexForAddress(address);
+		return _allocationContextArray[offset + index];
+	}
+
+	MMINLINE void setAllocationContextForAddress(const void *address, void *allocationContext, uintptr_t index)
+	{
+		uintptr_t offset = getAllocationContextIndexForAddress(address);
+		_allocationContextArray[offset + index] = allocationContext;
+	}
+
+	MMINLINE void resetAllocationContextForAddress(const void *address, uintptr_t size)
+	{
+		uintptr_t offset = getAllocationContextIndexForAddress(address);
+		uintptr_t count = getAllocationContextCount(size);
+		for (uintptr_t index = 0; index < count; index++) {
+			_allocationContextArray[offset + index] = 0;
+		}
 	}
 };
 


### PR DESCRIPTION
new variable _sharedReserved in AllocateDescriptor to indicate that this allocation is related with shared reserved region.

new _allocationContextArray in SparseVirtualMemory and related methods to keep/retrieve the allocation context of off-heap related reserved heap regions.