### PR TITLE
Invalidate alias sets upon refinement of unsafe shadows during VP

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -736,6 +736,11 @@ static bool refineUnsafeAccess(OMR::ValuePropagation *vp, TR::Node *node)
             return refuseToConstrainUnsafe(vp, node, "performTransformation denied");
 
         node->setSymbolReference(arrayShadow);
+
+        // With the array-shadow symref replacing the unsafe shadow symref, the existing alias sets may no
+        // longer be valid. We need to mark the current alias sets as invalid to trigger a recomputation of the
+        // alias sets the next time they are needed.
+        vp->optimizer()->setAliasSetsAreValid(false);
         return okToConstrainNormally;
     }
 


### PR DESCRIPTION
With the array-shadow symref replacing the unsafe shadow symref, the existing alias sets may no longer be valid. This fixes a problem observed during DeadTreesElimination where the incorrect alias sets resulted in an invalid transformation.