### PR TITLE
Introduce OMR_FINAL attribute for extensible classes

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -295,16 +295,16 @@ public:
 
     TR_StackMemory trStackMemory();
 
-    TR_Memory *trMemory() { return _trMemory; }
+    OMR_FINAL TR_Memory *trMemory() { return _trMemory; }
 
-    TR_HeapMemory trHeapMemory() { return _trMemory; }
+    OMR_FINAL TR_HeapMemory trHeapMemory() { return _trMemory; }
 
-    TR::Machine *machine() { return _machine; }
+    OMR_FINAL TR::Machine *machine() { return _machine; }
 
-    TR::Compilation *comp() { return _compilation; }
+    OMR_FINAL TR::Compilation *comp() { return _compilation; }
 
-    TR_FrontEnd *fe();
-    TR_Debug *getDebug();
+    OMR_FINAL TR_FrontEnd *fe();
+    OMR_FINAL TR_Debug *getDebug();
 
     void uncommonCallConstNodes();
 

--- a/compiler/codegen/OMRInstruction.hpp
+++ b/compiler/codegen/OMRInstruction.hpp
@@ -227,7 +227,7 @@ public:
      * Cached code generator object.
      * OMRTODO: should be retrievable from TLS.
      */
-    TR::CodeGenerator *cg() { return _cg; }
+    OMR_FINAL TR::CodeGenerator *cg() { return _cg; }
 
     bool needsGCMap() { return (_index & TO_MASK(NeedsGCMapBit)) != 0; }
 

--- a/compiler/codegen/OMRLinkage.hpp
+++ b/compiler/codegen/OMRLinkage.hpp
@@ -70,37 +70,37 @@ public:
     /**
      * @return Cached CodeGenerator object
      */
-    inline TR::CodeGenerator *cg();
+    OMR_FINAL inline TR::CodeGenerator *cg();
 
     /**
      * @return Machine object from cached CodeGenerator
      */
-    inline TR::Machine *machine();
+    OMR_FINAL inline TR::Machine *machine();
 
     /**
      * @return Compilation object from cached CodeGenerator
      */
-    inline TR::Compilation *comp();
+    OMR_FINAL inline TR::Compilation *comp();
 
     /**
      * @return FrontEnd object from cached CodeGenerator
      */
-    inline TR_FrontEnd *fe();
+    OMR_FINAL inline TR_FrontEnd *fe();
 
     /**
      * @return TR_Memory object from cached CodeGenerator
      */
-    inline TR_Memory *trMemory();
+    OMR_FINAL inline TR_Memory *trMemory();
 
     /**
      * @return TR_HeapMemory object
      */
-    inline TR_HeapMemory trHeapMemory();
+    OMR_FINAL inline TR_HeapMemory trHeapMemory();
 
     /**
      * @return TR_StackMemory object
      */
-    inline TR_StackMemory trStackMemory();
+    OMR_FINAL inline TR_StackMemory trStackMemory();
 
     TR_ALLOC(TR_Memory::Linkage)
 

--- a/compiler/codegen/OMRMachine.hpp
+++ b/compiler/codegen/OMRMachine.hpp
@@ -70,12 +70,12 @@ public:
      * @param[in] regNum : register number
      * @return RealRegister for specified register number
      */
-    TR::RealRegister *getRealRegister(TR::RealRegister::RegNum regNum) { return _registerFile[regNum]; }
+    OMR_FINAL TR::RealRegister *getRealRegister(TR::RealRegister::RegNum regNum) { return _registerFile[regNum]; }
 
     /**
      * \return : the cached TR::CodeGenerator object
      */
-    TR::CodeGenerator *cg() { return _cg; }
+    OMR_FINAL TR::CodeGenerator *cg() { return _cg; }
 
     /** \brief
      *     Sets the number of locked registers of a specific register kind for use as a cache lookup.
@@ -138,7 +138,7 @@ public:
     /**
      * \brief Retrieve a pointer to the register file
      */
-    TR::RealRegister **registerFile() { return _registerFile; }
+    OMR_FINAL TR::RealRegister **registerFile() { return _registerFile; }
 
     /**
      * \brief Retrieves the TR::RealRegister object for the given real register
@@ -147,7 +147,7 @@ public:
      *
      * \return : the desired TR::RealRegister object
      */
