### PR TITLE
AArch64: Implement vconvEvaluator

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -668,6 +668,10 @@ static const char *opCodeToNameMap[] = {
     "scvtf_wtod",
     "scvtf_xtos",
     "scvtf_xtod",
+    "vfcvtzs_stow4s",
+    "vfcvtzs_dtox2d",
+    "vscvtf_wtos4s",
+    "vscvtf_xtod2d",
     "fmovimms",
     "fmovimmd",
     "fcmps",
@@ -1584,7 +1588,7 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src1Instruction *instr)
     uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     log->printf("%s \t", getOpCodeName(&instr->getOpCode()));
 
-    if (op >= OP::fcvt_stod && op <= OP::scvtf_xtod) {
+    if (op >= OP::fcvt_stod && op <= OP::vscvtf_xtod2d) {
         TR_RegisterSizes regSize1 = TR_UnknownSizeReg; // trg register size
         TR_RegisterSizes regSize2 = TR_UnknownSizeReg; // src register size
         uint32_t sf = getSFbit(enc);
@@ -1601,6 +1605,9 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src1Instruction *instr)
         } else if (op >= OP::scvtf_wtos && op <= OP::scvtf_xtod) {
             regSize1 = getRegisterSizeFromFType(ftype);
             regSize2 = (sf == 1) ? TR_DoubleWordReg : TR_WordReg;
+        } else if (op >= OP::vfcvtzs_stow4s && op <= OP::vscvtf_xtod2d) {
+            regSize1 = TR_VectorReg128;
+            regSize2 = TR_VectorReg128;
         }
 
         print(log, instr->getTargetRegister(), regSize1);

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -712,6 +712,15 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
         case TR::vsqrt:
         case TR::vmsqrt:
             return (et == TR::Float || et == TR::Double);
+        case TR::vconv: {
+            // Expanding/contracting conversions are not supported
+            TR::DataType st = opcode.getVectorSourceDataType().getVectorElementType();
+            if ((st == TR::Int32 && et == TR::Float) || (st == TR::Int64 && et == TR::Double)
+                || (st == TR::Float && et == TR::Int32) || (st == TR::Double && et == TR::Int64))
+                return true;
+            else
+                return false;
+        }
         case TR::mand:
         case TR::mor:
         case TR::mxor:

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -670,6 +670,10 @@
 		scvtf_wtod,                                             	/* 0x1E620000	SCVTF     	 */
 		scvtf_xtos,                                             	/* 0x9E220000	SCVTF     	 */
 		scvtf_xtod,                                             	/* 0x9E620000	SCVTF     	 */
+		vfcvtzs_stow4s,                                         	/* 0x4EA1B800	FCVTZS    	 */
+		vfcvtzs_dtox2d,                                         	/* 0x4EE1B800	FCVTZS    	 */
+		vscvtf_wtos4s,                                          	/* 0x4E21D800	SCVTF     	 */
+		vscvtf_xtod2d,                                          	/* 0x4E61D800	SCVTF     	 */
 	/* Floating-Point Immediate */
 		fmovimms,                                               	/* 0x1E201000	FMOV      	 */
 		fmovimmd,                                               	/* 0x1E601000	FMOV      	 */

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -2975,7 +2975,23 @@ TR::Register *OMR::ARM64::TreeEvaluator::vcastEvaluator(TR::Node *node, TR::Code
 
 TR::Register *OMR::ARM64::TreeEvaluator::vconvEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+    TR::DataType st = node->getOpCode().getVectorSourceDataType().getVectorElementType();
+    TR::DataType et = node->getOpCode().getVectorResultDataType().getVectorElementType();
+    OP::Mnemonic convOp = OP::bad;
+
+    if (st == TR::Int32 && et == TR::Float) {
+        convOp = OP::vscvtf_wtos4s;
+    } else if (st == TR::Int64 && et == TR::Double) {
+        convOp = OP::vscvtf_xtod2d;
+    } else if (st == TR::Float && et == TR::Int32) {
+        convOp = OP::vfcvtzs_stow4s;
+    } else if (st == TR::Double && et == TR::Int64) {
+        convOp = OP::vfcvtzs_dtox2d;
+    } else {
+        TR_ASSERT_FATAL(false, "Unsupported type combination for vconv");
+    }
+
+    return inlineVectorUnaryOp(node, cg, convOp);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::vsetelemEvaluator(TR::Node *node, TR::CodeGenerator *cg)

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -675,6 +675,10 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
     0x1E620000, /* SCVTF     	scvtf_wtod	 */
     0x9E220000, /* SCVTF     	scvtf_xtos	 */
     0x9E620000, /* SCVTF     	scvtf_xtod	 */
+    0x4EA1B800, /* FCVTZS    	vfcvtzs_stow4s	 */
+    0x4EE1B800, /* FCVTZS    	vfcvtzs_dtox2d	 */
+    0x4E21D800, /* SCVTF     	vscvtf_wtos4s	 */
+    0x4E61D800, /* SCVTF     	vscvtf_xtod2d	 */
     /* Floating-Point Immediate */
     0x1E201000, /* FMOV      	fmovimms	 */
     0x1E601000, /* FMOV      	fmovimmd	 */

--- a/fvtest/compilertriltest/VectorTest.cpp
+++ b/fvtest/compilertriltest/VectorTest.cpp
@@ -995,3 +995,92 @@ INSTANTIATE_TEST_CASE_P(Long128ShiftRotateTest, BinaryDataDriven128Int64Test, ::
     std::make_tuple(TR::vrol, BinaryLongTest { { 30064771072, 4 }, { 0x70000000, 4}, { 4, 0 }, }),
     std::make_tuple(TR::vrol, BinaryLongTest { { 8, 2305843009213693953 }, { 8, 9}, { 64, -3 }, })
 )));
