### PR TITLE
Z: Add mask support in inlineVectorBinaryOp() and enable mask opcodes

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4422,6 +4422,9 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::ILOpC
         case TR::vxor:
         case TR::vor:
         case TR::vand:
+        case TR::vmxor:
+        case TR::vmor:
+        case TR::vmand:
         case TR::vnotz:
         case TR::vnolz:
             if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64)
@@ -4436,6 +4439,8 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::ILOpC
                 return false;
         case TR::vmax:
         case TR::vmin:
+        case TR::vmmax:
+        case TR::vmmin:
             if ((et == TR::Float || et == TR::Double)
                 && !cpu->supportsFeature(OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_1))
                 return false;


### PR DESCRIPTION
Mask binary operations return the result of the operation in each lane if the mask is true for that lane; otherwise, the result mirrors the first child operand.
Add support for mask types in inlineVectorUnaryOp() function and enables the following mask binary opcodes on the IBM Z platform: mor, mand, mxor, mmin, and mmax.