### PR TITLE
Fix register type handling for mask results on IBM Z platform

### DIFF
--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -431,6 +431,11 @@ public:
 
     bool isMaskResult() const { return typeProperties().testAny(ILTypeProp::MaskResult); }
 
+    bool isVectorOrMaskResult() const
+    {
+        return typeProperties().testAny(ILTypeProp::VectorResult | ILTypeProp::MaskResult);
+    }
+
     bool isVectorElementResult() const { return typeProperties().testAny(ILTypeProp::VectorElementResult); }
 
     bool isIntegerOrAddress() const { return typeProperties().testAny(ILTypeProp::Integer | ILTypeProp::Address); }

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -2478,7 +2478,7 @@ TR::Register *OMR::Z::CodeGenerator::gprClobberEvaluate(TR::Node *node, bool for
             }
 
             return targetRegister;
-        } else if (node->getOpCode().isVectorResult()) {
+        } else if (node->getOpCode().isVectorOrMaskResult()) {
             TR::Register *targetRegister = self()->allocateClobberableRegister(srcRegister);
             generateVRRaInstruction(self(), TR::InstOpCode::VLR, node, targetRegister, srcRegister);
             return targetRegister;

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -13943,7 +13943,7 @@ TR::Register *OMR::Z::TreeEvaluator::tryToReuseInputVectorRegs(TR::Node *node, T
 
     for (int32_t i = 0; i < numChildren; i++) {
         TR::Node *child = node->getChild(i);
-        if (child->getOpCode().isVectorResult() && child->getReferenceCount() <= 1) {
+        if (child->getOpCode().isVectorOrMaskResult() && child->getReferenceCount() <= 1) {
             returnReg = cg->gprClobberEvaluate(child);
             break;
         }


### PR DESCRIPTION
Previously, many code paths relied on `isVectorResult()` to determine whether a result should use a vector register. This method only returns true for vector result types, causing incorrect handling when the result type was a mask. Mask types also require vector registers, but were not accounted for in these checks.
To address this, introduced a new method `isVectorOrMaskResult()` that returns true for both vector and mask result types. Updated all relevant locations where register type decisions depend on these checks to use the new method.