### PR TITLE
Adds flags to control recognized call transformer

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -5114,6 +5114,40 @@ bool OMR::Node::chkSafeForCGToFastPathUnsafeCall()
     return self()->getOpCode().isCall() && _flags.testAny(unsafeFastPathCall);
 }
 
+bool OMR::Node::isSafeForCGToInlineStringIntrinsic()
+{
+    TR_ASSERT_FATAL(self()->getOpCode().isCall(), "Opcode must be call");
+    return _flags.testAny(inlineStringIntrinsic);
+}
+
+void OMR::Node::setIsSafeForCGToInlineStringIntrinsic(bool v)
+{
+    TR_ASSERT_FATAL(self()->getOpCode().isCall(), "Opcode must be call");
+    _flags.set(inlineStringIntrinsic);
+}
+
+bool OMR::Node::chkSafeForCGToInlineStringIntrinsic()
+{
+    return self()->getOpCode().isCall() && _flags.testAny(inlineStringIntrinsic);
+}
+
+bool OMR::Node::isSkippedInRecognizedCallTransformation()
+{
+    TR_ASSERT_FATAL(self()->getOpCode().isCall(), "Opcode must be call");
+    return _flags.testAny(skipRecognizedCallTransformation);
+}
+
+void OMR::Node::setSkippedInRecognizedCallTransformation(bool v)
+{
+    TR_ASSERT_FATAL(self()->getOpCode().isCall(), "Opcode must be call");
+    _flags.set(skipRecognizedCallTransformation);
+}
+
+bool OMR::Node::chkSkippedInRecognizedCallTransformation()
+{
+    return self()->getOpCode().isCall() && _flags.testAny(skipRecognizedCallTransformation);
+}
+
 bool OMR::Node::isCallThatWasRefinedFromKnownObject()
 {
     return self()->getOpCode().isCall() && _flags.testAny(wasRefinedFromKnownObject);

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -5114,6 +5114,40 @@ bool OMR::Node::chkSafeForCGToFastPathUnsafeCall()
     return self()->getOpCode().isCall() && _flags.testAny(unsafeFastPathCall);
 }
 
