### PR TITLE
Fix mTrueCountEvaluator on IBM Z platform

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -1115,7 +1115,6 @@ TR::Register *OMR::Z::TreeEvaluator::mTrueCountEvaluator(TR::Node *node, TR::Cod
     // For 8-bit or 16-bit lanes, perform a two-step reduction to avoid overflow.
     if (sizeMask <= 1) {
         // Pre-reduce to 32-bit elements using VSUM before final quadword summation.
-        scratchReg = cg->allocateRegister(TR_VRF);
         generateVRRcInstruction(cg, TR::InstOpCode::VSUM, node, scratchReg, scratchReg, zeroReg, 0, 0, sizeMask);
         sizeMask = 2;
     }


### PR DESCRIPTION
There is an unwanted extra register allocated in mTrueCountEvaluator that is causing failures.
Remove the extra register allocation from the evaluator.
https://github.com/eclipse-openj9/openj9/issues/23839