### PR TITLE
Z: implement mloadiFromArray/mstoreiToArray opcodes

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4434,6 +4434,8 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::ILOpC
         case TR::s2m:
         case TR::i2m:
         case TR::l2m:
+        case TR::mstoreiToArray:
+        case TR::mloadiFromArray:
             return true;
         default:
             return false;


### PR DESCRIPTION
Add backend support on IBM Z for the mloadiFromArray and mstoreiToArray opcodes used by the Vector API.