### PR TITLE
Fix operand order in `vsetelem` constant index path on IBM P platform

### DIFF
--- a/compiler/il/VectorOperations.enum
+++ b/compiler/il/VectorOperations.enum
@@ -965,12 +965,14 @@ VECTOR_OPERATION_MACRO(\
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
    /* .typeProperties          = */ ILTypeProp::VectorResult, \
-   /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .childProperties         = */ THREE_CHILD(ILChildProp::UnspecifiedChildType, ILChildProp::UnspecifiedChildType, ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
    /* .booleanCompareOpCode    = */ TR::BadILOp, \
    /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    vector set element */ \
+   /* .description             =    vector set element \
+                                    Set the element in the first child vector, at the index specified by the second \
+                                    child, to the value of the third child. */
 )
 VECTOR_OPERATION_MACRO(\
    /* .operation               = */ vsplats, \


### PR DESCRIPTION
The `vsetelem` opcode expects the first child to be the target vector, the second child to be the index, and the third child to be the value. In the `vdsetelemHelper()` function, the code path handling constant index values on IBM P platform mistakenly swapped the index and value children.
Correct the operand order in that path. Clarify the child roles by using descriptive names in helper functions and expanded the opcode documentation to make the expected behavior explicit.