### PR TITLE
Correct invalid cast by restoring proper TR::CompilerEnv allocation

### DIFF
--- a/compiler/env/CompilerEnv.hpp
+++ b/compiler/env/CompilerEnv.hpp
@@ -30,8 +30,9 @@ namespace TR {
 
 class OMR_EXTENSIBLE CompilerEnv : public OMR::CompilerEnvConnector {
 public:
-    CompilerEnv(TR::RawAllocator raw, const TR::PersistentAllocatorKit &persistentAllocatorKit)
-        : OMR::CompilerEnvConnector(raw, persistentAllocatorKit)
+    CompilerEnv(TR::RawAllocator raw, const TR::PersistentAllocatorKit &persistentAllocatorKit,
+        OMRPortLibrary *omrPortLib = NULL)
+        : OMR::CompilerEnvConnector(raw, persistentAllocatorKit, omrPortLib)
     {}
 };
 

--- a/fvtest/compilertest/Jit.hpp
+++ b/fvtest/compilertest/Jit.hpp
@@ -22,11 +22,13 @@
 
 #include <stdint.h>
 
+struct OMRPortLibrary;
+
 namespace TR { class MethodBuilder; }
 class TR_Memory;
 
 extern "C" bool initializeJit();
 extern "C" bool initializeJitWithOptions(char * options);
-extern "C" bool initializeJitWithOptionsAndPort(char *options, void *portLib);
+extern "C" bool initializeJitWithOptionsAndPort(char *options, OMRPortLibrary *portLib);
 extern "C" uint32_t compileMethodBuilder(TR::MethodBuilder *m, uint8_t **entry);
 extern "C" void shutdownJit();

--- a/fvtest/compilertest/control/TestJit.cpp
+++ b/fvtest/compilertest/control/TestJit.cpp
@@ -139,7 +139,8 @@ initializeCodeCache(TR::CodeCacheManager & codeCacheManager)
 // portLib is the OMRPortLibrary to use in compiler environment
 extern "C"
 bool
-initializeTestJitWithPort(TR_RuntimeHelper *helperIDs, void **helperAddresses, int32_t numHelpers, char *options, void *portLib)
+initializeTestJitWithPort(TR_RuntimeHelper *helperIDs, void **helperAddresses, int32_t numHelpers, char *options,
+   OMRPortLibrary *portLib)
    {
     // Force enable tree verifier
     std::string optionsWithVerifier = options;
@@ -156,7 +157,7 @@ initializeTestJitWithPort(TR_RuntimeHelper *helperIDs, void **helperAddresses, i
       {
       // Allocate the host environment structure
       //
-      TR::Compiler = static_cast<TR::CompilerEnv *>(new (rawAllocator) OMR::CompilerEnv(rawAllocator, TR::PersistentAllocatorKit(rawAllocator), (OMRPortLibrary *)portLib));
+      TR::Compiler = new (rawAllocator) TR::CompilerEnv(rawAllocator, TR::PersistentAllocatorKit(rawAllocator), portLib);
       }
    catch (const std::bad_alloc&)
       {
@@ -185,7 +186,7 @@ extern "C"
 bool
 initializeTestJit(TR_RuntimeHelper *helperIDs, void **helperAddresses, int32_t numHelpers, char *options)
    {
-      return initializeTestJitWithPort(helperIDs, helperAddresses, numHelpers, options, (void *)NULL);
+      return initializeTestJitWithPort(helperIDs, helperAddresses, numHelpers, options, (OMRPortLibrary *)NULL);
    }
 
 extern "C"
@@ -197,7 +198,7 @@ initializeJitWithOptions(char *options)
 
 extern "C"
 bool
-initializeJitWithOptionsAndPort(char *options, void *portLib)
+initializeJitWithOptionsAndPort(char *options, OMRPortLibrary *portLib)
    {
    return initializeTestJitWithPort(0, 0, 0, options, portLib);
    }


### PR DESCRIPTION
Remove the earlier cast from OMR::CompilerEnv to TR::CompilerEnv and extend TR::CompilerEnv to accept the new portLib parameter while forwarding it to the base constructor.