### PR TITLE
Z: Fix register copy instruction selection for FPR and VRF registers

### DIFF
--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -135,6 +135,9 @@ TR::Instruction *OMR::Z::Machine::registerCopy(TR::CodeGenerator *cg, TR_Registe
             break;
         }
         case TR_FPR:
+            TR_ASSERT_FATAL(TR_FPR == targetReg->getKind(),
+                "Invalid register copy: source and target register kinds differ. Source: %s, Target: %s.",
+                getDebug()->getRegisterKindName(rk), getDebug()->getRegisterKindName(targetReg->getKind()));
             cursor = generateRRInstruction(cg, TR::InstOpCode::LDR, node, targetReg, sourceReg, precedingInstruction);
             break;
         case TR_VRF:
@@ -2612,7 +2615,7 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
     TR::RealRegister *currentAssignedRegister = (realReg == NULL) ? NULL : toRealRegister(realReg);
     TR::RealRegister *spareReg = NULL;
     TR::Register *currentTargetVirtual = NULL;
-    TR_RegisterKinds rk = virtualRegister->getKind();
+    TR_RegisterKinds sourceRegisterKind = virtualRegister->getKind();
 
     TR::Instruction *cursor = NULL;
     TR::Node *currentNode = currentInstruction->getNode();
@@ -2623,14 +2626,13 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
 
     cg()->traceRegisterAssignment("COERCE %R into %R", virtualRegister, targetRegister);
 
