### PR TITLE
Introduce coldPathRecompTriggerCounterSymbol

### DIFF
--- a/compiler/compile/OMRNonHelperSymbols.enum
+++ b/compiler/compile/OMRNonHelperSymbols.enum
@@ -80,6 +80,7 @@
    osrScratchBufferSymbol,    //osrScratchBuffer slot on  j9vmthread
    osrFrameIndexSymbol,       // osrFrameIndex slot on j9vmthread
    osrReturnAddressSymbol,       // osrFrameIndex slot on j9vmthread
+   coldPathRecompTriggerCounterSymbol,
 
    /** \brief
     *

--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -476,6 +476,19 @@ TR::SymbolReference *OMR::SymbolReferenceTable::createRefinedArrayShadowSymbolRe
     return newRef;
 }
 
+TR::SymbolReference *OMR::SymbolReferenceTable::findOrCreateColdPathRecompTriggerCounterSymbolRef(void *counterAddress)
+{
+    if (!element(coldPathRecompTriggerCounterSymbol)) {
+        TR::StaticSymbol *sym = TR::StaticSymbol::create(trHeapMemory(), TR::Int32);
+        sym->setStaticAddress(counterAddress);
+        sym->setNotDataAddress();
+        sym->setRecompilationCounter();
+        element(coldPathRecompTriggerCounterSymbol)
+            = new (trHeapMemory()) TR::SymbolReference(self(), coldPathRecompTriggerCounterSymbol, sym);
+    }
+    return element(coldPathRecompTriggerCounterSymbol);
+}
+
 TR::SymbolReference *OMR::SymbolReferenceTable::findOrCreateRecompilationCounterSymbolRef(void *counterAddress)
 {
     if (!element(recompilationCounterSymbol)) {

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -150,7 +150,7 @@ public:
         osrFrameIndexSymbol, // osrFrameIndex slot on j9vmthread
         osrReturnAddressSymbol, // osrFrameIndex slot on j9vmthread
         contiguousArrayDataAddrFieldSymbol, // dataAddr field symbol used to track data portion of the array
-
+        coldPathRecompTriggerCounterSymbol,
         /** \brief
          *
          *  A call with this symbol marks a place in the jitted code where OSR transition to the VM interpreter is
@@ -778,7 +778,7 @@ public:
 
     // base recompilation
     TR::SymbolReference *findOrCreateRecompilationCounterSymbolRef(void *counterAddress);
-
+    TR::SymbolReference *findOrCreateColdPathRecompTriggerCounterSymbolRef(void *counterAddress);
     TR::SymbolReference *findOrCreateMethodSymbol(mcount_t owningMethodIndex, int32_t cpIndex, TR_ResolvedMethod *,
         TR::MethodSymbol::Kinds, bool = false);
     TR::SymbolReference *findOrCreateComputedStaticMethodSymbol(mcount_t owningMethodIndex, int32_t cpIndex,

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1415,6 +1415,8 @@ const char *TR_Debug::getName(TR::SymbolReference *symRef)
                 return "<this-range-extension>";
             case TR::SymbolReferenceTable::recompilationCounterSymbol:
                 return "<recompilation-counter>";
+            case TR::SymbolReferenceTable::coldPathRecompTriggerCounterSymbol:
+                return "<cold-path-recomp-trigger-counter>";
             case TR::SymbolReferenceTable::counterAddressSymbol:
                 return "<recompilation-counter-address>";
             case TR::SymbolReferenceTable::countForRecompileSymbol:
@@ -1845,28 +1847,28 @@ const char *TR_Debug::getStaticName(TR::SymbolReference *symRef)
 }
 
 // Note: This array needs to match up with what is in compile/SymbolReferenceTable.hpp
-static const char *commonNonhelperSymbolNames[]
-    = { "<contiguousArraySize>", "<discontiguousArraySize>", "<arrayClassRomPtr>", "<classRomPtr>",
-          "<javaLangClassFromClass>", "<classFromJavaLangClass>", "<addressOfClassOfMethod>", "<ramStaticsFromClass>",
-          "<componentClass>", "<componentClassAsPrimitive>", "<isArray>", "<isClassDepthAndFlags>",
-          "<initializeStatusFromClass>", "<isClassFlags>", "<vft>", "<currentThread>", "<recompilationCounter>",
-          "<excp>", "<indexableSize>", "<resolveCheck>", "<arrayTranslate>", "<arrayTranslateAndTest>", "<long2String>",
-          "<bitOpMem>", "<reverseLoad>", "<reverseStore>", "<currentTimeMaxPrecision>", "<encodeASCII>",
-          "<headerFlags>", "<singlePrecisionSQRT>", "<threadPrivateFlags>", "<arrayletSpineFirstElement>", "<dltBlock>",
-          "<countForRecompile>", "<gcrPatchPoint>", "<counterAddress>", "<startPC>", "<compiledMethod>",
-          "<thisRangeExtension>", "<profilingBufferCursor>", "<profilingBufferEnd>", "<profilingBuffer>", "<osrBuffer>",
-          "<osrScratchBuffer>", "<osrFrameIndex>", "<osrReturnAddress>", "<contiguousArrayDataAddrField>",
-          "<potentialOSRPointHelper>", "<osrFearPointHelper>", "<eaEscapeHelper>", "<lowTenureAddress>",
-          "<highTenureAddress>", "<fragmentParent>", "<globalFragment>", "<instanceShape>", "<instanceDescription>",
-          "<descriptionWordFromPtr>", "<classFromJavaLangClassAsPrimitive>", "<javaVM>", "<heapBase>", "<heapTop>",
-          "<j9methodExtraField>", "<j9methodConstantPoolField>", "<startPCLinkageInfo>", "<instanceShapeFromROMClass>",
-          "<objectEqualityComparison>", "<objectInequalityComparison>", "<nonNullableArrayNullStoreCheck>",
-          "<loadFlattenableArrayElementNonHelper>", "<storeFlattenableArrayElementNonHelper>", "<isIdentityObject>",
-          "<synchronizedFieldLoad>", "<atomicAdd>", "<atomicFetchAndAdd>", "<atomicFetchAndAdd32Bit>",
-          "<atomicFetchAndAdd64Bit>", "<atomicSwap>", "<atomicSwap32Bit>", "<atomicSwap64Bit>",
-          "<atomicCompareAndSwapReturnStatus>", "<atomicCompareAndSwapReturnValue>", "<jProfileValueSymbol>",
-          "<jProfileValueWithNullCHKSymbol>", "<j9VMThreadTempSlotField>", "<computedStaticCallSymbol>",
-          "<j9VMThreadFloatTemp1>", "<J9JNIMethodIDvTableIndexFieldSymbol>", "<jitDispatchJ9Method>" };
+static const char *commonNonhelperSymbolNames[] = { "<contiguousArraySize>", "<discontiguousArraySize>",
+    "<arrayClassRomPtr>", "<classRomPtr>", "<javaLangClassFromClass>", "<classFromJavaLangClass>",
+    "<addressOfClassOfMethod>", "<ramStaticsFromClass>", "<componentClass>", "<componentClassAsPrimitive>", "<isArray>",
+    "<isClassDepthAndFlags>", "<initializeStatusFromClass>", "<isClassFlags>", "<vft>", "<currentThread>",
+    "<recompilationCounter>", "<excp>", "<indexableSize>", "<resolveCheck>", "<arrayTranslate>",
+    "<arrayTranslateAndTest>", "<long2String>", "<bitOpMem>", "<reverseLoad>", "<reverseStore>",
+    "<currentTimeMaxPrecision>", "<encodeASCII>", "<headerFlags>", "<singlePrecisionSQRT>", "<threadPrivateFlags>",
+    "<arrayletSpineFirstElement>", "<dltBlock>", "<countForRecompile>", "<gcrPatchPoint>", "<counterAddress>",
+    "<startPC>", "<compiledMethod>", "<thisRangeExtension>", "<profilingBufferCursor>", "<profilingBufferEnd>",
+    "<profilingBuffer>", "<osrBuffer>", "<osrScratchBuffer>", "<osrFrameIndex>", "<osrReturnAddress>",
+    "<contiguousArrayDataAddrField>", "<coldPathRecompTriggerCounterSymbol>", "<potentialOSRPointHelper>",
+    "<osrFearPointHelper>", "<eaEscapeHelper>", "<lowTenureAddress>", "<highTenureAddress>", "<fragmentParent>",
+    "<globalFragment>", "<instanceShape>", "<instanceDescription>", "<descriptionWordFromPtr>",
+    "<classFromJavaLangClassAsPrimitive>", "<javaVM>", "<heapBase>", "<heapTop>", "<j9methodExtraField>",
+    "<j9methodConstantPoolField>", "<startPCLinkageInfo>", "<instanceShapeFromROMClass>", "<objectEqualityComparison>",
+    "<objectInequalityComparison>", "<nonNullableArrayNullStoreCheck>", "<loadFlattenableArrayElementNonHelper>",
+    "<storeFlattenableArrayElementNonHelper>", "<isIdentityObject>", "<synchronizedFieldLoad>", "<atomicAdd>",
+    "<atomicFetchAndAdd>", "<atomicFetchAndAdd32Bit>", "<atomicFetchAndAdd64Bit>", "<atomicSwap>", "<atomicSwap32Bit>",
+    "<atomicSwap64Bit>", "<atomicCompareAndSwapReturnStatus>", "<atomicCompareAndSwapReturnValue>",
+    "<jProfileValueSymbol>", "<jProfileValueWithNullCHKSymbol>", "<j9VMThreadTempSlotField>",
+    "<computedStaticCallSymbol>", "<j9VMThreadFloatTemp1>", "<J9JNIMethodIDvTableIndexFieldSymbol>",
+    "<jitDispatchJ9Method>" };
 
 const char *TR_Debug::getShadowName(TR::SymbolReference *symRef)
 {


### PR DESCRIPTION
Introduce a new non-helper symbol, coldPathRecompTriggerCounterSymbol,
and its associated findOrCreateColdPathRecompTriggerCounterSymbolRef()
factory method. The symbol references an Int32 static counter used to
track how many times a perceived cold path has been reached in jitted
code.