-    TR::RealRegister *realRegister(TR::RealRegister::RegNum rn) { return _registerFile[rn]; }
+    OMR_FINAL TR::RealRegister *realRegister(TR::RealRegister::RegNum rn) { return _registerFile[rn]; }
 
 private:
     TR::CodeGenerator *_cg;

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -298,25 +298,25 @@ public:
 
     ~Compilation() throw();
 
-    TR::Region &region() { return _heapMemoryRegion; }
+    OMR_FINAL TR::Region &region() { return _heapMemoryRegion; }
 
     TR::IL il;
 
-    TR::IlGenRequest &ilGenRequest() { return _ilGenRequest; }
+    OMR_FINAL TR::IlGenRequest &ilGenRequest() { return _ilGenRequest; }
 
-    TR::CodeGenerator *cg() { return _codeGenerator; }
+    OMR_FINAL TR::CodeGenerator *cg() { return _codeGenerator; }
 
-    TR_FrontEnd *fe() { return _fe; }
+    OMR_FINAL TR_FrontEnd *fe() { return _fe; }
 
-    TR::Options *getOptions() { return _options; }
+    OMR_FINAL TR::Options *getOptions() { return _options; }
 
-    TR_Memory *trMemory() { return _trMemory; }
+    OMR_FINAL TR_Memory *trMemory() { return _trMemory; }
 
-    TR_StackMemory trStackMemory() { return _trMemory; }
+    OMR_FINAL TR_StackMemory trStackMemory() { return _trMemory; }
 
-    TR_HeapMemory trHeapMemory() { return _trMemory; }
+    OMR_FINAL TR_HeapMemory trHeapMemory() { return _trMemory; }
 
-    TR_PersistentMemory *trPersistentMemory() { return _trMemory->trPersistentMemory(); }
+    OMR_FINAL TR_PersistentMemory *trPersistentMemory() { return _trMemory->trPersistentMemory(); }
 
     bool getOption(TR_CompilationOptions o) { return _options->getOption(o); }
 

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -67,15 +67,15 @@ public:
 
     TR_ALLOC(TR_Memory::SymbolReferenceTable)
 
-    TR::Compilation *comp() { return _compilation; }
+    OMR_FINAL TR::Compilation *comp() { return _compilation; }
 
-    TR_FrontEnd *fe() { return _fe; }
+    OMR_FINAL TR_FrontEnd *fe() { return _fe; }
 
-    TR_Memory *trMemory() { return _trMemory; }
+    OMR_FINAL TR_Memory *trMemory() { return _trMemory; }
 
-    TR_StackMemory trStackMemory() { return _trMemory; }
+    OMR_FINAL TR_StackMemory trStackMemory() { return _trMemory; }
 
-    TR_HeapMemory trHeapMemory() { return _trMemory; }
+    OMR_FINAL TR_HeapMemory trHeapMemory() { return _trMemory; }
 
     TR_Array<TR::SymbolReference *> baseArray;
 

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -262,9 +262,9 @@ public:
      * Field functions
      */
 
-    TR::TreeTop *getEntry() { return _pEntry; }
+    OMR_FINAL TR::TreeTop *getEntry() { return _pEntry; }
 
