### PR TITLE
Z: Fix feature detection for mask results by checking source type

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4414,16 +4414,19 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::ILOpC
             return (et == TR::Double && opcode.getVectorSourceDataType().getVectorElementType() == TR::Int64);
         case TR::vcast:
             return true;
-        case TR::mmAnyTrue:
-        case TR::mmAllTrue:
-        case TR::mAnyTrue:
-        case TR::mAllTrue:
         case TR::vcmpeq:
         case TR::vcmpne:
         case TR::vcmplt:
         case TR::vcmple:
         case TR::vcmpgt:
         case TR::vcmpge:
+            // Since these opcodes return a mask, verify the source type and CPU feature support.
+            return (opcode.getVectorSourceDataType().getVectorElementType() != TR::Float)
+                || cpu->supportsFeature(OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_1);
+        case TR::mmAnyTrue:
+        case TR::mmAllTrue:
+        case TR::mAnyTrue:
+        case TR::mAllTrue:
         case TR::m2v:
         case TR::m2l:
         case TR::m2i:

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -14006,14 +14006,14 @@ TR::Register *OMR::Z::TreeEvaluator::inlineVectorBinaryOp(TR::Node *node, TR::Co
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
+    TR::Node *firstChild = node->getFirstChild();
     // Before z14, vector instructions for floating point operations supported only long format (double) values.
     // Starting with z14, short format (float) values are also supported.
     TR_ASSERT_FATAL_WITH_NODE(node,
-        (node->getDataType().getVectorElementType() != TR::Float)
+        (firstChild->getDataType().getVectorElementType() != TR::Float)
             || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_1),
         "Unsupported float vector operation: short format floats require z14 or newer.");
 
-    TR::Node *firstChild = node->getFirstChild();
     TR::Node *secondChild = node->getSecondChild();
 
     TR::Register *targetReg = TR::TreeEvaluator::tryToReuseInputVectorRegs(node, cg);


### PR DESCRIPTION
Mask types in vector operations were changed to use int32 and int64 instead of float and double. This caused feature checks to fail when the result was a mask and the CPU lacked floating‑point vector support. @Spencer-Comin  discovered this issue during IBM Z test runs.
The solution is to check the source vector type when the result is a mask, ensuring feature requirements reflect operand semantics rather than mask representation. This restores correct gating for operations like vector compares that produce masks but depend on FP support in their inputs.
Tests were updated to cover CPUs with and without FP vector support, confirming previously failing cases now pass. Non‑mask operations and integer-only vectors remain unaffected.
@r30shah @gita-omr @hzongaro Please review this PR. This bug is causing failures in upstream tests on Z13. 