### PR TITLE
WIP: Vnot IL opcode implementation on x86 platform

### DIFF
--- a/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
@@ -1217,11 +1217,6 @@ TR::Register *OMR::X86::AMD64::TreeEvaluator::PassThroughEvaluator(TR::Node *nod
     return TR::TreeEvaluator::passThroughEvaluator(node, cg);
 }
 
-TR::Register *OMR::X86::AMD64::TreeEvaluator::vnotEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-{
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
-}
-
 TR::Register *OMR::X86::AMD64::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
     return TR::TreeEvaluator::SIMDsplatsEvaluator(node, cg);

--- a/compiler/x/amd64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluator.hpp
@@ -294,7 +294,6 @@ public:
     static TR::Register *vloadiEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *vminEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *vmaxEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-    static TR::Register *vnotEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *vorEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *vorUncheckedEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *vreturnEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1129,6 +1129,19 @@ bool OMR::X86::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::ILO
                     return false;
             }
             break;
+        case TR::vnot:
+        case TR::vmnot:
+            // vnot uses PCMPEQD + PXOR which are available with SSE2
+            switch (ot.getVectorLength()) {
+                case TR::VectorLength128:
+                    return true;
+                case TR::VectorLength256:
+                    return cpu->supportsFeature(OMR_FEATURE_X86_AVX2);
+                case TR::VectorLength512:
+                    return cpu->supportsFeature(OMR_FEATURE_X86_AVX512F);
+                default:
+                    return false;
+            }
         case TR::vbitselect:
             if (et.isFloatingPoint())
                 return false;

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -6807,6 +6807,14 @@ TR::Register *OMR::X86::TreeEvaluator::SIMDreductionEvaluator(TR::Node *node, TR
 TR::Register *OMR::X86::TreeEvaluator::unaryVectorMaskHelper(TR::InstOpCode opcode, OMR::X86::Encoding encoding,
     TR::Node *node, TR::Register *resultReg, TR::Register *valueReg, TR::Register *maskReg, TR::CodeGenerator *cg)
 {
+    if (node->getOpCode().getVectorOperation() == TR::vnot) {
+        TR::Register *tmpReg = vnotHelper(node, cg);
+        Inst_RegReg(OP::MOVDQURegReg, node, resultReg, valueReg, cg, encoding);
+        vectorMergeMaskHelper(node, resultReg, tmpReg, maskReg, cg);
+        cg->stopUsingRegister(tmpReg);
+        return resultReg;
+    }
+
     TR_ASSERT_FATAL(encoding != OMR::X86::Bad, "No suitable encoding method for opcode");
     bool vectorMask = maskReg->getKind() == TR_VRF;
     TR::Register *tmpReg = vectorMask ? cg->allocateRegister(TR_VRF) : NULL;
@@ -7319,9 +7327,14 @@ TR::Register *OMR::X86::TreeEvaluator::vmnegEvaluator(TR::Node *node, TR::CodeGe
     return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
 }
 
+TR::Register *OMR::X86::TreeEvaluator::vnotEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+{
+    return TR::TreeEvaluator::unaryVectorArithmeticEvaluator(node, cg);
+}
+
 TR::Register *OMR::X86::TreeEvaluator::vmnotEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+    return TR::TreeEvaluator::unaryVectorArithmeticEvaluator(node, cg);
 }
 
 TR::Register *OMR::X86::TreeEvaluator::vmorEvaluator(TR::Node *node, TR::CodeGenerator *cg)

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -364,6 +364,7 @@ public:
     static TR::Register *vmminEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *vmmulEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *vmnegEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+    static TR::Register *vnotEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *vmnotEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *vmorEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *vmorUncheckedEvaluator(TR::Node *node, TR::CodeGenerator *cg);
@@ -459,6 +460,7 @@ public:
     // For unary ILOpcodes that can be translated to a single SSE/AVX instruction
     static TR::Register *unaryVectorArithmeticEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *floatingPointAbsHelper(TR::Node *node, TR::CodeGenerator *cg);
+    static TR::Register *vnotHelper(TR::Node *node, TR::CodeGenerator *cg);
 
     // SIMD evaluators
     static TR::Register *SIMDRegLoadEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/codegen/UnaryEvaluator.cpp
+++ b/compiler/x/codegen/UnaryEvaluator.cpp
@@ -100,6 +100,49 @@ TR::Register *OMR::X86::TreeEvaluator::floatingPointAbsHelper(TR::Node *node, TR
     return resultReg;
 }
 
+TR::Register *OMR::X86::TreeEvaluator::vnotHelper(TR::Node *node, TR::CodeGenerator *cg)
+{
+    TR::Node *valueNode = node->getChild(0);
+    TR::Register *valueReg = cg->evaluate(valueNode);
+    TR::Register *resultReg = cg->allocateRegister(TR_VRF);
+    TR::Register *onesReg = cg->allocateRegister(TR_VRF);
+    TR::VectorLength vl = node->getType().getVectorLength();
+
+    TR::InstOpCode cmpOpcode = TR::InstOpCode::PCMPEQBRegReg;
+    TR::InstOpCode movOpcode = TR::InstOpCode::MOVDQURegReg;
+    TR::InstOpCode xorOpcode = TR::InstOpCode::PXORRegReg;
+
+    OMR::X86::Encoding cmpEncoding = cmpOpcode.getSIMDEncoding(&cg->comp()->target().cpu, vl);
+    OMR::X86::Encoding movEncoding = movOpcode.getSIMDEncoding(&cg->comp()->target().cpu, vl);
+    OMR::X86::Encoding xorEncoding = xorOpcode.getSIMDEncoding(&cg->comp()->target().cpu, vl);
+    TR_ASSERT_FATAL(cmpEncoding != OMR::X86::Bad, "vnot: No encoding method for cmp opcode");
+    TR_ASSERT_FATAL(movEncoding != OMR::X86::Bad, "vnot: No encoding method for mov opcode");
+    TR_ASSERT_FATAL(xorEncoding != OMR::X86::Bad, "vnot: No encoding method for xor opcode");
+
+    // Generate all ones vector
+    TR::InstOpCode ternOpcode = TR::InstOpCode::VPTERNLOGDRegMaskRegRegImm1;
+    OMR::X86::Encoding ternEncoding = ternOpcode.getSIMDEncoding(&cg->comp()->target().cpu, vl);
+    
+    if (xorEncoding >= OMR::X86::EVEX_L128 && ternEncoding != OMR::X86::Bad) {
+        // AVX-512 available
+        Inst_RegRegImm(ternOpcode.getMnemonic(), node, onesReg, onesReg, 0xff, cg, ternEncoding);
+    } else {
+        // SSE/AVX fallback
+        Inst_RegReg(xorOpcode.getMnemonic(), node, onesReg, onesReg, cg, xorEncoding);
+        Inst_RegReg(cmpOpcode.getMnemonic(), node, onesReg, onesReg, cg, cmpEncoding);
+    }
+
+    // Compute NOT
+    Inst_RegReg(movOpcode.getMnemonic(), node, resultReg, valueReg, cg, movEncoding);
+    Inst_RegReg(xorOpcode.getMnemonic(), node, resultReg, onesReg, cg, xorEncoding);
+
+    cg->stopUsingRegister(onesReg);
+    node->setRegister(resultReg);
+    cg->decReferenceCount(valueNode);
+    return resultReg;
+}
+
+
 TR::Register *OMR::X86::TreeEvaluator::unaryVectorArithmeticEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
     TR::ILOpCode opcode = node->getOpCode();
@@ -107,6 +150,10 @@ TR::Register *OMR::X86::TreeEvaluator::unaryVectorArithmeticEvaluator(TR::Node *
 
     if (opcode.getVectorOperation() == TR::vabs && type.getVectorElementType().isFloatingPoint()) {
         return TR::TreeEvaluator::floatingPointAbsHelper(node, cg);
+    }
+
+    if (opcode.getVectorOperation() == TR::vnot && !opcode.isVectorMasked()) {
+        return TR::TreeEvaluator::vnotHelper(node, cg);
     }
 
     TR::Node *valueNode = node->getChild(0);
@@ -202,7 +249,6 @@ TR::Register *OMR::X86::TreeEvaluator::integerAbsEvaluator(TR::Node *node, TR::C
     auto child = node->getFirstChild();
     auto value = cg->evaluate(child);
     auto result = cg->allocateRegister(value->getKind());
-
     auto is64Bit = TR::TreeEvaluator::getNodeIs64Bit(node, cg);
     Inst_RegReg(OP::MOVRegReg(is64Bit), node, result, value, cg);
     Inst_Reg(OP::NEGReg(is64Bit), node, result, cg);

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -1298,11 +1298,6 @@ TR::Register *OMR::X86::I386::TreeEvaluator::PassThroughEvaluator(TR::Node *node
     return TR::TreeEvaluator::passThroughEvaluator(node, cg);
 }
 
-TR::Register *OMR::X86::I386::TreeEvaluator::vnotEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-{
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
-}
-
 TR::Register *OMR::X86::I386::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
     return TR::TreeEvaluator::SIMDsplatsEvaluator(node, cg);

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.hpp
@@ -274,7 +274,6 @@ public:
     static TR::Register *vloadiEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *vmaxEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *vminEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-    static TR::Register *vnotEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *vorEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *vorUncheckedEvaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *vreturnEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -45,6 +45,7 @@ omr_add_executable(comptest NOWARNINGS
 	VectorTest.cpp
 	VectorMaskTest.cpp
 	VectorTestUtils.cpp
+	VnotTest.cpp
 	CallTest.cpp
 	LongAndAsRotateTest.cpp
 	MockStrategyTest.cpp

--- a/fvtest/compilertriltest/VnotTest.cpp
+++ b/fvtest/compilertriltest/VnotTest.cpp
@@ -1,0 +1,503 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2024
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+#include "JitTest.hpp"
+#include "default_compiler.hpp"
+#include "compilerunittest/CompilerUnitTest.hpp"
+#include "VectorTestUtils.hpp"
+
+class VnotTest : public TRTest::JitTest {};
+
+/**
+ * @brief Test vnot with Int8 elements - all zeros
+ */
+TEST_F(VnotTest, VnotInt8AllZeros) {
+    TR::VectorLength vl = TR::VectorLength128;
+    TR::DataTypes elementType = TR::Int8;
+    TR::DataType vt = TR::DataType::createVectorType(elementType, vl);
+    
+    TR::ILOpCode vnotOp = TR::ILOpCode::createVectorOpCode(TR::vnot, vt);
+    TR::CPU cpu = TR::CPU::detect(privateOmrPortLibrary);
+    
+    SKIP_IF(!TR::CodeGenerator::getSupportsOpCodeForAutoSIMD(&cpu, vnotOp), MissingImplementation);
+    
+    char inputTrees[1024];
+    std::snprintf(inputTrees, sizeof(inputTrees),
+                  "(method return=NoType args=[Address,Address]"
+                  "  (block"
+                  "    (vstoreiVector128Int8 offset=0 (aload parm=0)"
+                  "      (vnotVector128Int8 (vloadiVector128Int8 (aload parm=1))))"
+                  "    (return)))");
+    
+    auto trees = parseString(inputTrees);
+    ASSERT_NOTNULL(trees);
+    
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile());
+    
+    uint8_t input[16] = {0};
+    uint8_t expected[16];
+    uint8_t result[16] = {0};
+    
+    for (int i = 0; i < 16; i++) expected[i] = 0xFF;
+    
+    auto entry_point = compiler.getEntryPoint<void(*)(void*, void*)>();
+    entry_point(result, input);
+    
+    for (int i = 0; i < 16; i++) {
+        EXPECT_EQ(expected[i], result[i]);
+    }
+}
+
+/**
+ * @brief Test vnot with Int8 elements - all ones
+ */
+TEST_F(VnotTest, VnotInt8AllOnes) {
+    TR::VectorLength vl = TR::VectorLength128;
+    TR::DataTypes elementType = TR::Int8;
+    TR::DataType vt = TR::DataType::createVectorType(elementType, vl);
+    
+    TR::ILOpCode vnotOp = TR::ILOpCode::createVectorOpCode(TR::vnot, vt);
+    TR::CPU cpu = TR::CPU::detect(privateOmrPortLibrary);
+    
+    SKIP_IF(!TR::CodeGenerator::getSupportsOpCodeForAutoSIMD(&cpu, vnotOp), MissingImplementation);
+    
+    char inputTrees[1024];
+    std::snprintf(inputTrees, sizeof(inputTrees),
+                  "(method return=NoType args=[Address,Address]"
+                  "  (block"
+                  "    (vstoreiVector128Int8 offset=0 (aload parm=0)"
+                  "      (vnotVector128Int8 (vloadiVector128Int8 (aload parm=1))))"
+                  "    (return)))");
+    
+    auto trees = parseString(inputTrees);
+    ASSERT_NOTNULL(trees);
+    
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile());
+    
+    uint8_t input[16];
+    uint8_t expected[16] = {0};
+    uint8_t result[16] = {0};
+    
+    for (int i = 0; i < 16; i++) input[i] = 0xFF;
+    
+    auto entry_point = compiler.getEntryPoint<void(*)(void*, void*)>();
+    entry_point(result, input);
+    
+    for (int i = 0; i < 16; i++) {
+        EXPECT_EQ(expected[i], result[i]);
+    }
+}
+
+/**
+ * @brief Test vnot with Int8 elements - alternating pattern
+ */
+TEST_F(VnotTest, VnotInt8Alternating) {
+    TR::VectorLength vl = TR::VectorLength128;
+    TR::DataTypes elementType = TR::Int8;
+    TR::DataType vt = TR::DataType::createVectorType(elementType, vl);
+    
+    TR::ILOpCode vnotOp = TR::ILOpCode::createVectorOpCode(TR::vnot, vt);
+    TR::CPU cpu = TR::CPU::detect(privateOmrPortLibrary);
+    
+    SKIP_IF(!TR::CodeGenerator::getSupportsOpCodeForAutoSIMD(&cpu, vnotOp), MissingImplementation);
+    
+    char inputTrees[1024];
+    std::snprintf(inputTrees, sizeof(inputTrees),
+                  "(method return=NoType args=[Address,Address]"
+                  "  (block"
+                  "    (vstoreiVector128Int8 offset=0 (aload parm=0)"
+                  "      (vnotVector128Int8 (vloadiVector128Int8 (aload parm=1))))"
+                  "    (return)))");
+    
+    auto trees = parseString(inputTrees);
+    ASSERT_NOTNULL(trees);
+    
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile());
+    
+    uint8_t input[16] = {0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55,
+                         0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55};
+    uint8_t expected[16] = {0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA,
+                            0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA};
+    uint8_t result[16] = {0};
+    
+    auto entry_point = compiler.getEntryPoint<void(*)(void*, void*)>();
+    entry_point(result, input);
+    
+    for (int i = 0; i < 16; i++) {
+        EXPECT_EQ(expected[i], result[i]);
+    }
+}
+
+/**
+ * @brief Test vnot with Int16 elements - all zeros
+ */
+TEST_F(VnotTest, VnotInt16AllZeros) {
+    TR::VectorLength vl = TR::VectorLength128;
+    TR::DataTypes elementType = TR::Int16;
+    TR::DataType vt = TR::DataType::createVectorType(elementType, vl);
+    
+    TR::ILOpCode vnotOp = TR::ILOpCode::createVectorOpCode(TR::vnot, vt);
+    TR::CPU cpu = TR::CPU::detect(privateOmrPortLibrary);
+    
+    SKIP_IF(!TR::CodeGenerator::getSupportsOpCodeForAutoSIMD(&cpu, vnotOp), MissingImplementation);
+    
+    char inputTrees[1024];
+    std::snprintf(inputTrees, sizeof(inputTrees),
+                  "(method return=NoType args=[Address,Address]"
+                  "  (block"
+                  "    (vstoreiVector128Int16 offset=0 (aload parm=0)"
+                  "      (vnotVector128Int16 (vloadiVector128Int16 (aload parm=1))))"
+                  "    (return)))");
+    
+    auto trees = parseString(inputTrees);
+    ASSERT_NOTNULL(trees);
+    
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile());
+    
+    uint16_t input[8] = {0};
+    uint16_t expected[8] = {0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF};
+    uint16_t result[8] = {0};
+    
+    auto entry_point = compiler.getEntryPoint<void(*)(void*, void*)>();
+    entry_point(result, input);
+    
+    for (int i = 0; i < 8; i++) {
+        EXPECT_EQ(expected[i], result[i]);
+    }
+}
+
+/**
+ * @brief Test vnot with Int16 elements - alternating pattern
+ */
+TEST_F(VnotTest, VnotInt16Alternating) {
+    TR::VectorLength vl = TR::VectorLength128;
+    TR::DataTypes elementType = TR::Int16;
+    TR::DataType vt = TR::DataType::createVectorType(elementType, vl);
+    
+    TR::ILOpCode vnotOp = TR::ILOpCode::createVectorOpCode(TR::vnot, vt);
+    TR::CPU cpu = TR::CPU::detect(privateOmrPortLibrary);
+    
+    SKIP_IF(!TR::CodeGenerator::getSupportsOpCodeForAutoSIMD(&cpu, vnotOp), MissingImplementation);
+    
+    char inputTrees[1024];
+    std::snprintf(inputTrees, sizeof(inputTrees),
+                  "(method return=NoType args=[Address,Address]"
+                  "  (block"
+                  "    (vstoreiVector128Int16 offset=0 (aload parm=0)"
+                  "      (vnotVector128Int16 (vloadiVector128Int16 (aload parm=1))))"
+                  "    (return)))");
+    
+    auto trees = parseString(inputTrees);
+    ASSERT_NOTNULL(trees);
+    
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile());
+    
+    uint16_t input[8] = {0xAAAA, 0x5555, 0xAAAA, 0x5555, 0xAAAA, 0x5555, 0xAAAA, 0x5555};
+    uint16_t expected[8] = {0x5555, 0xAAAA, 0x5555, 0xAAAA, 0x5555, 0xAAAA, 0x5555, 0xAAAA};
+    uint16_t result[8] = {0};
+    
+    auto entry_point = compiler.getEntryPoint<void(*)(void*, void*)>();
+    entry_point(result, input);
+    
+    for (int i = 0; i < 8; i++) {
+        EXPECT_EQ(expected[i], result[i]);
+    }
+}
+
+/**
+ * @brief Test vnot with Int32 elements - all zeros
+ */
+TEST_F(VnotTest, VnotInt32AllZeros) {
+    TR::VectorLength vl = TR::VectorLength128;
+    TR::DataTypes elementType = TR::Int32;
+    TR::DataType vt = TR::DataType::createVectorType(elementType, vl);
+    
+    TR::ILOpCode vnotOp = TR::ILOpCode::createVectorOpCode(TR::vnot, vt);
+    TR::CPU cpu = TR::CPU::detect(privateOmrPortLibrary);
+    
+    SKIP_IF(!TR::CodeGenerator::getSupportsOpCodeForAutoSIMD(&cpu, vnotOp), MissingImplementation);
+    
+    char inputTrees[1024];
+    std::snprintf(inputTrees, sizeof(inputTrees),
+                  "(method return=NoType args=[Address,Address]"
+                  "  (block"
+                  "    (vstoreiVector128Int32 offset=0 (aload parm=0)"
+                  "      (vnotVector128Int32 (vloadiVector128Int32 (aload parm=1))))"
+                  "    (return)))");
+    
+    auto trees = parseString(inputTrees);
+    ASSERT_NOTNULL(trees);
+    
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile());
+    
+    uint32_t input[4] = {0};
+    uint32_t expected[4] = {0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF};
+    uint32_t result[4] = {0};
+    
+    auto entry_point = compiler.getEntryPoint<void(*)(void*, void*)>();
+    entry_point(result, input);
+    
+    for (int i = 0; i < 4; i++) {
+        EXPECT_EQ(expected[i], result[i]);
+    }
+}
+
+/**
+ * @brief Test vnot with Int32 elements - all ones
+ */
+TEST_F(VnotTest, VnotInt32AllOnes) {
+    TR::VectorLength vl = TR::VectorLength128;
+    TR::DataTypes elementType = TR::Int32;
+    TR::DataType vt = TR::DataType::createVectorType(elementType, vl);
+    
+    TR::ILOpCode vnotOp = TR::ILOpCode::createVectorOpCode(TR::vnot, vt);
+    TR::CPU cpu = TR::CPU::detect(privateOmrPortLibrary);
+    
+    SKIP_IF(!TR::CodeGenerator::getSupportsOpCodeForAutoSIMD(&cpu, vnotOp), MissingImplementation);
+    
+    char inputTrees[1024];
+    std::snprintf(inputTrees, sizeof(inputTrees),
+                  "(method return=NoType args=[Address,Address]"
+                  "  (block"
+                  "    (vstoreiVector128Int32 offset=0 (aload parm=0)"
+                  "      (vnotVector128Int32 (vloadiVector128Int32 (aload parm=1))))"
+                  "    (return)))");
+    
+    auto trees = parseString(inputTrees);
+    ASSERT_NOTNULL(trees);
+    
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile());
+    
+    uint32_t input[4] = {0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF};
+    uint32_t expected[4] = {0};
+    uint32_t result[4] = {0};
+    
+    auto entry_point = compiler.getEntryPoint<void(*)(void*, void*)>();
+    entry_point(result, input);
+    
+    for (int i = 0; i < 4; i++) {
+        EXPECT_EQ(expected[i], result[i]);
+    }
+}
+
+/**
+ * @brief Test vnot with Int32 elements - alternating pattern
+ */
+TEST_F(VnotTest, VnotInt32Alternating) {
+    TR::VectorLength vl = TR::VectorLength128;
+    TR::DataTypes elementType = TR::Int32;
+    TR::DataType vt = TR::DataType::createVectorType(elementType, vl);
+    
+    TR::ILOpCode vnotOp = TR::ILOpCode::createVectorOpCode(TR::vnot, vt);
+    TR::CPU cpu = TR::CPU::detect(privateOmrPortLibrary);
+    
+    SKIP_IF(!TR::CodeGenerator::getSupportsOpCodeForAutoSIMD(&cpu, vnotOp), MissingImplementation);
+    
+    char inputTrees[1024];
+    std::snprintf(inputTrees, sizeof(inputTrees),
+                  "(method return=NoType args=[Address,Address]"
+                  "  (block"
+                  "    (vstoreiVector128Int32 offset=0 (aload parm=0)"
+                  "      (vnotVector128Int32 (vloadiVector128Int32 (aload parm=1))))"
+                  "    (return)))");
+    
+    auto trees = parseString(inputTrees);
+    ASSERT_NOTNULL(trees);
+    
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile());
+    
+    uint32_t input[4] = {0xAAAAAAAA, 0x55555555, 0xAAAAAAAA, 0x55555555};
+    uint32_t expected[4] = {0x55555555, 0xAAAAAAAA, 0x55555555, 0xAAAAAAAA};
+    uint32_t result[4] = {0};
+    
+    auto entry_point = compiler.getEntryPoint<void(*)(void*, void*)>();
+    entry_point(result, input);
+    
+    for (int i = 0; i < 4; i++) {
+        EXPECT_EQ(expected[i], result[i]);
+    }
+}
+
+/**
+ * @brief Test vnot with Int32 elements - mixed pattern
+ */
+TEST_F(VnotTest, VnotInt32Mixed) {
+    TR::VectorLength vl = TR::VectorLength128;
+    TR::DataTypes elementType = TR::Int32;
+    TR::DataType vt = TR::DataType::createVectorType(elementType, vl);
+    
+    TR::ILOpCode vnotOp = TR::ILOpCode::createVectorOpCode(TR::vnot, vt);
+    TR::CPU cpu = TR::CPU::detect(privateOmrPortLibrary);
+    
+    SKIP_IF(!TR::CodeGenerator::getSupportsOpCodeForAutoSIMD(&cpu, vnotOp), MissingImplementation);
+    
+    char inputTrees[1024];
+    std::snprintf(inputTrees, sizeof(inputTrees),
+                  "(method return=NoType args=[Address,Address]"
+                  "  (block"
+                  "    (vstoreiVector128Int32 offset=0 (aload parm=0)"
+                  "      (vnotVector128Int32 (vloadiVector128Int32 (aload parm=1))))"
+                  "    (return)))");
+    
+    auto trees = parseString(inputTrees);
+    ASSERT_NOTNULL(trees);
+    
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile());
+    
+    uint32_t input[4] = {0x12345678, 0x9ABCDEF0, 0xFEDCBA98, 0x76543210};
+    uint32_t expected[4] = {0xEDCBA987, 0x6543210F, 0x01234567, 0x89ABCDEF};
+    uint32_t result[4] = {0};
+    
+    auto entry_point = compiler.getEntryPoint<void(*)(void*, void*)>();
+    entry_point(result, input);
+    
+    for (int i = 0; i < 4; i++) {
+        EXPECT_EQ(expected[i], result[i]);
+    }
+}
+
+/**
+ * @brief Test vnot with Int64 elements - all zeros
+ */
+TEST_F(VnotTest, VnotInt64AllZeros) {
+    TR::VectorLength vl = TR::VectorLength128;
+    TR::DataTypes elementType = TR::Int64;
+    TR::DataType vt = TR::DataType::createVectorType(elementType, vl);
+    
+    TR::ILOpCode vnotOp = TR::ILOpCode::createVectorOpCode(TR::vnot, vt);
+    TR::CPU cpu = TR::CPU::detect(privateOmrPortLibrary);
+    
+    SKIP_IF(!TR::CodeGenerator::getSupportsOpCodeForAutoSIMD(&cpu, vnotOp), MissingImplementation);
+    
+    char inputTrees[1024];
+    std::snprintf(inputTrees, sizeof(inputTrees),
+                  "(method return=NoType args=[Address,Address]"
+                  "  (block"
+                  "    (vstoreiVector128Int64 offset=0 (aload parm=0)"
+                  "      (vnotVector128Int64 (vloadiVector128Int64 (aload parm=1))))"
+                  "    (return)))");
+    
+    auto trees = parseString(inputTrees);
+    ASSERT_NOTNULL(trees);
+    
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile());
+    
+    uint64_t input[2] = {0};
+    uint64_t expected[2] = {0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF};
+    uint64_t result[2] = {0};
+    
+    auto entry_point = compiler.getEntryPoint<void(*)(void*, void*)>();
+    entry_point(result, input);
+    
+    for (int i = 0; i < 2; i++) {
+        EXPECT_EQ(expected[i], result[i]);
+    }
+}
+
+/**
+ * @brief Test vnot with Int64 elements - all ones
+ */
+TEST_F(VnotTest, VnotInt64AllOnes) {
+    TR::VectorLength vl = TR::VectorLength128;
+    TR::DataTypes elementType = TR::Int64;
+    TR::DataType vt = TR::DataType::createVectorType(elementType, vl);
+    
+    TR::ILOpCode vnotOp = TR::ILOpCode::createVectorOpCode(TR::vnot, vt);
+    TR::CPU cpu = TR::CPU::detect(privateOmrPortLibrary);
+    
+    SKIP_IF(!TR::CodeGenerator::getSupportsOpCodeForAutoSIMD(&cpu, vnotOp), MissingImplementation);
+    
+    char inputTrees[1024];
+    std::snprintf(inputTrees, sizeof(inputTrees),
+                  "(method return=NoType args=[Address,Address]"
+                  "  (block"
+                  "    (vstoreiVector128Int64 offset=0 (aload parm=0)"
+                  "      (vnotVector128Int64 (vloadiVector128Int64 (aload parm=1))))"
+                  "    (return)))");
+    
+    auto trees = parseString(inputTrees);
+    ASSERT_NOTNULL(trees);
+    
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile());
+    
+    uint64_t input[2] = {0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF};
+    uint64_t expected[2] = {0};
+    uint64_t result[2] = {0};
+    
+    auto entry_point = compiler.getEntryPoint<void(*)(void*, void*)>();
+    entry_point(result, input);
+    
+    for (int i = 0; i < 2; i++) {
+        EXPECT_EQ(expected[i], result[i]);
+    }
+}
+
+/**
+ * @brief Test vnot with Int64 elements - alternating pattern
+ */
+TEST_F(VnotTest, VnotInt64Alternating) {
+    TR::VectorLength vl = TR::VectorLength128;
+    TR::DataTypes elementType = TR::Int64;
+    TR::DataType vt = TR::DataType::createVectorType(elementType, vl);
+    
+    TR::ILOpCode vnotOp = TR::ILOpCode::createVectorOpCode(TR::vnot, vt);
+    TR::CPU cpu = TR::CPU::detect(privateOmrPortLibrary);
+    
+    SKIP_IF(!TR::CodeGenerator::getSupportsOpCodeForAutoSIMD(&cpu, vnotOp), MissingImplementation);
+    
+    char inputTrees[1024];
+    std::snprintf(inputTrees, sizeof(inputTrees),
+                  "(method return=NoType args=[Address,Address]"
+                  "  (block"
+                  "    (vstoreiVector128Int64 offset=0 (aload parm=0)"
+                  "      (vnotVector128Int64 (vloadiVector128Int64 (aload parm=1))))"
+                  "    (return)))");
+    
+    auto trees = parseString(inputTrees);
+    ASSERT_NOTNULL(trees);
+    
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile());
+    
+    uint64_t input[2] = {0xAAAAAAAAAAAAAAAA, 0x5555555555555555};
+    uint64_t expected[2] = {0x5555555555555555, 0xAAAAAAAAAAAAAAAA};
+    uint64_t result[2] = {0};
+    
+    auto entry_point = compiler.getEntryPoint<void(*)(void*, void*)>();
+    entry_point(result, input);
+    
+    for (int i = 0; i < 2; i++) {
+        EXPECT_EQ(expected[i], result[i]);
+    }
+}
+
+// Made with Bob


### PR DESCRIPTION
Added the opcode vnot and vmnot tree evaluators in the parent class inside codegen files.
Added vnot helper function and used under unaryVectorArithmeticEvaluator. 
Added new VnotTest.cpp unit test for testing proper vnot operations.
Signed-off-by: Zhuoyang Li <zhuoyli@ibm.com>