### PR TITLE
Implement logical reduction opcodes on IBM Z platform

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4400,6 +4400,12 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::ILOpC
         case TR::vnolz:
         case TR::vmnotz:
         case TR::vmnolz:
+        case TR::vreductionAnd:
+        case TR::vmreductionAnd:
+        case TR::vreductionOr:
+        case TR::vmreductionOr:
+        case TR::vreductionXor:
+        case TR::vmreductionXor:
             if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64)
                 return true;
             else

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -1589,7 +1589,7 @@ TR::Register *OMR::Z::TreeEvaluator::vmreductionAddEvaluator(TR::Node *node, TR:
 
 TR::Register *OMR::Z::TreeEvaluator::vmreductionAndEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+    return TR::TreeEvaluator::vreductionAndEvaluator(node, cg);
 }
 
 TR::Register *OMR::Z::TreeEvaluator::vmreductionFirstNonZeroEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -1614,7 +1614,7 @@ TR::Register *OMR::Z::TreeEvaluator::vmreductionMulEvaluator(TR::Node *node, TR:
 
 TR::Register *OMR::Z::TreeEvaluator::vmreductionOrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+    return TR::TreeEvaluator::vreductionOrEvaluator(node, cg);
 }
 
 TR::Register *OMR::Z::TreeEvaluator::vmreductionOrUncheckedEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -1624,7 +1624,7 @@ TR::Register *OMR::Z::TreeEvaluator::vmreductionOrUncheckedEvaluator(TR::Node *n
 
 TR::Register *OMR::Z::TreeEvaluator::vmreductionXorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+    return TR::TreeEvaluator::vreductionXorEvaluator(node, cg);
 }
 
 TR::Register *OMR::Z::TreeEvaluator::vmsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -15095,6 +15095,28 @@ int32_t getVectorElementSize(TR::Node *node)
     }
 }
 
