### PR TITLE
WIP:SRDA encoding fix for z/OS

### DIFF
--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -2196,7 +2196,9 @@ uint8_t *TR::S390RSInstruction::generateBinaryEncoding()
         || op == TR::InstOpCode::MVCLU || op == TR::InstOpCode::CLCLE || op == TR::InstOpCode::CLCLU) {
         toRealRegister(getSecondRegister()->getHighOrder())->setRegister2Field((uint32_t *)cursor);
     } else if (getLastRegister()) {
-        toRealRegister(getLastRegister())->setRegister2Field((uint32_t *)cursor);
+        if (op != TR::InstOpCode::SRDA ) {
+            toRealRegister(getLastRegister())->setRegister2Field((uint32_t *)cursor);
+        }
     }
 
     instructionStart = cursor;


### PR DESCRIPTION
Before this fix the r+1 register was getting encoded by https://github.com/eclipse-omr/omr/blob/master/compiler/z/codegen/S390Instruction.cpp#L2144 as shown below, even though it is not actually a register SRDA instruction. For now this register encoding is ignored by hardware but it can cause an invalid instruction issue in future.
<img width="2190" height="252" alt="image" src="https://github.com/user-attachments/assets/802f2773-a5ac-4ea1-9220-41dea9c18852" />
In this modification the encoding of r+1 register is skipped if the instruction is SRDA, r+1 register will be 0.