-    if (rk != TR_FPR && rk != TR_VRF) {
+    if (sourceRegisterKind != TR_FPR && sourceRegisterKind != TR_VRF) {
         if (virtualRegister->is64BitReg()) {
             cg()->traceRegisterAssignment(" coerceRA: %R needs 64 bit reg ", virtualRegister);
         } else {
             cg()->traceRegisterAssignment(" coerceRA: %R needs 32 bit reg ", virtualRegister);
         }
     }
-
     // already assign with the one we want
     if (currentAssignedRegister == targetRegister) {
         // All is good, so do nothing except set all pointers
@@ -2660,7 +2662,8 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
         } else {
             // virtual register is currently assigned to a different register,
             // override it with the target reg
-            cursor = self()->registerCopy(cg(), rk, currentAssignedRegister, targetRegister, currentInstruction);
+            cursor = self()->registerCopy(cg(), sourceRegisterKind, currentAssignedRegister, targetRegister,
+                currentInstruction);
 
             currentAssignedRegister->setState(TR::RealRegister::Free);
             currentAssignedRegister->setAssignedRegister(NULL);
@@ -2673,7 +2676,9 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
         uint64_t regMask = 0xffffffff;
         if (currentTargetVirtual->isUsedInMemRef())
             regMask = ~TR::RealRegister::GPR0Mask;
-        spareReg = self()->findBestFreeRegister(currentInstruction, rk, currentTargetVirtual, regMask);
+        TR_RegisterKinds currentTargetRegKind = currentTargetVirtual->getKind();
+        spareReg
+            = self()->findBestFreeRegister(currentInstruction, currentTargetRegKind, currentTargetVirtual, regMask);
 
         cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
 
@@ -2683,8 +2688,7 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
             virtualRegister->block();
             currentTargetVirtual->block();
 
-            spareReg = self()->freeBestRegister(currentInstruction, currentTargetVirtual,
-                currentTargetVirtual->getKind(), true);
+            spareReg = self()->freeBestRegister(currentInstruction, currentTargetVirtual, currentTargetRegKind, true);
 
             virtualRegister->unblock();
             currentTargetVirtual->unblock();
@@ -2692,9 +2696,10 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
 
         // find a free register if the virtual register hasn't been assigned to any real register
         // or it is a FPR for later use
-        // virtual register is currently assigned to a different register,
+        // virtual register is currently assigned to a different register.
         if (currentAssignedRegister != NULL) {
-            if (!self()->isAssignable(currentTargetVirtual, currentAssignedRegister)) {
+            if (!self()->isAssignable(currentTargetVirtual, currentAssignedRegister)
+                || (currentTargetRegKind != sourceRegisterKind)) {
                 {
                     /**
                      * Register exchange API takes care of exchanging between registers.
@@ -2711,9 +2716,10 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
                     }
                     cg()->traceRegAssigned(currentTargetVirtual, spareReg);
 
-                    cursor = self()->registerCopy(cg(), rk, targetRegister, spareReg, currentInstruction);
-                    cursor
-                        = self()->registerCopy(cg(), rk, currentAssignedRegister, targetRegister, currentInstruction);
+                    cursor = self()->registerCopy(cg(), currentTargetRegKind, targetRegister, spareReg,
+                        currentInstruction);
+                    cursor = self()->registerCopy(cg(), sourceRegisterKind, currentAssignedRegister, targetRegister,
+                        currentInstruction);
 
                     spareReg->setState(TR::RealRegister::Assigned);
                     currentTargetVirtual->setAssignedRegister(spareReg);
@@ -2728,8 +2734,8 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
             } else {
                 cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
 
-                cursor = self()->registerExchange(cg(), rk, targetRegister, currentAssignedRegister, spareReg,
-                    currentInstruction);
+                cursor = self()->registerExchange(cg(), sourceRegisterKind, targetRegister, currentAssignedRegister,
+                    spareReg, currentInstruction);
 
                 currentAssignedRegister->setState(TR::RealRegister::Blocked);
                 currentAssignedRegister->setAssignedRegister(currentTargetVirtual);
@@ -2739,7 +2745,7 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
             cg()->traceRegAssigned(currentTargetVirtual, spareReg);
 
             // virtual register is not assigned yet, copy register
-            cursor = self()->registerCopy(cg(), rk, targetRegister, spareReg, currentInstruction);
+            cursor = self()->registerCopy(cg(), currentTargetRegKind, targetRegister, spareReg, currentInstruction);
 
             spareReg->setState(TR::RealRegister::Assigned);
             spareReg->setAssignedRegister(currentTargetVirtual);
@@ -2765,7 +2771,7 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
         currentTargetVirtual = targetRegister->getAssignedRegister();
         cg()->traceRegisterAssignment("target %R is assigned, assigned to %R", targetRegister, currentTargetVirtual);
 
-        if (rk != TR_FPR && rk != TR_VRF && currentTargetVirtual) {
+        if (sourceRegisterKind != TR_FPR && sourceRegisterKind != TR_VRF && currentTargetVirtual != NULL) {
             // this happens for OOL spill, simply return
             if (currentTargetVirtual == virtualRegister) {
                 virtualRegister->setAssignedRegister(targetRegister);
@@ -2777,7 +2783,9 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
         uint64_t regMask = 0xffffffff;
         if (currentTargetVirtual->isUsedInMemRef())
             regMask = ~TR::RealRegister::GPR0Mask;
-        spareReg = self()->findBestFreeRegister(currentInstruction, rk, currentTargetVirtual, regMask);
+        TR_RegisterKinds currentTargetRegKind = currentTargetVirtual->getKind();
+        spareReg
+            = self()->findBestFreeRegister(currentInstruction, currentTargetRegKind, currentTargetVirtual, regMask);
 
         cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
 
@@ -2791,7 +2799,8 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
             //  We may not be able to do an exchange as the target virtReg is not
             //  allowed to be assigned to the source's realReg (e.g. GPR0).
             if (!self()->isAssignable(currentTargetVirtual, currentAssignedRegister)
-                || (rk != TR_FPR && rk != TR_VRF)) {
+                || (sourceRegisterKind != TR_FPR && sourceRegisterKind != TR_VRF)
+                || (currentTargetRegKind != sourceRegisterKind)) {
                 // There is an alternative to blindly spilling because:
                 //   1. there was a FREE reg
                 //   2. freeBestReg found a better choice to be spilled
@@ -2802,11 +2811,11 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
                     virtualRegister->block();
                     if (virtualRegister->is64BitReg()) {
                         // TODO: Can we allow a null return here? Why are the two paths different?
-                        spareReg = self()->freeBestRegister(currentInstruction, currentTargetVirtual,
-                            currentTargetVirtual->getKind());
+                        spareReg
+                            = self()->freeBestRegister(currentInstruction, currentTargetVirtual, currentTargetRegKind);
                     } else {
                         spareReg = self()->freeBestRegister(currentInstruction, currentTargetVirtual,
-                            currentTargetVirtual->getKind(), true);
+                            currentTargetRegKind, true);
                     }
 
                     // For some reason (blocked/locked regs etc), we couldn't find a spare reg so spill the virtual in
@@ -2825,8 +2834,8 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
                 // to the spareReg, and move the source reg to the target.
                 if (targetRegister->getRegisterNumber() != spareReg->getRegisterNumber() && !doNotRegCopy) {
                     cg()->traceRegAssigned(currentTargetVirtual, spareReg);
-
-                    cursor = self()->registerCopy(cg(), rk, targetRegister, spareReg, currentInstruction);
+                    cursor = self()->registerCopy(cg(), currentTargetRegKind, targetRegister, spareReg,
+                        currentInstruction);
 
                     targetRegister->setState(TR::RealRegister::Unlatched);
                     targetRegister->setAssignedRegister(NULL);
@@ -2835,8 +2844,8 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
                     spareReg->setAssignedRegister(currentTargetVirtual);
                     currentTargetVirtual->setAssignedRegister(spareReg);
                 }
-
-                cursor = self()->registerCopy(cg(), rk, currentAssignedRegister, targetRegister, currentInstruction);
+                cursor = self()->registerCopy(cg(), sourceRegisterKind, currentAssignedRegister, targetRegister,
+                    currentInstruction);
                 currentAssignedRegister->setState(TR::RealRegister::Unlatched);
                 currentAssignedRegister->setAssignedRegister(NULL);
             } else {
@@ -2860,13 +2869,13 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
                     cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
                     cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
 
-                    cursor
-                        = self()->registerCopy(cg(), rk, currentAssignedRegister, targetRegister, currentInstruction);
+                    cursor = self()->registerCopy(cg(), sourceRegisterKind, currentAssignedRegister, targetRegister,
+                        currentInstruction);
                     currentAssignedRegister->setState(TR::RealRegister::Unlatched);
                     currentAssignedRegister->setAssignedRegister(NULL);
                 } else {
-                    cursor = self()->registerExchange(cg(), rk, targetRegister, currentAssignedRegister, spareReg,
-                        currentInstruction);
+                    cursor = self()->registerExchange(cg(), sourceRegisterKind, targetRegister, currentAssignedRegister,
+                        spareReg, currentInstruction);
                     currentAssignedRegister->setState(TR::RealRegister::Assigned);
                     currentAssignedRegister->setAssignedRegister(currentTargetVirtual);
                     currentTargetVirtual->setAssignedRegister(currentAssignedRegister);
@@ -2893,11 +2902,11 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
                     if (virtualRegister->is64BitReg()) {
                         // TODO: Can we allow a null return here? Why are the two paths different? There is a similar
                         // case above.
-                        spareReg = self()->freeBestRegister(currentInstruction, currentTargetVirtual,
-                            currentTargetVirtual->getKind());
+                        spareReg
+                            = self()->freeBestRegister(currentInstruction, currentTargetVirtual, currentTargetRegKind);
                     } else {
                         spareReg = self()->freeBestRegister(currentInstruction, currentTargetVirtual,
-                            currentTargetVirtual->getKind(), true);
+                            currentTargetRegKind, true);
                     }
 
                     // For some reason (blocked/locked regs etc), we couldn't find a spare reg so spill the virtual in
@@ -2917,11 +2926,12 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
                 if (targetRegister->getRegisterNumber() != spareReg->getRegisterNumber() && !doNotRegCopy) {
                     cg()->resetRegisterAssignmentFlag(TR_RegisterSpilled);
                     cg()->traceRegAssigned(currentTargetVirtual, spareReg);
-
-                    cursor = self()->registerCopy(cg(), rk, targetRegister, spareReg, currentInstruction);
+                    cursor = self()->registerCopy(cg(), currentTargetRegKind, targetRegister, spareReg,
+                        currentInstruction);
 
                     spareReg->setState(TR::RealRegister::Assigned);
                     spareReg->setAssignedRegister(currentTargetVirtual);
+                    currentTargetVirtual->setAssignedRegister(spareReg);
 
                     targetRegister->setState(TR::RealRegister::Unlatched);
                     targetRegister->setAssignedRegister(NULL);
@@ -2976,7 +2986,8 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
         } else {
             // virtual register is currently assigned to a different register,
             // override it with the target reg
-            cursor = self()->registerCopy(cg(), rk, currentAssignedRegister, targetRegister, currentInstruction);
+            cursor = self()->registerCopy(cg(), sourceRegisterKind, currentAssignedRegister, targetRegister,
+                currentInstruction);
 
             currentAssignedRegister->setState(TR::RealRegister::Free);
             currentAssignedRegister->setAssignedRegister(NULL);


### PR DESCRIPTION
On the IBM Z platform, FPR and half of VRF registers share overlapping storage. This overlap makes it possible that:
1- for a register copy operation to have different source and target register kinds.
2- incorrect target real register to be selected, for example, VRF (that does not overlap with any FPR) instead of FPR.
The solution is to select the target real register and the copy instruction based on the register kind of the target virtual register.
In the coerceRegisterAssignment path, the logic attempted to copy or exchange values without verifying that the source and target registers shared a compatible kind. Because overlapping registers may belong to different kinds, the swap logic could incorrectly move an VRF value into a FPR register.
Add proper register-kind checks and handles the platform-specific cases to avoid cross-kind exchanges.