### PR TITLE
Handle mask types as vector types in Global Register Assigner

### DIFF
--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -1034,7 +1034,7 @@ TR_GlobalRegisterNumber OMR::CodeGenerator::pickRegister(TR::RegisterCandidate *
 
         const bool usesFPR = (dtype == TR::Float || dtype == TR::Double);
 
-        const bool usesVRF = dtype.isVector();
+        const bool usesVRF = dtype.isVector() || dtype.isMask();
 
         if (self()->terseSimulateTreeEvaluation()) {
             traceMsg(self()->comp(), "         { Picking register for %s%s candidate #%d %s\n",

--- a/compiler/optimizer/OMRRegisterCandidate.cpp
+++ b/compiler/optimizer/OMRRegisterCandidate.cpp
@@ -193,7 +193,7 @@ TR_RegisterKinds OMR::RegisterCandidate::getRegisterKinds()
     TR::DataType dt = getDataType();
     if (dt == TR::Float || dt == TR::Double)
         return TR_FPR;
-    else if (dt.isVector())
+    else if (dt.isVector() || dt.isMask())
         return TR_VRF;
     else
         return TR_GPR;
@@ -2114,7 +2114,7 @@ bool OMR::RegisterCandidates::assign(TR::Block **cfgBlocks, int32_t numberOfBloc
                 : "",
             rc->getWeight());
         bool isFloat = (rc->getDataType() == TR::Float || rc->getDataType() == TR::Double);
-        bool isVector = rc->getDataType().isVector();
+        bool isVector = rc->getDataType().isVector() || rc->getDataType().isMask();
         bool needs2Regs = false;
 
         if (rc->rcNeeds2Regs(comp()))
@@ -2316,10 +2316,10 @@ bool OMR::RegisterCandidates::assign(TR::Block **cfgBlocks, int32_t numberOfBloc
             continue;
         }
 
-        if (dt.isVector() && !comp()->cg()->hasGlobalVRF()) {
+        if ((dt.isVector() || dt.isMask()) && !comp()->cg()->hasGlobalVRF()) {
             if (trace)
-                traceMsg(comp(),
-                    "Leaving candidate because it has vector type but no global vector registers provided\n");
+                traceMsg(comp(), "Leaving candidate because it has %s type but no global vector registers provided\n",
+                    TR::DataType::getName(dt));
             TR_ASSERT(!comp()->target().cpu.isZ(), "ed : debug : Should never get here for vector GRA on z");
             continue;
         }
@@ -2358,7 +2358,7 @@ bool OMR::RegisterCandidates::assign(TR::Block **cfgBlocks, int32_t numberOfBloc
         }
 
         bool isFloat = (dt == TR::Float || dt == TR::Double);
-        bool isVector = dt.isVector();
+        bool isVector = dt.isVector() || dt.isMask();
         int32_t firstRegister, lastRegister;
 
         if (isFloat) {


### PR DESCRIPTION
In the OMR type system, both mask and vector types are intended to use vector registers. However, the Global Register Assigner was not treating mask types as vector types, resulting in incorrect register assignments—specifically, assigning General Purpose Registers (GPRs) instead of vector registers. This misclassification led to invalid instruction generation and test failures during compilation. The issue was observed on the IBM Z platform but is not specific to it. Resolve the problem by updating the register assigner logic to treat mask types equivalently to vector types, ensuring correct register allocation and instruction selection across platforms.

Fixes: #7993