### PR TITLE
Add max abandon size to gc extensions

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -346,6 +346,7 @@ public:
 	uintptr_t tlhMaximumSize;
 	uintptr_t tlhInitialSize;
 	uintptr_t tlhIncrementSize;
+	uintptr_t tlhMaxAbandonSize; /**< cycle-average estimate of abandonSize (max(tlhMinimumSize, refreshSize/2)) across all threads, updated each GC by TLHAllocationSupport::restart() */
 	uintptr_t tlhSurvivorDiscardThreshold; /**< below this size GC (Scavenger) will discard survivor copy cache TLH, if alloc not succeeded (otherwise we reuse memory for next TLH) */
 	uintptr_t tlhTenureDiscardThreshold; /**< below this size GC (Scavenger) will discard tenure copy cache TLH, if alloc not succeeded (otherwise we reuse memory for next TLH) */
 
@@ -1573,6 +1574,10 @@ public:
 		, tlhMaximumSize(131072)
 		, tlhInitialSize(2048)
 		, tlhIncrementSize(4096)
+		, tlhMaxAbandonSize(tlhInitialSize * 3/8) /* seed: best estimate of tlhMaxAbandonSize before any GC has run, computed by applying the two-point average formula
+		                                           * in MM_TLHAllocationSupport::restart() to the initial state where every thread starts at refreshSize = tlhInitialSize.
+		                                           * Using the formula result rather than 0 ensures consumers active before the first GC see a realistic value,
+		                                           * and avoids seeding the OMR_MAX in restart() so high that early real updates would be silently suppressed. */
 		, tlhSurvivorDiscardThreshold(tlhMinimumSize)
 		, tlhTenureDiscardThreshold(tlhMinimumSize)
 		, allocationStats()

--- a/gc/base/TLHAllocationSupport.cpp
+++ b/gc/base/TLHAllocationSupport.cpp
@@ -98,25 +98,55 @@ MM_TLHAllocationSupport::clear(MM_EnvironmentBase *env)
 	_tlh->refreshSize = extensions->tlhInitialSize;
 }
 
+uintptr_t
+MM_TLHAllocationSupport::getThreadAbandonSize()
+{
+	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(_omrVMThread->_vm);
+	uintptr_t tlhMinimumSize = extensions->tlhMinimumSize;
+	uintptr_t halfRefreshSize = getRefreshSize() >> 1;
+
+	if (tlhMinimumSize > halfRefreshSize) {
+		return tlhMinimumSize;
+	} else {
+		return halfRefreshSize;
+	}
+}
+
 void
 MM_TLHAllocationSupport::restart(MM_EnvironmentBase *env)
 {
-	MM_GCExtensionsBase* extensions = env->getExtensions();
-	uintptr_t refreshSize;
+	MM_GCExtensionsBase *extensions = env->getExtensions();
 
 	/* Preserve the refresh size across the zeroing */
-	refreshSize = _tlh->refreshSize;
+	uintptr_t refreshSize = _tlh->refreshSize;
+
+	/* Update the global high-water mark of a realistic abandonSize estimate across all threads
+	 * (see tlhMaxAbandonSize seed value in GCExtensionsBase.hpp).
+	 * abandonSize for a thread is a function of its refresh size.
+	 *
+	 * The average is approximated from two sample points that bracket the cycle:
+	 *   1. Just before restart: refreshSize is at its peak (end of cycle),
+	 *   2. Just after restart: refreshSize has been reduced (start of next cycle),
+	 * The average of these two endpoints approximates the mean abandonSize over the cycle.
+	 *
+	 * Note: threadPeakAbandonSize must be captured before setAllZeroes() clears _tlh,
+	 * and the new refreshSize must be set before the second getThreadAbandonSize() call.
+	 */
+	uintptr_t threadPeakAbandonSize = getThreadAbandonSize();
 
 	/* Clear current information accumulated */
 	setAllZeroes();
 
 	_tlh->refreshSize = MM_Math::roundToCeiling(extensions->tlhInitialSize, refreshSize / 2);
+
+	uintptr_t threadAverageAbandonSize = (threadPeakAbandonSize + getThreadAbandonSize()) / 2;
+	extensions->tlhMaxAbandonSize = OMR_MAX(extensions->tlhMaxAbandonSize, threadAverageAbandonSize);
 }
 
 bool
 MM_TLHAllocationSupport::refresh(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, bool shouldCollectOnFailure)
 {
-	MM_GCExtensionsBase* extensions = env->getExtensions();
+	MM_GCExtensionsBase *extensions = env->getExtensions();
 	bool const compressed = extensions->compressObjectReferences();
 
 	/* Refresh the TLH only if the allocation request will fit in half the refresh size
@@ -125,8 +155,7 @@ MM_TLHAllocationSupport::refresh(MM_EnvironmentBase *env, MM_AllocateDescription
 	uintptr_t sizeInBytesRequired = allocDescription->getContiguousBytes();
 	uintptr_t tlhMinimumSize = extensions->tlhMinimumSize;
 	uintptr_t tlhMaximumSize = extensions->tlhMaximumSize;
-	uintptr_t halfRefreshSize = getRefreshSize() >> 1;
-	uintptr_t abandonSize = (tlhMinimumSize > halfRefreshSize ? tlhMinimumSize : halfRefreshSize);
+	uintptr_t abandonSize = getThreadAbandonSize();
 	if (sizeInBytesRequired > abandonSize) {
 		/* increase thread hungriness if we did not refresh */
 		if (getRefreshSize() < tlhMaximumSize && sizeInBytesRequired < tlhMaximumSize) {

--- a/gc/base/TLHAllocationSupport.hpp
+++ b/gc/base/TLHAllocationSupport.hpp
@@ -173,6 +173,13 @@ private:
 	 */
 	void reconnect(MM_EnvironmentBase *env);
 
+
+	/**
+	 *
+	 * Get calculated abandon size.
+	 */
+	uintptr_t getThreadAbandonSize();
+
 	/**
 	 * Restart the cache from its current start to an appropriate base state.
 	 * Reset the cache details back to a starting state that is appropriate for where it currently is.


### PR DESCRIPTION
This change adds an abandon size max variable to be used in future reporting.