+int32_t getVectorElementLength(TR::Node *node)
+{
+    TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+        "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
+    switch (node->getDataType().getVectorElementType()) {
+        case TR::Int8:
+            return 8;
+        case TR::Int16:
+            return 16;
+        case TR::Int32:
+        case TR::Float:
+            return 32;
+        case TR::Int64:
+        case TR::Double:
+            return 64;
+        default:
+            TR_ASSERT(false, "Unknown vector node type %s for element size\n", node->getDataType().toString());
+            return 0;
+    }
+}
+
 int32_t getVectorElementSizeMask(TR::Node *node)
 {
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
@@ -15718,11 +15740,6 @@ TR::Register *OMR::Z::TreeEvaluator::vreductionAddEvaluator(TR::Node *node, TR::
     return resultReg;
 }
 
-TR::Register *OMR::Z::TreeEvaluator::vreductionAndEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-{
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
-}
-
 TR::Register *OMR::Z::TreeEvaluator::vreductionFirstNonZeroEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
     return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
@@ -15743,9 +15760,90 @@ TR::Register *OMR::Z::TreeEvaluator::vreductionMulEvaluator(TR::Node *node, TR::
     return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
 }
 
+/**
+ * \brief
+ * Performs a logical reduction across all vector lanes.
+ *
+ * \details
+ * Applies the specified logical operation horizontally across the lanes of a
+ * vector and returns the result in a GPR, sign‑extended to 64 bits. The
+ * operation may optionally be masked. When masking is enabled, lanes disabled
+ * by the mask must be set to either 0 or 1 before the reduction, as required by
+ * the reduction semantics. The setUnmaskedLanes argument determines whether
+ * those masked-out lanes are cleared or set.
+ *
+ * \param node
+ * The IL node for the logical reduction.
+ *
+ * \param cg
+ * The code generator.
+ *
+ * \param op
+ * The logical operation to apply (e.g., AND, OR, XOR).
+ *
+ * \param setUnmaskedLanes
+ * Indicates whether masked-out lanes should be set to 1 (true)
+ * or cleared to 0 (false) before the reduction.
+ *
+ * \return
+ * A GPR containing the sign-extended reduction result.
+ */
+static TR::Register *logicalReductionHelper(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
+    bool setUnmaskedLanes)
+{
+    TR::Node *firstChild = node->getFirstChild();
+    uint8_t elementSizeMask = getVectorElementSizeMask(firstChild);
+    bool isMasked = node->getOpCode().isVectorMasked();
+    TR::Register *sourceReg = isMasked ? cg->gprClobberEvaluate(firstChild) : cg->evaluate(firstChild);
+    if (isMasked) {
+        TR::Node *maskChild = node->getSecondChild();
+        TR::Register *maskReg = cg->evaluate(maskChild);
+        if (setUnmaskedLanes) {
+            // Set all bits of unmasked lanes to 1.
+            generateVRRcInstruction(cg, TR::InstOpCode::VOC, node, sourceReg, sourceReg, maskReg, 0, 0, 0);
+        } else {
+            // Zero all bits of unmasked lanes.
+            generateVRRcInstruction(cg, TR::InstOpCode::VN, node, sourceReg, sourceReg, maskReg, 0, 0, 0);
+        }
+        cg->decReferenceCount(maskChild);
+    }
+
+    TR::Register *scratchReg = cg->allocateRegister();
+    TR::Register *resultReg = cg->allocateRegister();
+    // Move the first half of the source to the result register and the second half to the scratch register;
+    generateVRScInstruction(cg, TR::InstOpCode::VLGV, node, resultReg, sourceReg, generateS390MemoryReference(0, cg),
+        3);
+    generateVRScInstruction(cg, TR::InstOpCode::VLGV, node, scratchReg, sourceReg, generateS390MemoryReference(1, cg),
+        3);
+    int laneLength = getVectorElementLength(firstChild);
+    for (int dataLength = 64; dataLength >= laneLength; dataLength /= 2) {
+        if (dataLength < 64) {
+            // Iteratively split the data in half, load the second half into the scratch register, and apply the
+            // operation with the first half until the desired element size is reached.
+            generateRSInstruction(cg, TR::InstOpCode::SLLG, node, scratchReg, resultReg, dataLength);
+        }
+        generateRREInstruction(cg, op, node, resultReg, scratchReg);
+    }
+
+    // The value is left aligned in a 64 bit GPR. If the lane width is smaller than 64 bits, arithmetic shift right
+    // to obtain the correct sign extended result.
+    if (laneLength < 64)
+        generateRSInstruction(cg, TR::InstOpCode::SRAG, node, resultReg, resultReg, 64 - laneLength);
+
+    cg->decReferenceCount(firstChild);
+    cg->stopUsingRegister(scratchReg);
+    node->setRegister(resultReg);
+    return resultReg;
+}
+
+TR::Register *OMR::Z::TreeEvaluator::vreductionAndEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+{
+    return logicalReductionHelper(node, cg, TR::InstOpCode::NGR, true /* setUnmaskedLanes */);
+}
+
 TR::Register *OMR::Z::TreeEvaluator::vreductionOrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+    return logicalReductionHelper(node, cg, TR::InstOpCode::OGR, false /* setUnmaskedLanes */);
 }
 
 TR::Register *OMR::Z::TreeEvaluator::vreductionOrUncheckedEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -15755,7 +15853,7 @@ TR::Register *OMR::Z::TreeEvaluator::vreductionOrUncheckedEvaluator(TR::Node *no
 
 TR::Register *OMR::Z::TreeEvaluator::vreductionXorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+    return logicalReductionHelper(node, cg, TR::InstOpCode::XGR, false /* setUnmaskedLanes */);
 }
 
 TR::Register *OMR::Z::TreeEvaluator::vreturnEvaluator(TR::Node *node, TR::CodeGenerator *cg)


### PR DESCRIPTION
Logical reduction opcodes perform lane-wise logical operations (AND, OR, XOR) across all lanes of a vector to produce a single value. The implementation executes the logical operation on the vector, sign extends the final result, and returns it in a GPR.