### PR TITLE
Add support for vcompress and vexpand on IBM Z platform.

### DIFF
--- a/compiler/il/VectorOperations.enum
+++ b/compiler/il/VectorOperations.enum
@@ -1185,7 +1185,10 @@ VECTOR_OPERATION_MACRO(\
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
    /* .booleanCompareOpCode    = */ TR::BadILOp, \
    /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    vector expand based on mask: opposite of compress */ \
+   /* .description             =    vector expand based on mask: The first element of the source is placed in the \
+                                    position of the first true lane in the mask. The second element is placed in \
+                                    the position of the second true lane, and so forth. All lanes not selected by \
+                                    the mask are set to zero. */ \
 )
 VECTOR_OPERATION_MACRO(\
    /* .operation               = */ vshl, \

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4365,6 +4365,8 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::ILOpC
         case TR::vmreductionMax:
         case TR::vreductionMin:
         case TR::vmreductionMin:
+        case TR::vcompress:
+        case TR::vexpand:
             return true;
         case TR::vmul:
         case TR::vmmul:

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -1898,12 +1898,143 @@ TR::Register *OMR::Z::TreeEvaluator::vmpopcntEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::Z::TreeEvaluator::vcompressEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+    /*
+     * Algorithm
+     *  a) Replace unset lanes of the mask with a lane size (adjusted for VSLB instruction)
+     *     and set lanes with zero.
+     *  b) Start a loop to process lane by lane:
+     *   1) Copy the rightmost lane of source into the leftmost lane of result.
+     *   2) Shift the result left by the rightmost number in the mask:
+     *        masked   -> shift 0 bytes (keep lane)
+     *        unmasked -> shift lane_size bytes (drop lane)
+     *   3) Rotate source and the mask by one lane so the next candidate becomes
+     *      the rightmost lane.
+     * Repeat for the number of lanes. result register ends with masked-in lanes packed
+     * left and zeros elsewhere. source is restored after a full-width rotation.
+     */
+    TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+        "Only 128-bit vectors are supported %s", node->getDataType().toString());
+    const uint8_t elementSizeMask = static_cast<uint8_t>(getVectorElementSizeMask(node));
+    const int32_t elementSize = getVectorElementSize(node);
+    TR::Register *resultReg = cg->allocateRegister(TR_VRF);
+    TR::Register *loopCountReg = cg->allocateRegister();
+    TR::Register *sourceReg = cg->evaluate(node->getFirstChild());
+    TR::Register *maskReg = cg->gprClobberEvaluate(node->getSecondChild());
+
+    // Fill the unmasked lanes with the number that would shift one element in VSLB instruction.
+    generateVRIaInstruction(cg, TR::InstOpCode::VREPI, node, resultReg, elementSize << 3, elementSizeMask);
+    generateVRRcInstruction(cg, TR::InstOpCode::VNC, node, maskReg, resultReg, maskReg, 0);
+    // VSLB instruction that was used in the loop, uses the byte element 7 of maskReg
+    // so we need to rotate the mask to move byte 15 to byte 7.
+    generateVRIdInstruction(cg, TR::InstOpCode::VSLDB, node, maskReg, maskReg, maskReg, 8, 0);
+    // Zero the result register.
+    generateVRIaInstruction(cg, TR::InstOpCode::VGBM, node, resultReg, 0, 0);
+
+    // Start a loop to compress the vector lane by lane.
+    generateRIInstruction(cg, TR::InstOpCode::LHI, node, loopCountReg, 16 / elementSize);
+    // Put the loop inside a control flow.
+    TR::LabelSymbol *cFlowStartLabel = generateLabelSymbol(cg);
+    generateS390LabelInstruction(cg, TR::InstOpCode::label, node, cFlowStartLabel);
+    cFlowStartLabel->setStartInternalControlFlow();
+    // Shift the rightmost element of the source to the result leftmost.
+    generateVRIdInstruction(cg, TR::InstOpCode::VSLDB, node, resultReg, sourceReg, resultReg, 16 - elementSize, 0);
+    // Remove the last inserted element if it was unmasked.
+    generateVRRcInstruction(cg, TR::InstOpCode::VSLB, node, resultReg, resultReg, maskReg, 0);
+    // rotate source and mask to the right by one element for the next loop
+    generateVRIdInstruction(cg, TR::InstOpCode::VSLDB, node, sourceReg, sourceReg, sourceReg, 16 - elementSize, 0);
+    generateVRIdInstruction(cg, TR::InstOpCode::VSLDB, node, maskReg, maskReg, maskReg, 16 - elementSize, 0);
+    // Repeat until all lanes are processed.
+    generateS390BranchInstruction(cg, TR::InstOpCode::BRCT, node, loopCountReg, cFlowStartLabel);
+    // End of control flow.
+    TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 4, cg);
+    deps->addPostCondition(resultReg, TR::RealRegister::AssignAny);
+    deps->addPostCondition(loopCountReg, TR::RealRegister::AssignAny);
+    deps->addPostCondition(sourceReg, TR::RealRegister::AssignAny);
+    deps->addPostCondition(maskReg, TR::RealRegister::AssignAny);
+
+    TR::LabelSymbol *cFlowEndLabel = generateLabelSymbol(cg);
+    generateS390LabelInstruction(cg, TR::InstOpCode::label, node, cFlowEndLabel, deps);
+    cFlowEndLabel->setEndInternalControlFlow();
+
+    cg->stopUsingRegister(loopCountReg);
+    node->setRegister(resultReg);
+    cg->decReferenceCount(node->getFirstChild());
+    cg->decReferenceCount(node->getSecondChild());
+    return resultReg;
 }
 
 TR::Register *OMR::Z::TreeEvaluator::vexpandEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+    /*
+     * Algorithm
+     *  a) Create a register with lane size (adjusted for VSLB instruction) for masked lanes.
+     *  b) Start a loop to process lane by lane:
+     *   1) Copy the leftmost lane of source into the rightmost lane of result.
+     *   2) Shift the source right by the leftmost number in the shiftCountReg:
+     *        masked   -> shift lane_size bytes (Move to the next element)
+     *        unmasked -> shift 0 bytes (keeo the lane)
+     *   3) Rotate the mask by one lane so the next candidate becomes the left lane.
+     *   Repeat for the number of lanes. result register ends with masked-in lanes but
+     *   the value is repeated in the following unmasked lanes.
+     *  c) AND the result and the mask to zero values in unmasked lanes.
+     */
+    TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+        "Only 128-bit vectors are supported %s", node->getDataType().toString());
+    const uint8_t elementSizeMask = static_cast<uint8_t>(getVectorElementSizeMask(node));
+    const int32_t elementSize = getVectorElementSize(node);
+    TR::Register *resultReg = cg->allocateRegister(TR_VRF);
+    TR::Register *loopCountReg = cg->allocateRegister();
+    TR::Register *sourceReg = cg->gprClobberEvaluate(node->getFirstChild());
+    TR::Register *maskReg = cg->evaluate(node->getSecondChild());
+    TR::Register *shiftCountReg = cg->allocateRegister(TR_VRF);
+
+    // Fill the masked lanes of the shiftCountReg with the number that would shift one element in VSLB instruction.
+    generateVRIaInstruction(cg, TR::InstOpCode::VREPI, node, shiftCountReg, elementSize << 3, elementSizeMask);
+    generateVRRcInstruction(cg, TR::InstOpCode::VN, node, shiftCountReg, shiftCountReg, maskReg, 0);
+    // VSLB uses the byte element 7 of V3 so we need to rotate the mask to move the rightmost byte of the leftmost
+    // element to position 7. In case of 8 byte element size, the rightmost byte of the leftmost element is in correct
+    // position.
+    if (elementSize < 8)
+        generateVRIdInstruction(cg, TR::InstOpCode::VSLDB, node, shiftCountReg, shiftCountReg, shiftCountReg,
+            8 + elementSize, 0);
+
+    // Start a loop to expand the vector lane by lane.
+    generateRIInstruction(cg, TR::InstOpCode::LHI, node, loopCountReg, 16 / elementSize);
+    // Put the loop inside a control flow.
+    TR::LabelSymbol *cFlowStartLabel = generateLabelSymbol(cg);
+    generateS390LabelInstruction(cg, TR::InstOpCode::label, node, cFlowStartLabel);
+    cFlowStartLabel->setStartInternalControlFlow();
+    // Shift the leftmost element of the source to the result rightmost.
+    generateVRIdInstruction(cg, TR::InstOpCode::VSLDB, node, resultReg, resultReg, sourceReg, elementSize, 0);
+    // Move to the next source element if the current element is masked.
+    generateVRRcInstruction(cg, TR::InstOpCode::VSLB, node, sourceReg, sourceReg, shiftCountReg, 0);
+    // Rotate shiftCountReg left for the next loop.
+    generateVRIdInstruction(cg, TR::InstOpCode::VSLDB, node, shiftCountReg, shiftCountReg, shiftCountReg, elementSize,
+        0);
+    // Process the next element.
+    generateS390BranchInstruction(cg, TR::InstOpCode::BRCT, node, loopCountReg, cFlowStartLabel);
+
+    // End of control flow.
+    TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 5, cg);
+    deps->addPostCondition(resultReg, TR::RealRegister::AssignAny);
+    deps->addPostCondition(loopCountReg, TR::RealRegister::AssignAny);
+    deps->addPostCondition(sourceReg, TR::RealRegister::AssignAny);
+    deps->addPostCondition(maskReg, TR::RealRegister::AssignAny);
+    deps->addPostCondition(shiftCountReg, TR::RealRegister::AssignAny);
+
+    TR::LabelSymbol *cFlowEndLabel = generateLabelSymbol(cg);
+    generateS390LabelInstruction(cg, TR::InstOpCode::label, node, cFlowEndLabel, deps);
+    cFlowEndLabel->setEndInternalControlFlow();
+
+    // Zero the unmasked lanes.
+    generateVRRcInstruction(cg, TR::InstOpCode::VN, node, resultReg, resultReg, maskReg, 0);
+
+    cg->stopUsingRegister(loopCountReg);
+    cg->stopUsingRegister(shiftCountReg);
+    node->setRegister(resultReg);
+    cg->decReferenceCount(node->getFirstChild());
+    cg->decReferenceCount(node->getSecondChild());
+    return resultReg;
 }
 
 TR::Register *OMR::Z::TreeEvaluator::vshlEvaluator(TR::Node *node, TR::CodeGenerator *cg)


### PR DESCRIPTION
These opcodes add vector compression and expansion capabilities on IBM Z platform.
@r30shah @hzongaro @gita-omr Please review this PR and share your feedback. Thanks.