### PR TITLE
Misc. cleanup and refactoring for x86 MemoryReferences

### DIFF
--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -58,9 +58,6 @@ class Machine;
 #define MAX_MEMREF_SIZE (6) // ModRM + SIB + disp32
 #define MAX_INSTRUCTION_SIZE (15) // See x86-64 processor manual vol 3 sec 1.1
 
-// Hack markers
-#define REGISTERS_CAN_CHANGE_AFTER_INITIALIZATION (true)
-
 OMR::X86::AMD64::MemoryReference::MemoryReference(TR::CodeGenerator *cg)
     : OMR::X86::MemoryReference(cg)
     , _forceRIPRelative(false)
@@ -367,21 +364,7 @@ void OMR::X86::AMD64::MemoryReference::assignRegisters(TR::Instruction *currentI
 uint32_t OMR::X86::AMD64::MemoryReference::estimateBinaryLength(TR::Instruction *containingInstruction,
     TR::CodeGenerator *cg)
 {
-    uint32_t estimate;
-
-    if (0 && REGISTERS_CAN_CHANGE_AFTER_INITIALIZATION && getBaseRegister() && getIndexRegister() && _addressRegister) {
-        // We thought we might need _addressRegister during initialization
-        // because _baseRegister or _indexRegister NULL.  However, someone
-        // subsequently changed the registers, and we can't handle
-        // [base+index+disp64] anyway, so don't even try.
-        //
-        // TODO:AMD64: Always pass the regs in the constructor, rather than using
-        // the vanilla constructor and setting the regs afterward.
-        //
-        _addressRegister = NULL;
-    }
-
-    estimate = OMR::X86::MemoryReference::estimateBinaryLength(containingInstruction, cg);
+    uint32_t estimate = OMR::X86::MemoryReference::estimateBinaryLength(containingInstruction, cg);
 
     // For [disp32], AMD64 needs a SIB byte
     //

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -272,9 +272,14 @@ bool OMR::X86::AMD64::MemoryReference::needsAddressLoadInstruction(intptr_t next
         return !IS_32BIT_SIGNED(displacement);
     }
 
-    // At this point, the memory reference is known not to have a base or index register.
-    // The remaining logic determines how to interpret the displacement.
+    // At this point, the memory reference is known not to have a base or index register
+    // (a displacement only).
     //
+    // The displacement holds an address in memory, and the remaining logic determines
+    // whether a 64-bit immediate load instruction is required to materialize the address.
+    // If not, the address is materialized through either a 32-bit RIP-relative form or
+    // a 32-bit absolute form.
+
     if (cg->needClassAndMethodPointerRelocations()) {
         return true;
     }
@@ -296,7 +301,11 @@ bool OMR::X86::AMD64::MemoryReference::needsAddressLoadInstruction(intptr_t next
 
     if (IS_32BIT_SIGNED(displacement)) {
         return false;
-    } else if (cg->comp()->isOutOfProcessCompilation() && sym && sym->isStatic()
+    }
+
+    // At this point, the displacement is known to be 64-bit
+
+    if (cg->comp()->isOutOfProcessCompilation() && sym && sym->isStatic()
         && !sym->isStaticAddressWithinMethodBounds()) {
         return true;
     } else if (IS_32BIT_RIP(displacement, nextInstructionAddress)) {

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -181,15 +181,15 @@ void OMR::X86::AMD64::MemoryReference::finishInitialization(TR::CodeGenerator *c
         // Binary encoding will fatally assert otherwise.
         //
         mightNeedAddressRegister = false;
-    } else if (getDataSnippet()) {
-        // Assume snippets are in RIP range
-        //
-        mightNeedAddressRegister = false;
     } else if (!getBaseRegister() && !getIndexRegister()
         && (cg->needRelocationsForStatics() || cg->needClassAndMethodPointerRelocations()
             || cg->needRelocationsForBodyInfoData() || cg->needRelocationsForPersistentInfoData()
             || cg->needRelocationsForPersistentProfileInfoData())) {
         mightNeedAddressRegister = true;
+    } else if (getLabel()) {
+        // Assume labels are in RIP range
+        //
+        mightNeedAddressRegister = false;
     } else if (sr.getSymbol() != NULL
         && (sr.isUnresolved() || (sr.stackAllocatedArrayAccess() && !IS_32BIT_SIGNED(getDisplacement())))) {
         // Once resolved, the address could be anything, so be conservative.
@@ -516,8 +516,8 @@ uint8_t *OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(uint8_t *modRM
             "malformed memory reference for RIP-relative addressing");
     }
 
-    if (getDataSnippet() || getLabel()) {
-        // The inherited logic has a special case for RIP-based ConstantDataSnippet and label references.
+    if (getLabel()) {
+        // The inherited logic has a special case for RIP-based label references.
         //
         return OMR::X86::MemoryReference::generateBinaryEncoding(modRM, containingInstruction, cg);
     }

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -854,7 +854,7 @@ uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::Instruction *contai
             }
             if (displacement == 0 && !base->needsDisp() && !base->needsSIB() && !isForceWideDisplacement()) {
                 length = 0;
-            } else if (displacement >= -128 && displacement <= 127 && !isForceWideDisplacement()) {
+            } else if (IS_8BIT_SIGNED(displacement) && !isForceWideDisplacement()) {
                 length = 1;
             } else {
                 // If there is a symbol or if the displacement will not fit in a byte,
@@ -877,7 +877,7 @@ uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::Instruction *contai
                 length = 5;
                 break;
             }
-            if (displacement >= -128 && displacement <= 127 && !isForceWideDisplacement()) {
+            if (IS_8BIT_SIGNED(displacement) && !isForceWideDisplacement()) {
                 length = 2;
             } else {
                 // If there is a symbol or if the displacement will not fit in a byte,
@@ -943,7 +943,7 @@ uint32_t OMR::X86::MemoryReference::getBinaryLengthLowerBound(TR::CodeGenerator 
 
             if (displacement == 0 && !base->needsDisp() && !base->needsSIB() && !isForceWideDisplacement()) {
                 length = 0;
-            } else if (displacement >= -128 && displacement <= 127 && !isForceWideDisplacement()) {
+            } else if (IS_8BIT_SIGNED(displacement) && !isForceWideDisplacement()) {
                 if (displacement != 0)
                     length = 1;
             } else
@@ -1196,7 +1196,7 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
 
             immediateCursor = cursor;
 
-            *(int32_t *)cursor = (int32_t)getSymbolReference().getOffset();
+            *(int32_t *)cursor = static_cast<int32_t>(getSymbolReference().getOffset());
 
             if (getUnresolvedDataSnippet() != NULL) {
                 getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
@@ -1233,34 +1233,32 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
             immediateCursor = cursor;
 
             if (symbol) {
-                TR::StaticSymbol *staticSym = symbol->getStaticSymbol();
-
-                if (staticSym) {
-                    if (getUnresolvedDataSnippet() == NULL) {
-                        *(int32_t *)cursor
-                            = (int32_t)(getSymbolReference().getOffset() + (intptr_t)staticSym->getStaticAddress());
-                    } else {
-                        *(int32_t *)cursor = (int32_t)getSymbolReference().getOffset();
-                    }
-                } else if (symbol->isShadow()) {
-                    *(int32_t *)cursor = (int32_t)getSymbolReference().getOffset();
-                } else
-                    TR_ASSERT(0, "generateBinaryEncoding, new symbol hierarchy problem");
+                displacement = getDisplacement();
+                TR_ASSERT_FATAL(IS_32BIT_SIGNED(displacement),
+                    "MR_disp symbol displacement out of range: %" OMR_PRIxPTR, displacement);
             } else {
                 if (getLabel()) {
+                    // The MemoryReference for a Label is an address in the code cache within this
+                    // compilation unit. Because the address of labels appearing in the code after
+                    // this memory reference has not been determined yet, use the relocation
+                    // mechanism to patch it in after binary encoding. For 64-bit targets, RIP-relative
+                    // addressing is used (relative relocation), but for 32-bit targets the absolute
+                    // address of the label is used (absolute relocation).
+                    //
                     if (comp->target().is64Bit()) {
-                        // This cast is ok because we only need the low 32 bits of the address
-                        // *(int32_t *)cursor = -(int32_t)(intptr_t)(cursor+4);
-                        // if it is X86MEMIMM instruction, offset need consider immedidate length
-                        *(int32_t *)cursor = -(
+                        displacement = -(
                             int32_t)(intptr_t)(cursor + 4 + containingInstruction->getOpCode().info().ImmediateSize());
                     } else {
-                        *(int32_t *)cursor = (int32_t)0;
+                        displacement = 0;
                     }
                 } else {
-                    *(int32_t *)cursor = (int32_t)getSymbolReference().getOffset();
+                    displacement = getSymbolReference().getOffset();
+                    TR_ASSERT_FATAL(IS_32BIT_SIGNED(displacement),
+                        "MR_disp no symbol no label displacement out of range: %" OMR_PRIxPTR, displacement);
                 }
             }
+
+            *(int32_t *)cursor = static_cast<int32_t>(displacement);
 
             if (getUnresolvedDataSnippet() != NULL) {
                 getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
@@ -1296,10 +1294,9 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
 
             if (displacement == 0 && !base->needsDisp() && !base->needsDisp() && !isForceWideDisplacement()) {
                 ModRM(modRM)->setBase();
-            } else if (displacement >= -128 && displacement <= 127 && !isForceWideDisplacement()) {
+            } else if (IS_8BIT_SIGNED(displacement) && !isForceWideDisplacement()) {
                 ModRM(modRM)->setBaseDisp8();
-                *cursor = (uint8_t)displacement;
-                ++cursor;
+                *(int8_t *)cursor++ = static_cast<int8_t>(displacement);
             } else {
                 // If there is a symbol or if the displacement will not fit in a byte,
                 // then displacement will be 4 bytes.
@@ -1324,9 +1321,9 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
             index->setIndexRegisterFieldInSIB(cursor);
             setStrideFieldInSIB(cursor);
             ++cursor;
-            displacement = getDisplacement();
             immediateCursor = cursor;
 
+            displacement = getDisplacement();
             TR_ASSERT(IS_32BIT_SIGNED(displacement),
                 "64-bit displacement should have been replaced in TR_AMD64MemoryReference::generateBinaryEncoding");
 
@@ -1337,15 +1334,15 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
                 setForceWideDisplacement();
             }
 
-            if (displacement >= -128 && displacement <= 127 && !isForceWideDisplacement()) {
+            if (IS_8BIT_SIGNED(displacement) && !isForceWideDisplacement()) {
                 ModRM(modRM)->setBaseDisp8()->setHasSIB();
-                *cursor++ = (uint8_t)displacement;
+                *(int8_t *)cursor++ = static_cast<int8_t>(displacement);
             } else {
                 // If there is a symbol or if the displacement will not fit in a byte,
                 // then displacement will be 4 bytes.
                 //
                 ModRM(modRM)->setBaseDisp32()->setHasSIB();
-                *(int32_t *)cursor = (int32_t)displacement;
+                *(int32_t *)cursor = static_cast<int32_t>(displacement);
                 if (getUnresolvedDataSnippet() != NULL) {
                     getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
                 }

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -126,10 +126,10 @@ OMR::X86::MemoryReference::MemoryReference(TR::SymbolReference *symRef, TR::Code
     , _flags(0)
     , _reloKind(-1)
 {
-    self()->initialize(symRef, cg);
+    self()->initializeFromSymRef(symRef, cg);
 }
 
-OMR::X86::MemoryReference::MemoryReference(TR::SymbolReference *symRef, intptr_t displacement, TR::CodeGenerator *cg)
+OMR::X86::MemoryReference::MemoryReference(TR::SymbolReference *symRef, intptr_t extraOffset, TR::CodeGenerator *cg)
     : _baseRegister(NULL)
     , _baseNode(NULL)
     , _indexRegister(NULL)
@@ -141,8 +141,8 @@ OMR::X86::MemoryReference::MemoryReference(TR::SymbolReference *symRef, intptr_t
     , _flags(0)
     , _reloKind(-1)
 {
-    self()->initialize(symRef, cg);
-    _symbolReference.addToOffset(displacement);
+    self()->initializeFromSymRef(symRef, cg);
+    _symbolReference.addToOffset(extraOffset);
 }
 
 // Constructor called to generate a memory reference for all kinds of
@@ -164,96 +164,93 @@ OMR::X86::MemoryReference::MemoryReference(TR::Node *rootLoadOrStore, TR::CodeGe
     TR::SymbolReference *symRef = rootLoadOrStore->getSymbolReference();
     TR::Compilation *comp = cg->comp();
 
-    if (symRef) {
-        TR::Symbol *symbol = symRef->getSymbol();
+    TR_ASSERT_FATAL_WITH_NODE(rootLoadOrStore, symRef, "Expecting node to have a symRef");
 
-        bool isStore = rootLoadOrStore->getOpCode().isStore();
-        bool isUnresolved = symRef->isUnresolved();
+    TR::Symbol *symbol = symRef->getSymbol();
 
-        _symbolReference.setSymbol(symbol);
-        _symbolReference.addToOffset(symRef->getOffset());
-        _symbolReference.setOwningMethodIndex(symRef->getOwningMethodIndex());
-        _symbolReference.setCPIndex(symRef->getCPIndex());
-        _symbolReference.copyFlags(symRef);
-        _symbolReference.copyRefNumIfPossible(symRef, comp->getSymRefTab());
+    bool isStore = rootLoadOrStore->getOpCode().isStore();
+    bool isUnresolved = symRef->isUnresolved();
 
-        if (rootLoadOrStore->getOpCode().isIndirect()) {
-            // Special case an indirect load or store off a local object. This
-            // can be treated as a direct load or store off the frame pointer
-            // We can't do this when the access is unresolved.
-            //
-            TR::Node *base = rootLoadOrStore->getFirstChild();
+    _symbolReference.setSymbol(symbol);
+    _symbolReference.addToOffset(symRef->getOffset());
+    _symbolReference.setOwningMethodIndex(symRef->getOwningMethodIndex());
+    _symbolReference.setCPIndex(symRef->getCPIndex());
+    _symbolReference.copyFlags(symRef);
+    _symbolReference.copyRefNumIfPossible(symRef, comp->getSymRefTab());
 
-            // Use the register evaluated from the loadaddr as the base object
-            // in a memory reference rather than accessing directly from the
-            // stack.
-            //
-            static bool useLoadAddrRegisterForLocalObjectMemRef
-                = feGetEnv("TR_useLoadAddrRegisterForLocalObjectMemRef") ? true : false;
+    if (rootLoadOrStore->getOpCode().isIndirect()) {
+        // Special case an indirect load or store off a local object. This
+        // can be treated as a direct load or store off the frame pointer
+        // We can't do this when the access is unresolved.
+        //
+        TR::Node *base = rootLoadOrStore->getFirstChild();
 
-            if (!isUnresolved && !useLoadAddrRegisterForLocalObjectMemRef && base->getOpCodeValue() == TR::loadaddr
-                && base->getSymbol()->isLocalObject()) {
-                _baseRegister = cg->getFrameRegister();
-                _symbolReference.setSymbol(base->getSymbol());
-                _symbolReference.copyFlags(base->getSymbolReference());
-                _baseNode = base;
-            } else {
-                if (isUnresolved) {
-                    // If it is an unresolved reference to a field of a local object
-                    // then force the localobject address to be evaluated into a register
-                    // otherwise the resolution may not work properly if the computation
-                    // is folded away into an esp + offset computation
-                    //
-                    if (base->getOpCodeValue() == TR::loadaddr && base->getSymbol()->isLocalObject())
-                        cg->evaluate(base);
+        // Use the register evaluated from the loadaddr as the base object
+        // in a memory reference rather than accessing directly from the
+        // stack.
+        //
+        static bool useLoadAddrRegisterForLocalObjectMemRef
+            = feGetEnv("TR_useLoadAddrRegisterForLocalObjectMemRef") ? true : false;
 
-                    setUnresolvedDataSnippet(TR::UnresolvedDataSnippet::create(cg, rootLoadOrStore, &_symbolReference,
-                        isStore, symRef->canCauseGC()));
-                    cg->addSnippet(getUnresolvedDataSnippet());
-                }
-
-                if (!debug("noAddressAddRemat") && canRematerializeAddressAdds) {
-                    rematerializeAddressAdds(rootLoadOrStore, cg);
-                    base = rootLoadOrStore->getFirstChild(); // It may have changed
-                }
-
-                if (symbol->isMethodMetaData()) {
-                    _baseRegister = cg->getMethodMetaDataRegister();
-                }
-
-                rcount_t refCount = base->getReferenceCount();
-                self()->populateMemoryReference(base, cg);
-                self()->checkAndDecReferenceCount(base, refCount, cg);
-            }
+        if (!isUnresolved && !useLoadAddrRegisterForLocalObjectMemRef && base->getOpCodeValue() == TR::loadaddr
+            && base->getSymbol()->isLocalObject()) {
+            _baseRegister = cg->getFrameRegister();
+            _symbolReference.setSymbol(base->getSymbol());
+            _symbolReference.copyFlags(base->getSymbolReference());
+            _baseNode = base;
         } else {
-            if (symbol->isStatic()) {
-                if (isUnresolved) {
-                    setUnresolvedDataSnippet(TR::UnresolvedDataSnippet::create(cg, rootLoadOrStore, &_symbolReference,
-                        isStore, symRef->canCauseGC()));
-                    cg->addSnippet(getUnresolvedDataSnippet());
-                }
-                _baseNode = rootLoadOrStore;
-            } else {
-                if (!symbol->isMethodMetaData()) {
-                    // Must be either auto or parm or error
-                    //
-                    _baseRegister = cg->getFrameRegister();
-                } else {
-                    _baseRegister = cg->getMethodMetaDataRegister();
-                }
-                _baseNode = NULL;
+            if (isUnresolved) {
+                // If it is an unresolved reference to a field of a local object
+                // then force the localobject address to be evaluated into a register
+                // otherwise the resolution may not work properly if the computation
+                // is folded away into an esp + offset computation
+                //
+                if (base->getOpCodeValue() == TR::loadaddr && base->getSymbol()->isLocalObject())
+                    cg->evaluate(base);
+
+                setUnresolvedDataSnippet(TR::UnresolvedDataSnippet::create(cg, rootLoadOrStore, &_symbolReference,
+                    isStore, symRef->canCauseGC()));
+                cg->addSnippet(getUnresolvedDataSnippet());
             }
-        }
 
-        if (isUnresolved) {
-            // Need a wide field because we don't know how big the displacement
-            // may turn out to be once resolved.
-            //
-            setForceWideDisplacement();
-        }
+            if (!debug("noAddressAddRemat") && canRematerializeAddressAdds) {
+                rematerializeAddressAdds(rootLoadOrStore, cg);
+                base = rootLoadOrStore->getFirstChild(); // It may have changed
+            }
 
+            if (symbol->isMethodMetaData()) {
+                _baseRegister = cg->getMethodMetaDataRegister();
+            }
+
+            rcount_t refCount = base->getReferenceCount();
+            self()->populateMemoryReference(base, cg);
+            self()->checkAndDecReferenceCount(base, refCount, cg);
+        }
     } else {
-        diagnostic("OMR::X86::MemoryReference::OMR::X86::MemoryReference() ==> no symbol reference");
+        if (symbol->isStatic()) {
+            if (isUnresolved) {
+                setUnresolvedDataSnippet(TR::UnresolvedDataSnippet::create(cg, rootLoadOrStore, &_symbolReference,
+                    isStore, symRef->canCauseGC()));
+                cg->addSnippet(getUnresolvedDataSnippet());
+            }
+            _baseNode = rootLoadOrStore;
+        } else {
+            if (!symbol->isMethodMetaData()) {
+                // Must be either auto or parm or error
+                //
+                _baseRegister = cg->getFrameRegister();
+            } else {
+                _baseRegister = cg->getMethodMetaDataRegister();
+            }
+            _baseNode = NULL;
+        }
+    }
+
+    if (isUnresolved) {
+        // Need a wide field because we don't know how big the displacement
+        // may turn out to be once resolved.
+        //
+        setForceWideDisplacement();
     }
 
     // TODO: aliasing sets?
@@ -275,7 +272,7 @@ TR::X86DataSnippet *OMR::X86::MemoryReference::getDataSnippet()
     return hasUnresolvedDataSnippet() ? NULL : (TR::X86DataSnippet *)_dataSnippet;
 }
 
-void OMR::X86::MemoryReference::initialize(TR::SymbolReference *symRef, TR::CodeGenerator *cg)
+void OMR::X86::MemoryReference::initializeFromSymRef(TR::SymbolReference *symRef, TR::CodeGenerator *cg)
 {
     TR::Compilation *comp = cg->comp();
     TR::Symbol *symbol = symRef->getSymbol();
@@ -290,6 +287,11 @@ void OMR::X86::MemoryReference::initialize(TR::SymbolReference *symRef, TR::Code
 
     _indexRegister = NULL;
     _symbolReference.setSymbol(symbol);
+
+    // The TR::SymbolReference for a newly allocated MemoryReference should have an offset of 0.
+    // However, the `addToOffset` API is used (rather than `setOffset`) just in case an additional
+    // displacement was provided to the MemoryReference constructor.
+    //
     _symbolReference.addToOffset(symRef->getOffset());
     _symbolReference.setOwningMethodIndex(symRef->getOwningMethodIndex());
     _symbolReference.setCPIndex(symRef->getCPIndex());
@@ -302,10 +304,11 @@ void OMR::X86::MemoryReference::initialize(TR::SymbolReference *symRef, TR::Code
         cg->addSnippet(getUnresolvedDataSnippet());
         setForceWideDisplacement();
     }
+
     // TODO: aliasing sets?
 }
 
-OMR::X86::MemoryReference::MemoryReference(TR::MemoryReference &mr, intptr_t n, TR::CodeGenerator *cg,
+OMR::X86::MemoryReference::MemoryReference(TR::MemoryReference &mr, intptr_t extraOffset, TR::CodeGenerator *cg,
     TR_ScratchRegisterManager *srm)
     : _symbolReference(cg->comp()->getSymRefTab())
 {
@@ -315,7 +318,7 @@ OMR::X86::MemoryReference::MemoryReference(TR::MemoryReference &mr, intptr_t n, 
     _indexRegister = mr._indexRegister;
     _indexNode = mr._indexNode;
     _label = mr._label;
-    _symbolReference = TR::SymbolReference(comp->getSymRefTab(), mr._symbolReference, n);
+    _symbolReference = TR::SymbolReference(comp->getSymRefTab(), mr._symbolReference, extraOffset);
     _reloKind = -1;
 
     if (mr.getUnresolvedDataSnippet() != NULL) {
@@ -1509,12 +1512,12 @@ TR::MemoryReference *TR::MRef_sym(TR::SymbolReference *sr, TR::CodeGenerator *cg
     return new (cg->trHeapMemory()) TR::MemoryReference(sr, cg);
 }
 
-TR::MemoryReference *TR::MRef_symOff(TR::SymbolReference *sr, intptr_t offset, TR::CodeGenerator *cg)
+TR::MemoryReference *TR::MRef_symOff(TR::SymbolReference *sr, intptr_t extraOffset, TR::CodeGenerator *cg)
 {
-    return new (cg->trHeapMemory()) TR::MemoryReference(sr, offset, cg);
+    return new (cg->trHeapMemory()) TR::MemoryReference(sr, extraOffset, cg);
 }
 
-TR::MemoryReference *TR::MRef_MRefOff(TR::MemoryReference &mr, intptr_t offset, TR::CodeGenerator *cg)
+TR::MemoryReference *TR::MRef_MRefOff(TR::MemoryReference &mr, intptr_t extraOffset, TR::CodeGenerator *cg)
 {
-    return new (cg->trHeapMemory()) TR::MemoryReference(mr, offset, cg);
+    return new (cg->trHeapMemory()) TR::MemoryReference(mr, extraOffset, cg);
 }

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -1247,7 +1247,6 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
 
             if (symbol) {
                 TR::StaticSymbol *staticSym = symbol->getStaticSymbol();
-                TR::MethodSymbol *methodSym = symbol->getMethodSymbol();
 
                 if (staticSym) {
                     if (getUnresolvedDataSnippet() == NULL) {
@@ -1256,18 +1255,6 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
                     } else {
                         *(int32_t *)cursor = (int32_t)getSymbolReference().getOffset();
                     }
-                } else if (methodSym) {
-                    /* ----------------------------------------------------- */
-                    /* This is fake. Not supported for JIT compilation;      */
-                    /* just avoiding a core dump                             */
-                    /* ----------------------------------------------------- */
-                    *(int32_t *)cursor = 0;
-                } else if (symbol->isRegisterMappedSymbol()) {
-                    displacement = getSymbolReference().getOffset() + symbol->getRegisterMappedSymbol()->getOffset();
-                    TR_ASSERT(IS_32BIT_SIGNED(displacement),
-                        "64-bit displacement should have been replaced in "
-                        "TR_AMD64MemoryReference::generateBinaryEncoding");
-                    *(int32_t *)cursor = (int32_t)displacement;
                 } else if (symbol->isShadow()) {
                     *(int32_t *)cursor = (int32_t)getSymbolReference().getOffset();
                 } else

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -89,8 +89,8 @@ OMR::X86::MemoryReference::MemoryReference(TR::X86DataSnippet *cds, TR::CodeGene
     , _baseNode(NULL)
     , _indexRegister(NULL)
     , _indexNode(NULL)
-    , _dataSnippet(cds)
-    , _label(NULL)
+    , _dataSnippet(NULL)
+    , _label(cds->getSnippetLabel())
     , _symbolReference(cg->comp()->getSymRefTab())
     , _stride(0)
     , _flags(0)
@@ -267,11 +267,6 @@ TR::UnresolvedDataSnippet *OMR::X86::MemoryReference::setUnresolvedDataSnippet(T
     return ((TR::UnresolvedDataSnippet *)(_dataSnippet = s));
 }
 
-TR::X86DataSnippet *OMR::X86::MemoryReference::getDataSnippet()
-{
-    return hasUnresolvedDataSnippet() ? NULL : (TR::X86DataSnippet *)_dataSnippet;
-}
-
 void OMR::X86::MemoryReference::initializeFromSymRef(TR::SymbolReference *symRef, TR::CodeGenerator *cg)
 {
     TR::Compilation *comp = cg->comp();
@@ -325,8 +320,6 @@ OMR::X86::MemoryReference::MemoryReference(TR::MemoryReference &mr, intptr_t ext
         _dataSnippet
             = TR::UnresolvedDataSnippet::create(cg, _baseNode, &_symbolReference, false, _symbolReference.canCauseGC());
         cg->addSnippet(_dataSnippet);
-    } else if (mr.getDataSnippet() != NULL) {
-        _dataSnippet = mr.getDataSnippet();
     } else {
         _dataSnippet = NULL;
     }
@@ -1117,15 +1110,9 @@ void OMR::X86::MemoryReference::addMetaDataForCodeAddress(uint32_t addressTypes,
                     }
                 }
             } else {
-                TR::X86DataSnippet *cds = getDataSnippet();
-                TR::LabelSymbol *label = NULL;
+                TR::LabelSymbol *label = getLabel();
 
-                if (cds)
-                    label = cds->getSnippetLabel();
-                else
-                    label = getLabel();
-
-                if (label != NULL) {
+                if (label) {
                     if (cg->comp()->target().is64Bit()) {
                         // Assume the snippet is in RIP range
                         // TODO:AMD64: Would it be cleaner to have some kind of "isRelative" flag rather than
@@ -1260,16 +1247,7 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
                 } else
                     TR_ASSERT(0, "generateBinaryEncoding, new symbol hierarchy problem");
             } else {
-                TR::X86DataSnippet *cds = getDataSnippet();
-                TR_ASSERT(cds == NULL || getLabel() == NULL,
-                    "a memRef cannot have both a constant data snippet and a label");
-                TR::LabelSymbol *label = NULL;
-                if (cds)
-                    label = cds->getSnippetLabel();
-                else
-                    label = getLabel();
-
-                if (label != NULL) {
+                if (getLabel()) {
                     if (comp->target().is64Bit()) {
                         // This cast is ok because we only need the low 32 bits of the address
                         // *(int32_t *)cursor = -(int32_t)(intptr_t)(cursor+4);

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -1109,22 +1109,6 @@ void OMR::X86::MemoryReference::addMetaDataForCodeAddress(uint32_t addressTypes,
                         }
                     }
                 }
-            } else {
-                TR::LabelSymbol *label = getLabel();
-
-                if (label) {
-                    if (cg->comp()->target().is64Bit()) {
-                        // Assume the snippet is in RIP range
-                        // TODO:AMD64: Would it be cleaner to have some kind of "isRelative" flag rather than
-                        // "is64BitTarget"?
-                        cg->addRelocation(new (cg->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, label));
-                    } else {
-                        cg->addRelocation(new (cg->trHeapMemory()) TR::LabelAbsoluteRelocation(cursor, label));
-                        cg->addExternalRelocation(
-                            TR::ExternalRelocation::create(cursor, 0, TR_AbsoluteMethodAddress, cg), __FILE__, __LINE__,
-                            node);
-                    }
-                }
             }
 
             break;
@@ -1186,6 +1170,8 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
 
         case MR_index + MR_disp:
         case MR_index: {
+            // To encode these cases, the ISA always requires a SIB and a disp32
+            //
             index = toRealRegister(getIndexRegister());
             ModRM(modRM)->setBase()->setHasSIB();
             *++cursor = 0x00;
@@ -1237,19 +1223,35 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
                 TR_ASSERT_FATAL(IS_32BIT_SIGNED(displacement),
                     "MR_disp symbol displacement out of range: %" OMR_PRIxPTR, displacement);
             } else {
-                if (getLabel()) {
-                    // The MemoryReference for a Label is an address in the code cache within this
-                    // compilation unit. Because the address of labels appearing in the code after
-                    // this memory reference has not been determined yet, use the relocation
-                    // mechanism to patch it in after binary encoding. For 64-bit targets, RIP-relative
-                    // addressing is used (relative relocation), but for 32-bit targets the absolute
-                    // address of the label is used (absolute relocation).
+                TR::LabelSymbol *labelSym = getLabel();
+                if (labelSym) {
+                    // The MemoryReference for a label is an address in the code cache within this
+                    // compilation unit
                     //
                     if (comp->target().is64Bit()) {
+                        // Use RIP-relative addressing on 64-bit. All labels are assumed to be
+                        // within RIP-relative displacement range.
+                        //
                         displacement = -(
                             int32_t)(intptr_t)(cursor + 4 + containingInstruction->getOpCode().info().ImmediateSize());
+
+                        if (labelSym->getCodeLocation()) {
+                            // Compute the displacement to the known label location. No relocation is required.
+                            //
+                            displacement = reinterpret_cast<intptr_t>(labelSym->getCodeLocation()) + displacement;
+                        } else {
+                            cg->addRelocation(
+                                new (cg->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, labelSym));
+                        }
                     } else {
+                        // Use an absolute code address on 32-bit, which will be filled in during
+                        // relocation processing
+                        //
                         displacement = 0;
+                        cg->addRelocation(new (cg->trHeapMemory()) TR::LabelAbsoluteRelocation(cursor, labelSym));
+                        cg->addExternalRelocation(
+                            TR::ExternalRelocation::create(cursor, 0, TR_AbsoluteMethodAddress, cg), __FILE__, __LINE__,
+                            containingInstruction->getNode());
                     }
                 } else {
                     displacement = getSymbolReference().getOffset();
@@ -1302,7 +1304,7 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
                 // then displacement will be 4 bytes.
                 //
                 ModRM(modRM)->setBaseDisp32();
-                *(int32_t *)cursor = (int32_t)displacement;
+                *(int32_t *)cursor = static_cast<int32_t>(displacement);
                 if (getUnresolvedDataSnippet() != NULL) {
                     getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
                 }

--- a/compiler/x/codegen/OMRMemoryReference.hpp
+++ b/compiler/x/codegen/OMRMemoryReference.hpp
@@ -235,19 +235,9 @@ public:
 
     OMR_FINAL intptr_t getDisplacement();
 
-    // An unresolved data snippet, unresolved virtual call snippet, and constant data snippet are mutually exclusive for
-    // a given memory reference.  Hence, they share the same pointer.
-    //
     OMR_FINAL TR::UnresolvedDataSnippet *getUnresolvedDataSnippet();
 
     OMR_FINAL TR::UnresolvedDataSnippet *setUnresolvedDataSnippet(TR::UnresolvedDataSnippet *s);
-
-    OMR_FINAL TR::X86DataSnippet *getDataSnippet();
-
-    OMR_FINAL TR::X86DataSnippet *setConstantDataSnippet(TR::X86DataSnippet *s)
-    {
-        return ((TR::X86DataSnippet *)(_dataSnippet = s));
-    }
 
     OMR_FINAL TR::LabelSymbol *getLabel() { return _label; }
 

--- a/compiler/x/codegen/OMRMemoryReference.hpp
+++ b/compiler/x/codegen/OMRMemoryReference.hpp
@@ -102,7 +102,13 @@ protected:
 
     static const uint8_t _multiplierToStrideMap[HIGHEST_STRIDE_MULTIPLIER + 1];
 
-    void initialize(TR::SymbolReference *symRef, TR::CodeGenerator *cg);
+    /**
+     * @brief Initialize the MemoryReference from fields in the provided TR::SymbolReference
+     *
+     * @param[in] symRef : \c TR::SymbolReference to initialize from
+     * @param[in] cg : \c TR::CodeGenerator object
+     */
+    void initializeFromSymRef(TR::SymbolReference *symRef, TR::CodeGenerator *cg);
 
 public:
     TR_ALLOC(TR_Memory::MemoryReference)
@@ -204,9 +210,10 @@ public:
 
     MemoryReference(TR::SymbolReference *symRef, TR::CodeGenerator *cg);
 
-    MemoryReference(TR::SymbolReference *symRef, intptr_t displacement, TR::CodeGenerator *cg);
+    MemoryReference(TR::SymbolReference *symRef, intptr_t extraOffset, TR::CodeGenerator *cg);
 
-    MemoryReference(TR::MemoryReference &mr, intptr_t n, TR::CodeGenerator *cg, TR_ScratchRegisterManager *srm = NULL);
+    MemoryReference(TR::MemoryReference &mr, intptr_t extraOffset, TR::CodeGenerator *cg,
+        TR_ScratchRegisterManager *srm = NULL);
 
     OMR_FINAL TR::Register *getBaseRegister() { return _baseRegister; }
 
@@ -438,8 +445,8 @@ TR::MemoryReference *MRef_const(TR::X86DataSnippet *cds, TR::CodeGenerator *cg);
 TR::MemoryReference *MRef_label(TR::LabelSymbol *label, TR::CodeGenerator *cg);
 TR::MemoryReference *MRef_node(TR::Node *node, TR::CodeGenerator *cg, bool canRematerializeAddressAdds = true);
 TR::MemoryReference *MRef_sym(TR::SymbolReference *sr, TR::CodeGenerator *cg);
-TR::MemoryReference *MRef_symOff(TR::SymbolReference *sr, intptr_t offset, TR::CodeGenerator *cg);
-TR::MemoryReference *MRef_MRefOff(TR::MemoryReference &mr, intptr_t offset, TR::CodeGenerator *cg);
+TR::MemoryReference *MRef_symOff(TR::SymbolReference *sr, intptr_t extraOffset, TR::CodeGenerator *cg);
+TR::MemoryReference *MRef_MRefOff(TR::MemoryReference &mr, intptr_t extraOffset, TR::CodeGenerator *cg);
 } // namespace TR
 
 #endif

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -1273,19 +1273,20 @@ void TR_Debug::print(OMR::Logger *log, TR::MemoryReference *mr, TR_RegisterSizes
     }
 
     if (!hasTerm) {
-        // This must be an absolute memory reference (a constant data snippet or a label)
+        // This must be an absolute memory reference to a label
         //
-        TR::X86DataSnippet *cds = mr->getDataSnippet();
-        TR::LabelSymbol *label = NULL;
-        if (cds)
-            label = cds->getSnippetLabel();
-        else
-            label = mr->getLabel();
-        TR_ASSERT(label, "expecting a constant data snippet or a label");
+        TR::LabelSymbol *label = mr->getLabel();
+
+        TR_ASSERT_FATAL(label, "expecting a label");
+
+        TR::X86ConstantDataSnippet *cds = NULL;
+        if (label->getSnippet() && label->getSnippet()->getKind() == TR::Snippet::IsConstantData) {
+            cds = static_cast<TR::X86ConstantDataSnippet *>(label->getSnippet());
+        }
 
         int64_t disp = (int64_t)(label->getCodeLocation());
 
-        if (mr->getLabel()) {
+        if (label && !cds) {
             print(log, label);
             if (disp) {
                 log->prints(" : ");
@@ -1296,7 +1297,7 @@ void TR_Debug::print(OMR::Logger *log, TR::MemoryReference *mr, TR_RegisterSizes
                 true);
         } else if (cds) {
             log->prints("Data ");
-            print(log, cds->getSnippetLabel());
+            print(log, label);
             log->prints(": ");
             auto data = cds->getRawData();
             for (auto i = 0; i < cds->getDataSize(); i++) {


### PR DESCRIPTION
* Improve x86 MemoryReferences for labels
* Clean up X86 MemoryReference binary encoding and length estimation logic
* Treat DataSnippets as labels in x86 MemoryReferences
* Remove impossible cases from x86 MemRef binary encoding
* Give more descriptive name to some MRef constructor displacements