### PR TITLE
Allow pre-eval escaping conversion nodes of evaluated array-access

### DIFF
--- a/compiler/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/codegen/OMRTreeEvaluator.cpp
@@ -616,11 +616,12 @@ void OMR::TreeEvaluator::evaluateNodesWithFutureUses(TR::Node *node, TR::CodeGen
 
         if (actualLoadOrStoreChild->getOpCode().isStore() || actualLoadOrStoreChild->getOpCode().isLoadConst()
             || actualLoadOrStoreChild->getOpCode().isArrayRef()
-            || (actualLoadOrStoreChild->getOpCode().isLoad() && actualLoadOrStoreChild->getSymbolReference()
+            || (actualLoadOrStoreChild->getOpCode().isLoad() && !actualLoadOrStoreChild->getRegister()
+                && actualLoadOrStoreChild->getSymbolReference()
                 && (actualLoadOrStoreChild->getSymbolReference()->getSymbol()->isArrayShadowSymbol()
                     || actualLoadOrStoreChild->getSymbolReference()->getSymbol()->isArrayletShadowSymbol()))) {
             // These types of nodes are likey specific to one path or another and may cause
-            // a failure if evaluated on a common path.
+            // a failure if evaluated on a common path. Except array accesses if already evaluated.
             //
             if (comp->getOption(TR_TraceCG)) {
                 traceMsg(comp,


### PR DESCRIPTION
`preEvaluateEscapingNodesForSpineCheck` gets called to pre-evaluate a future used commoned node before branching out of mainline code. It restricts pre-evaluating conversions with array-access children for correctness of access. But if array-access is already evaluated this restriction is non-beneficial and might prevent a needed pre-evaluation into the mainline code for a future used commoned node.

For example, in a tree like below, the restriction does not allow early evaluation of the `n764n aloadi` as expected, but should allow early evaluating `n769n i2l` given that the array access child `n779n iloadi` is already evaluated.

```
n763n    (  0)  BNDCHKwithSpineCHK [#1] (Unsigned spineCHKWithArrayElementChild )                    [0xa0001005009de30] bci=[-1,37,2119] rc=0 vc=3348 vn=- li=65 udi=- nc=4 flg=0x4028
 n764n    (  2)    aloadi  <array-shadow>[#251  Shadow] [flags 0x80000607 0x0 ] ()                    [0xa0001005009de80] bci=[-1,37,2119] rc=2 vc=3348 vn=- li=65 udi=- nc=1 flg=0x8
 n765n    (  1)      aladd (X>=0 internalPtr )                                                        [0xa0001005009ded0] bci=[-1,37,2119] rc=1 vc=3348 vn=- li=65 udi=- nc=2 flg=0x8100
 n990n    (  7)        ==>aRegLoad (in &GPR_0340) (X!=0 SeenRealReference )
 n767n    (  1)        lsub (X>=0 cannotOverflow )                                                    [0xa0001005009df70] bci=[-1,37,2119] rc=1 vc=3348 vn=- li=65 udi=- nc=2 flg=0x1100
 n768n    (  1)          lshl (X>=0 )                                                                 [0xa0001005009dfc0] bci=[-1,37,2119] rc=1 vc=3348 vn=- li=65 udi=- nc=2 flg=0x100
 n769n    (  2)            i2l (highWordZero X>=0 )                                                   [0xa0001005009e010] bci=[-1,37,2119] rc=2 vc=3348 vn=- li=65 udi=- nc=1 flg=0x4100
 n779n    (  4)              ==>iloadi (in GPR_0353) (X>=0 cannotOverflow )  // [0x0A0001005009E330]
 n1219n   (  1)            iconst 3 (X!=0 X>=0 )                                                      [0xa00010050486cc0] bci=[-1,37,2119] rc=1 vc=3348 vn=- li=65 udi=- nc=0 flg=0x104
 n616n    (  5)          ==>lconst -24 (X!=0 X<=0 )
 n990n    (  7)    ==>aRegLoad (in &GPR_0340) (X!=0 SeenRealReference )
 n989n    (  4)    ==>iRegLoad (in GPR_0339) (X>=0 cannotOverflow SeenRealReference )
 n779n    (  4)    ==>iloadi (in GPR_0353) (X>=0 cannotOverflow )
------------------------------
avoiding escaping commoned subtree 0A0001005009DE80 [RealLoad/Store: 0A0001005009DE80], but processing its children: node is array shadow
avoiding escaping commoned subtree 0A0001005009E010 [RealLoad/Store: 0A0001005009E330], but processing its children: node is array shadow
```

Issue: https://github.com/eclipse-openj9/openj9/issues/22656