### PR TITLE
Handle removed edges in mergeDefConstraints in GVP

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -2246,6 +2246,22 @@ TR::VPConstraint *OMR::ValuePropagation::mergeDefConstraints(TR::Node *node, int
 
         sym = defNode->getSymbol();
         defValueNumber = getValueNumber(defNode);
+
+        if (node->getSymbol()->isAutoOrParm()
+            && _curDefinedOnAllPaths->get(defNode->getSymbolReference()->getReferenceNumber())
+            && !findStoreConstraint(defValueNumber, sym)) {
+            /*
+             * Def node has not been found and there are no backedge constraints to consider.
+             * This guarantees an unseen def so NULL is returned.
+             */
+            logprintf(trace(), log,
+                "   %s [%p] looking at def value %d, %s [%p]: no backedge constraints to consider. def was not "
+                "found.\n",
+                node->getOpCode().getName(), node, getValueNumber(defNode), defNode->getOpCode().getName(), defNode);
+
+            return NULL;
+        }
+
         // if we haven't seen a def on this iteration along all paths we must consider the backedge constraints
         if (node->getSymbol()->isAutoOrParm() && !unseenDefsFound
             && !_curDefinedOnAllPaths->get(defNode->getSymbolReference()->getReferenceNumber())) {
@@ -2530,11 +2546,11 @@ TR::VPConstraint *OMR::ValuePropagation::mergeDefConstraints(TR::Node *node, int
             }
         }
 
-        // check if there are unseen defs even after consulting
-        // backedge store constraints. don't return a
-        // constraint until all defs are seen
-        //
-        if (_loopInfo && lastTimeThrough() && unseenDefsFound)
+        /*
+         * Check if there are unseen defs even after consulting backedge store constraints.
+         * Return NULL if a def has not been found.
+         */
+        if (unseenDefsFound)
             return NULL;
     }
 


### PR DESCRIPTION
This modifies mergeDefConstraints in the Global Value Propagation opt to handle cases where a def node is not dead but can no longer reach the use node due to edges that have been removed from the CFG during GVP.

My changes add a new check to `mergeDefConstraints`.
If `_curDefinedOnAllPaths` is true at this point, all the defs on all paths to the use are known.
If `findStoreConstraint` is also false at this point then the def being looked at isn't one that was found.
This guarantees an unseen def so `NULL` is returned.

Prior to my change, `mergeDefConstraints` incorrectly assumes the def has been seen and processed at this point if `_curDefinedOnAllPaths` returns true which was incorrect.

It was possible to reach this point under those conditions if GVP removes all edges between a def and a use but the def is still alive due to a different use and there are no backedge defs of this use.

If backedges existed, it would enter the loop and realize it can't find the definition and then return NULL.