### PR TITLE
Fix isZiipSMTEnabled to correctly detect SMT-2 on z/OS

### DIFF
--- a/port/zos390/omrsimap.h
+++ b/port/zos390/omrsimap.h
@@ -97,11 +97,11 @@ typedef struct J9CCT {
  * Resources Manager Control Table Extension 3 (RMCTX3). Also known as IRARMCTZ.
  *
  * Fields of interest:
- *    RMCTZ_MT_zIIP - bit indicating whether SMT-2 is enabled for zIIP processors
+ *    RMCTZ_MT_zIIP - Thread count per zIIP core, 1 for SMT-1 and 2 for SMT-2
  */
 typedef struct J9IRARMCTZ {
 	uint8_t rmctzFiller[1270];        /**< 0:1270 Ignore fields not relevant to current implementation */
-	uint8_t rmctz_mt_ziip;            /**< 1270:1 bit indicating whether SMT-2 is enabled for zIIP processors */
+	uint8_t rmctz_mt_ziip;            /**< 1270:1 Thread count per zIIP core */
 	/**< Ignore rest of the RMCT Extension 3 */
 } J9IRARMCTZ;
 

--- a/port/zos390/omrsysinfo_helpers.c
+++ b/port/zos390/omrsysinfo_helpers.c
@@ -201,17 +201,17 @@ isIipHonorPrioritySet(struct OMRPortLibrary *portLibrary)
 }
 
 BOOLEAN
-isSMTEnabled(void)
+isZiipSMTEnabled(void)
 {
 	J9CVT * __ptr32 cvtp = ((J9PSA *)0)->flccvt;
-	return (0 != cvtp->cvtopctp->rmctirarmctz->rmctz_mt_ziip) ? TRUE : FALSE;
+	return (2 == cvtp->cvtopctp->rmctirarmctz->rmctz_mt_ziip) ? TRUE : FALSE;
 }
 
 double
 retrieveZosZiipCapacity(void)
 {
 	double ziipCount = retrieveZosOnlineZiipCount();
-	if (isSMTEnabled()) {
+	if (isZiipSMTEnabled()) {
 		ziipCount *= SMT_2_GAIN_FACTOR;
 	}
 	return ziipCount;
@@ -228,7 +228,7 @@ retrieveZosOnlineZiipCount(void)
 	 * online_zIIP_count already accounts for SMT-2 by returning
 	 * double the actual number of physical zIIP engines.
 	 */
-	if (isSMTEnabled()) {
+	if (isZiipSMTEnabled()) {
 		ziipCount = (ziipCount + 1) / 2;
 	}
 	return ziipCount;

--- a/port/zos390/omrsysinfo_helpers.h
+++ b/port/zos390/omrsysinfo_helpers.h
@@ -94,13 +94,13 @@ BOOLEAN
 isIipHonorPrioritySet(struct OMRPortLibrary *portLibrary);
 
 /**
- * Indicate whether simultaneous multithreading (SMT) is enabled. When enabled,
- * each zIIP engine provides two logical processors.
+ * Indicate whether simultaneous multithreading (SMT) is enabled for zIIPs. When
+ * enabled, each zIIP engine provides two logical processors.
  *
  * @return TRUE if multithreading is enabled and FALSE otherwise
  */
 BOOLEAN
-isSMTEnabled(void);
+isZiipSMTEnabled(void);
 
 /**
  * Return the available zIIP capacity. For SMT-1, this matches the online zIIP


### PR DESCRIPTION
The RMCTZ_MT_zIIP field in J9IRARMCTZ holds the thread count per zIIP core (1 = SMT-1, 2 = SMT-2), not a boolean flag. The previous check != 0 returned TRUE for both SMT-1 and SMT-2.

On SMT-1 z/OS systems, isZiipSMTEnabled() incorrectly returned TRUE, which caused a cascade of incorrect calculations:

1. retrieveZosOnlineZiipCount() — halved the online zIIP count, under-reporting the number of available zIIP engines.
2. retrieveZosZiipCapacity() — applied SMT_2_GAIN_FACTOR to the already-halved count, compounding the error and producing an incorrect (too low) zIIP capacity value.
3. retrieveZosCpuCapacity() / omrsysinfo_get_CPU_capacity() — consumed the wrong ziipCapacity, producing an incorrect total CPU capacity.
4. CpuUtilization::update() on z/OS — computes _cpuIdle = 100.0 * cpuCapacity * cpuIdle, so the underestimated capacity fed directly into the idle CPU metric.
5. computeCpuLoadFactor() in the JIT sampler thread — uses cpuIdle to decide whether the JVM is CPU-starved. With cpuIdle artificially low, the JIT could incorrectly classify the JVM as starved, causing it to throttle compilation threads unnecessarily and degrading JIT throughput.