### PR TITLE
Z: Enable msplats opcode

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4404,6 +4404,7 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::ILOpC
         case TR::vstorei:
         case TR::vneg:
         case TR::vsplats:
+        case TR::msplats:
         case TR::vabs:
             return true;
         case TR::vmul:

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -1072,7 +1072,7 @@ TR::Register *OMR::Z::TreeEvaluator::mstoreiEvaluator(TR::Node *node, TR::CodeGe
 
 TR::Register *OMR::Z::TreeEvaluator::msplatsEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+    return TR::TreeEvaluator::vsplatsEvaluator(node, cg);
 }
 
 TR::Register *OMR::Z::TreeEvaluator::mTrueCountEvaluator(TR::Node *node, TR::CodeGenerator *cg)


### PR DESCRIPTION
Enable vsplats opcode on IBM Z platform.
vsplats has the required instructions to satisfy msplats opcode. Redirect msplats evaluation request to vsplats evaluator.

signed-off-by Ehsan Kiani Far <ehsan.kianifar@gmail.com>