### PR TITLE
Z: Implement vreductionand, vreductionor, and vreductionxor

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4424,6 +4424,9 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::ILOpC
         case TR::vand:
         case TR::vnotz:
         case TR::vnolz:
+        case TR::vreductionAnd:
+        case TR::vreductionOr:
+        case TR::vreductionXor:
             if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64)
                 return true;
             else


### PR DESCRIPTION
This commit adds support for the vreductionand, vreductionor, and vreductionxor opcodes on the IBM Z platform. These opcodes perform bitwise reduction across all lanes of a vector, producing a scalar result.