### PR TITLE
OMR changes for recompiling method in the face of phase change

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1314,6 +1314,8 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
      SET_OPTION_BIT(TR_EnableRATPurging), "F" },
     { "enableReassociation", "O\tapply reassociation rules in Simplifier", SET_OPTION_BIT(TR_EnableReassociation),
      "F" },
+    { "enableRecompDueToPatchedNopableGuards",
+     "O\tRecompile high optimization compiles if the nopable guard has been patched", SET_OPTION_BIT(TR_EnableRecompDueToPatchedNopableGuards), "F" },
     { "enableRecompilationPushing", "O\tenable pushing methods to be recompiled",
      SET_OPTION_BIT(TR_EnableRecompilationPushing), "F" },
     { "enableRefinedAliases",

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -813,7 +813,7 @@ enum TR_CompilationOptions {
     TR_UseHigherMethodCounts                                 = 0x00000020 + 24,
     TR_FullInlineUnderOSRDebug                               = 0x00000040 + 24,
     TR_DisablePRBE                                           = 0x00000080 + 24,
-    // Available                                             = 0x00000100 + 24,
+    TR_EnableRecompDueToPatchedNopableGuards                 = 0x00000100 + 24,
     TR_X86HLE                                                = 0x00000200 + 24,
     TR_DisableAdaptiveDumbInliner                            = 0x00000400 + 24,
     // Available                                             = 0x00000800 + 24,

--- a/compiler/control/OptimizationPlan.hpp
+++ b/compiler/control/OptimizationPlan.hpp
@@ -138,6 +138,10 @@ public:
 
     void setInsertPatchableJProfiling(bool b) { _flags.set(InsertPatchableJProfiling, b); }
 
+    bool getDoNotInsertPhaseChangeRecomp() const { return _flags.testAny(DoNotInsertPhaseChangeRecomp); }
+
+    void setDoNotInsertPhaseChangeRecomp(bool b) { _flags.set(DoNotInsertPhaseChangeRecomp, b); }
+
     // Insert epilogue yieldpoints if the method is being sampled
     bool getInsertEpilogueYieldpoints() const { return _flags.testAny(UseSampling); }
 
@@ -287,6 +291,8 @@ public:
         InducedByDLT = 0x00800000, // Compilation that follows a DLT compilation
         DisableEDO = 0x01000000, // Do not insert EDO profiling trees for this compilation
         InsertPatchableJProfiling = 0x02000000, // Insert patchable JProfiling trees for this compilation
+        DoNotInsertPhaseChangeRecomp
+            = 0x04000000, // Do not insert a test in cold blocks to detect phase change and trigger recompilation
     };
 
 private:


### PR DESCRIPTION
Changes in this PR adds option to enable recompilation of method in the face of phase change and also adds a flag in the optimization plan so that further recompilation due to same reason of the method can be prevented.