+
+typedef bool (*vconvEqFunc)(void *, void *);
+
+bool eq_f2i(void *pf, void *pi)
+{
+    return (static_cast<int32_t>(*static_cast<float *>(pf)) == *static_cast<int32_t *>(pi));
+}
+bool eq_i2f(void *pi, void *pf)
+{
+    return (static_cast<float>(*static_cast<int32_t *>(pi)) == *static_cast<float *>(pf));
+}
+bool eq_d2l(void *pd, void *pl)
+{
+    return (static_cast<int64_t>(*static_cast<double *>(pd)) == *static_cast<int64_t *>(pl));
+}
+bool eq_l2d(void *pl, void *pd)
+{
+    return (static_cast<double>(*static_cast<int64_t *>(pl)) == *static_cast<double *>(pd));
+}
+
+class ParameterizedVectorConvTest : public VectorTest, public ::testing::WithParamInterface<std::tuple<TR::DataTypes, TR::DataTypes, vconvEqFunc>> {};
+
+TEST_P(ParameterizedVectorConvTest, Vector128ConvTest) {
+    // Assuming VectorLength128 and conversion between types of same size only
+    TR::DataTypes sourceType = std::get<0>(GetParam());
+    TR::DataTypes resultType = std::get<1>(GetParam());
+    vconvEqFunc fn = std::get<2>(GetParam());
+
+    int sourceTypeSize = TRTest::typeSize(sourceType);
+    int resultTypeSize = TRTest::typeSize(resultType);
+    ASSERT_NE(sourceType, resultType);
+    ASSERT_EQ(sourceTypeSize, resultTypeSize);
+
+    char sourceTypeName[8];
+    char resultTypeName[8];
+    char inputTrees[1024];
+
+    std::snprintf(sourceTypeName, sizeof(sourceTypeName), "%s", TR::DataType::getName(sourceType));
+    std::snprintf(resultTypeName, sizeof(resultTypeName), "%s", TR::DataType::getName(resultType));
+    std::snprintf(inputTrees, sizeof(inputTrees),
+                  "(method return= NoType args=[Address,Address] "
+                  "  (block                                      "
+                  "    (vstoreiVector128%s offset=0              "
+                  "      (aload parm=0)                          "
+                  "        (vconvVector128%s_Vector128%s         "
+                  "          (vloadiVector128%s (aload parm=1))))"
+                  "    (return)))                                ",
+                  resultTypeName, sourceTypeName, resultTypeName, sourceTypeName);
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+    SKIP_ON_RISCV(MissingImplementation);
+    SKIP_ON_X86(MissingImplementation);
+    SKIP_ON_HAMMER(MissingImplementation);
+    if (!(sourceType == TR::Int64 && resultType == TR::Double)) {
+        SKIP_ON_POWER(MissingImplementation);
+        SKIP_ON_S390(MissingImplementation);
+        SKIP_ON_S390X(MissingImplementation);
+    }
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<void (*)(void *, void *)>();
+
+    int8_t output[16] = { 0 };
+    int8_t input[16];
+
+    for (int32_t i = 0; i < sizeof(input)/sourceTypeSize; i++) {
+        int32_t offset = sourceTypeSize * i;
+        TRTest::generateByType(input + offset, sourceType, false);
+    }
+
+    entry_point(output, input);
+
+    for (int32_t i = 0; i < sizeof(input)/sourceTypeSize; i++) {
+        int32_t offset = sourceTypeSize * i;
+        EXPECT_TRUE(fn(input + offset, output + offset));
+    }
+
+}
+
+INSTANTIATE_TEST_CASE_P(Vector128Conv, ParameterizedVectorConvTest, ::testing::ValuesIn(*TRTest::MakeVector<std::tuple<TR::DataTypes, TR::DataTypes, vconvEqFunc>>(
+    std::make_tuple(TR::Int32, TR::Float, eq_i2f),
+    std::make_tuple(TR::Float, TR::Int32, eq_f2i),
+    std::make_tuple(TR::Int64, TR::Double, eq_l2d),
+    std::make_tuple(TR::Double, TR::Int64, eq_d2l)
+)));


### PR DESCRIPTION
This commit implements vconvEvaluator for AArch64 for limited type combinations.
It also adds testcases for vconv.