+bool OMR::Node::isSafeForCGToInlineStringIntrinsic()
+{
+    TR_ASSERT_FATAL(self()->getOpCode().isCall(), "Opcode must be call");
+    return _flags.testAny(inlineStringIntrinsic);
+}
+
+void OMR::Node::setIsSafeForCGToInlineStringIntrinsic(bool v)
+{
+    TR_ASSERT_FATAL(self()->getOpCode().isCall(), "Opcode must be call");
+    _flags.set(inlineStringIntrinsic);
+}
+
+bool OMR::Node::chkSafeForCGToInlineStringIntrinsic()
+{
+    return self()->getOpCode().isCall() && _flags.testAny(inlineStringIntrinsic);
+}
+
+bool OMR::Node::checkSkipRecognizedCallTransformation()
+{
+    TR_ASSERT_FATAL(self()->getOpCode().isCall(), "Opcode must be call");
+    return _flags.testAny(skipRecognizedCallTransformation);
+}
+
+void OMR::Node::setSkipRecognizedCallTransformation(bool v)
+{
+    TR_ASSERT_FATAL(self()->getOpCode().isCall(), "Opcode must be call");
+    _flags.set(skipRecognizedCallTransformation);
+}
+
+bool OMR::Node::chkSkipRecognizedCallTransformation()
+{
+    return self()->getOpCode().isCall() && _flags.testAny(skipRecognizedCallTransformation);
+}
+
 bool OMR::Node::isCallThatWasRefinedFromKnownObject()
 {
     return self()->getOpCode().isCall() && _flags.testAny(wasRefinedFromKnownObject);

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1246,6 +1246,14 @@ public:
     void setIsSafeForCGToFastPathUnsafeCall(bool v);
     bool chkSafeForCGToFastPathUnsafeCall();
 
+    bool isSafeForCGToInlineStringIntrinsic();
+    void setIsSafeForCGToInlineStringIntrinsic(bool v);
+    bool chkSafeForCGToInlineStringIntrinsic();
+
+    bool isSkippedInRecognizedCallTransformation();
+    void setSkippedInRecognizedCallTransformation(bool v);
+    bool chkSkippedInRecognizedCallTransformation();
+
     // Flag used by TR::ladd and TR::lsub or by TR::lshl and TR::lshr for compressedPointers
     bool containsCompressionSequence();
     void setContainsCompressionSequence(bool v);
@@ -1947,6 +1955,8 @@ protected:
         desynchronizeCall = 0x00020000,
         preparedForDirectToJNI = 0x00040000, // TODO: make J9_PROJECT_SPECIFIC
         unsafeFastPathCall = 0x00080000, // TODO: make J9_PROJECT_SPECIFIC
+        inlineStringIntrinsic = 0x00100000,
+        skipRecognizedCallTransformation = 0x00200000,
 
         // Flag used by TR::ladd and TR::lsub or by TR::lshl and TR::lshr for compressedPointers
         isCompressionSequence = 0x00000800,

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1246,6 +1246,14 @@ public:
     void setIsSafeForCGToFastPathUnsafeCall(bool v);
     bool chkSafeForCGToFastPathUnsafeCall();
 
+    bool isSafeForCGToInlineStringIntrinsic();
+    void setIsSafeForCGToInlineStringIntrinsic(bool v);
+    bool chkSafeForCGToInlineStringIntrinsic();
+
+    bool checkSkipRecognizedCallTransformation();
+    void setSkipRecognizedCallTransformation(bool v);
+    bool chkSkipRecognizedCallTransformation();
+
     // Flag used by TR::ladd and TR::lsub or by TR::lshl and TR::lshr for compressedPointers
     bool containsCompressionSequence();
     void setContainsCompressionSequence(bool v);
@@ -1947,6 +1955,8 @@ protected:
         desynchronizeCall = 0x00020000,
         preparedForDirectToJNI = 0x00040000, // TODO: make J9_PROJECT_SPECIFIC
         unsafeFastPathCall = 0x00080000, // TODO: make J9_PROJECT_SPECIFIC
+        inlineStringIntrinsic = 0x00100000, // TODO: make J9_PROJECT_SPECIFIC
+        skipRecognizedCallTransformation = 0x00200000, // TODO: make J9_PROJECT_SPECIFIC
 
         // Flag used by TR::ladd and TR::lsub or by TR::lshl and TR::lshr for compressedPointers
         isCompressionSequence = 0x00000800,

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -886,6 +886,8 @@ int32_t TR_Debug::nodePrintAllFlags(OMR::Logger *log, TR::Node *node)
     FLAG(chkIsReferenceNonNull, "referenceIsNonNull");
     FLAG(isPreparedForDirectJNI, "preparedForDirectJNI");
     FLAG(chkSafeForCGToFastPathUnsafeCall, "safeForCGToFastPathUnsafeCall");
+    FLAG(chkSafeForCGToInlineStringIntrinsic, "safeForCGToInlineStringIntrinsic");
+    FLAG(chkSkippedInRecognizedCallTransformation, "skipRecognizedCallTransformation");
 
 #undef FLAG
 #undef FLAG_IF

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -886,6 +886,8 @@ int32_t TR_Debug::nodePrintAllFlags(OMR::Logger *log, TR::Node *node)
     FLAG(chkIsReferenceNonNull, "referenceIsNonNull");
     FLAG(isPreparedForDirectJNI, "preparedForDirectJNI");
     FLAG(chkSafeForCGToFastPathUnsafeCall, "safeForCGToFastPathUnsafeCall");
+    FLAG(chkSafeForCGToInlineStringIntrinsic, "safeForCGToInlineStringIntrinsic");
+    FLAG(chkSkipRecognizedCallTransformation, "skipRecognizedCallTransformation");
 
 #undef FLAG
 #undef FLAG_IF


### PR DESCRIPTION
OMRNode is updated with additional flags for call nodes.

Flags are used as part of the recognizedCallTransformer opt.