-    TR::TreeTop *setEntry(TR::TreeTop *p)
+    OMR_FINAL TR::TreeTop *setEntry(TR::TreeTop *p)
     {
         if (TR::comp()->getOptimizer() && !TR::comp()->isPeekingMethod()) {
             TR::comp()->getOptimizer()->setCachedExtendedBBInfoValid(false);
@@ -272,9 +272,9 @@ public:
         return (_pEntry = p);
     }
 
-    TR::TreeTop *getExit() { return _pExit; }
+    OMR_FINAL TR::TreeTop *getExit() { return _pExit; }
 
-    TR::TreeTop *setExit(TR::TreeTop *p)
+    OMR_FINAL TR::TreeTop *setExit(TR::TreeTop *p)
     {
         if (TR::comp()->getOptimizer() && !TR::comp()->isPeekingMethod()) {
             TR::comp()->getOptimizer()->setCachedExtendedBBInfoValid(false);
@@ -282,19 +282,19 @@ public:
         return (_pExit = p);
     }
 
-    TR_BitVector *getLiveLocals() { return _liveLocals; }
+    OMR_FINAL TR_BitVector *getLiveLocals() { return _liveLocals; }
 
-    TR_BitVector *setLiveLocals(TR_BitVector *v) { return (_liveLocals = v); }
+    OMR_FINAL TR_BitVector *setLiveLocals(TR_BitVector *v) { return (_liveLocals = v); }
 
-    TR_BlockStructure *getStructureOf() { return _pStructureOf; }
+    OMR_FINAL TR_BlockStructure *getStructureOf() { return _pStructureOf; }
 
-    TR_BlockStructure *setStructureOf(TR_BlockStructure *p) { return (_pStructureOf = p); }
+    OMR_FINAL TR_BlockStructure *setStructureOf(TR_BlockStructure *p) { return (_pStructureOf = p); }
 
     int32_t getNestingDepth();
 
     TR_Array<TR::GlobalRegister> &getGlobalRegisters(TR::Compilation *);
 
-    void clearGlobalRegisters() { _globalRegisters = NULL; }
+    OMR_FINAL void clearGlobalRegisters() { _globalRegisters = NULL; }
 
     struct InstructionBoundaries : TR_Link<InstructionBoundaries> {
         InstructionBoundaries(uint32_t s = UINT_MAX, uint32_t e = UINT_MAX)
@@ -308,19 +308,19 @@ public:
 
     void setInstructionBoundaries(uint32_t startPC, uint32_t endPC);
 
-    InstructionBoundaries &getInstructionBoundaries() { return _instructionBoundaries; }
+    OMR_FINAL InstructionBoundaries &getInstructionBoundaries() { return _instructionBoundaries; }
 
     void addExceptionRangeForSnippet(uint32_t startPC, uint32_t endPC);
 
-    InstructionBoundaries *getFirstSnippetBoundaries() { return _snippetBoundaries.getFirst(); }
+    OMR_FINAL InstructionBoundaries *getFirstSnippetBoundaries() { return _snippetBoundaries.getFirst(); }
 
-    TR::Instruction *getFirstInstruction() { return _firstInstruction; }
+    OMR_FINAL TR::Instruction *getFirstInstruction() { return _firstInstruction; }
 
-    TR::Instruction *setFirstInstruction(TR::Instruction *i) { return (_firstInstruction = i); }
+    OMR_FINAL TR::Instruction *setFirstInstruction(TR::Instruction *i) { return (_firstInstruction = i); }
 
-    TR::Instruction *getLastInstruction() { return _lastInstruction; }
+    OMR_FINAL TR::Instruction *getLastInstruction() { return _lastInstruction; }
 
-    TR::Instruction *setLastInstruction(TR::Instruction *i) { return (_lastInstruction = i); }
+    OMR_FINAL TR::Instruction *setLastInstruction(TR::Instruction *i) { return (_lastInstruction = i); }
 
     class TR_CatchBlockExtension {
     public:

--- a/compiler/infra/Annotations.hpp
+++ b/compiler/infra/Annotations.hpp
@@ -41,24 +41,19 @@
  *
  * or inside a branching expression:
  *
- *     if(OMR_LIKELY(isTrue()))
- *
- * \def OMR_NORETURN   Marks a function as non-returning for the purposes of
- * code generation and optimization.
- *
- * \def OMR_EXTENSIBLE Marks a class as an 'Extensible' class.
- *
- * \def OMR_LIKELY     Marks a branch as being more likely.
- *
- * \def OMR_UNLIKELY   Marks a branch as being less likely.
+ *     if (OMR_LIKELY(isTrue()))
  *
  * \todo Provide OMR_RETURNS_NONNULL annotation
  * \todo Provide OMR_DEPRECATED      annotation
- * \todo Provide OMR_MALLOC          annotation.
+ * \todo Provide OMR_MALLOC          annotation
  *
  */
 
 // OMR_NORETURN
+//
+// Marks a function as non-returning for the purposes of code generation and
+// optimization
+//
 #if defined(_MSC_VER)
 #define OMR_NORETURN _declspec(noreturn)
 #elif defined(__GNUC__)
@@ -71,15 +66,34 @@
 #endif
 
 // OMR_EXTENSIBLE
+//
+// Used on a class definition to indicate that the class is extensible
+//
 #if defined(__clang__) // Only clang is checking this macro for now
 #define OMR_EXTENSIBLE __attribute__((annotate("OMR_Extensible")))
 #else
 #define OMR_EXTENSIBLE
 #endif
 
+// OMR_FINAL
+//
+// Used on a member function declaration in an extensible class to
+// indicate the function will not be overridden in a subclass
+//
+#if defined(__clang__) // Only clang is checking this macro for now
+#define OMR_FINAL __attribute__((annotate("OMR_FINAL")))
+#else
+#define OMR_FINAL
+#endif
+
 // OMR_LIKELY and OMR_UNLIKELY
+//
+// OMR_LIKELY     Marks a branch as being more likely
+// OMR_UNLIKELY   Marks a branch as being less likely
+//
 // TODO: check if the definition of these macros is too broad,
 //       __builtin_expect() may not have any effect on xlC
+//
 #if defined(TR_HOST_X86) && defined(OMR_OS_WINDOWS)
 #define OMR_LIKELY(expr) (expr)
 #define OMR_UNLIKELY(expr) (expr)

--- a/doc/compiler/extensible_classes/Extensible_Classes.md
+++ b/doc/compiler/extensible_classes/Extensible_Classes.md
@@ -120,11 +120,23 @@ It simply performs a `static_cast` of the `this` pointer to a pointer to the
 most derived type (which we forward declared) and returns the result. All calls
 to member functions from within an extensible class must be prefixed with
 `self()->`. Using the implicit `this` pointer **must be avoided** as it
-circumvents the down cast
-and can lead to strange and unpredictable behaviour.
+circumvents the downcast and can lead to strange and unpredictable behaviour.
 
-> To enforce this rule, we use a clang-based linter, `OMRChecker`, that uses a
-class annotation to verify that extensible classes are implemented correctly.
+Declarations of member functions in extensible classes can be decorated with
+`OMR_FINAL` to indicate that this implementation will not be overridden by a
+subclass. This is useful for functions such as getters and setters that are
+highly unlikely to be needed to be extended by a consuming project. The real
+benefit of this is to avoid the use of `self()` when invoking these functions
+as there is only one implementation. This improves the esthetics of the code
+and its readability. For example,
+```
+    OMR_FINAL TR::Compilation *comp() { return _comp; }
+```
+On certain build compilers (e.g., Clang), `OMR_FINAL` expands to a compiler
+annotation and is available to tools built on that compiler technology.
+
+The correct use of `self()` with extensible classes is enforced with a
+Clang-based linter (called `OMRChecker`).
 
 ### Naming and Namespaces
 


### PR DESCRIPTION
This PR introduces an `OMR_FINAL` attribute that can be used in the compiler component to decorate member functions in C++ extensible classes to indicate they will not be overridden by a subclass. This attribute is not enforced by the compiler at build time and serves primarily as documentation. However, its intended semantics in the code can be verified using third-party linting tools, such as those built with Clang.

The introduction of this attribute is motivated by the desire to improve code readability by eliminating the requirement for `self()` calls when dispatching trivial member functions (such as getters and setters) in extensible classes.

This PR includes a commit that demonstrates how and where `OMR_FINAL` can be used in a number of extensible classes. This is not an exhaustive application of `OMR_FINAL`, only a demonstrative set. Eliminating the unnecessary `self()` calls will occur in future PRs in OMR and downstream projects.

An alternative approach to achieve the same result is to introduce an attribute to decorate the member functions that could be extended by sub-classes in an extensible class hierarchy. This is more in line with the way C++ allows methods to be extended via virtual functions and dynamic polymorphism. However, taking such an approach would require scrutiny of every member function in an extensible class to determine which are acceptable extension points and which are not. This is a far larger undertaking than is necessary to achieve the end goal (more readable code). In addition, the number of `OMR_FINAL` functions is expected to be much less than the number of extension points allowed.
