### PR TITLE
Introduce a X86NoOperandInstruction class for opcodes with no operands

### DIFF
--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -122,6 +122,7 @@ struct J9AnnotationInfoEntry;
 struct J9PortLibrary;
 
 namespace TR {
+class X86NoOperandInstruction;
 class X86LabelInstruction;
 class X86PaddingInstruction;
 class X86AlignmentInstruction;
@@ -898,6 +899,7 @@ public:
     void printX86OOLSequences(OMR::Logger *log);
 
     void printx(OMR::Logger *log, TR::Instruction *);
+    void print(OMR::Logger *log, TR::X86NoOperandInstruction *);
     void print(OMR::Logger *log, TR::X86LabelInstruction *);
     void print(OMR::Logger *log, TR::X86PaddingInstruction *);
     void print(OMR::Logger *log, TR::X86AlignmentInstruction *);

--- a/compiler/x/codegen/BinaryEvaluator.cpp
+++ b/compiler/x/codegen/BinaryEvaluator.cpp
@@ -1770,7 +1770,7 @@ TR::Register *OMR::X86::TreeEvaluator::signedIntegerDivOrRemAnalyser(TR::Node *n
                 cdqDependencies->addPreCondition(edxRegister, TR::RealRegister::edx, cg);
                 cdqDependencies->addPostCondition(tempRegister, TR::RealRegister::eax, cg);
                 cdqDependencies->addPostCondition(edxRegister, TR::RealRegister::edx, cg);
-                Inst(OP::CXXAcc(nodeIs64Bit), node, cdqDependencies, cg);
+                Inst0(OP::CXXAcc(nodeIs64Bit), node, cdqDependencies, cg);
 
                 if (dvalue == 2) // special case when working with 2
                 {
@@ -2023,7 +2023,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerDivOrRemEvaluator(TR::Node *node, 
                 if (node->getFirstChild()->isNonNegative() || node->getOpCode().isUnsigned())
                     Inst_RegReg(OP::XOR4RegReg, node, edxRegister, edxRegister, edxDeps, cg);
                 else
-                    Inst(OP::CXXAcc(nodeIs64Bit), node, eaxEdxDeps, cg);
+                    Inst0(OP::CXXAcc(nodeIs64Bit), node, eaxEdxDeps, cg);
                 if (node->getOpCode().isUnsigned()
                     || (node->getFirstChild()->isNonNegative() && node->getSecondChild()->isNonNegative()))
                     divideInstr
@@ -2036,7 +2036,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerDivOrRemEvaluator(TR::Node *node, 
                 if (node->getFirstChild()->isNonNegative() || node->getOpCode().isUnsigned())
                     Inst_RegReg(OP::XOR4RegReg, node, edxRegister, edxRegister, edxDeps, cg);
                 else
-                    Inst(OP::CXXAcc(nodeIs64Bit), node, eaxEdxDeps, cg);
+                    Inst0(OP::CXXAcc(nodeIs64Bit), node, eaxEdxDeps, cg);
                 if (node->getOpCode().isUnsigned()
                     || (node->getFirstChild()->isNonNegative() && node->getSecondChild()->isNonNegative()))
                     divideInstr = Inst_RegMem(OP::DIVAccMem(nodeIs64Bit), node, eaxRegister, tempMR, eaxEdxDeps, cg);

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -1104,7 +1104,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerReturnEvaluator(TR::Node *node, TR
     }
 
     if (linkageProperties.getCallerCleanup()) {
-        Inst(OP::RET, node, dependencies, cg);
+        Inst0(OP::RET, node, dependencies, cg);
     } else {
         Inst_Imm(OP::RETImm2, node, 0, dependencies, cg);
     }
@@ -1148,7 +1148,7 @@ TR::Register *OMR::X86::TreeEvaluator::returnEvaluator(TR::Node *node, TR::CodeG
     }
 
     if (cg->getProperties().getCallerCleanup()) {
-        Inst(OP::RET, node, cg);
+        Inst0(OP::RET, node, cg);
     } else {
         Inst_Imm(OP::RETImm2, node, 0, cg);
     }

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -382,7 +382,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpReturnEvaluator(TR::Node *node, TR::Cod
     }
 
     if (linkageProperties.getCallerCleanup()) {
-        Inst(OP::RET, node, dependencies, cg);
+        Inst0(OP::RET, node, dependencies, cg);
     } else {
         Inst_Imm(OP::RETImm2, node, 0, dependencies, cg);
     }
@@ -797,7 +797,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbo
         Inst_MemReg(OP::MOVSSMemReg, node, tempMR, floatReg, cg);
         Inst_Mem(OP::FLDMem, node, MRef_MRefOff(*tempMR, 0, cg), cg);
 
-        Inst(OP::FLDDUP, node, cg);
+        Inst0(OP::FLDDUP, node, cg);
 
         // For slow conversion only, change the rounding mode on the FPU via its control word register.
         //
@@ -852,7 +852,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbo
         Inst_Label(OP::label, node, reStartLabel, deps, cg);
 
         cg->decReferenceCount(child);
-        Inst(OP::FSTPST0, node, cg);
+        Inst0(OP::FSTPST0, node, cg);
 
         TR::Register *targetRegister = cg->allocateRegisterPair(lowReg, highReg);
         node->setRegister(targetRegister);

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -648,7 +648,7 @@ void OMR::X86::CodeGenerator::beginInstructionSelection()
     }
 
     if (getAppendInstruction())
-        Inst(OP::proc, startNode, self());
+        Inst0(OP::proc, startNode, self());
     else
         new (self()->trHeapMemory()) TR::Instruction(OP::proc, (TR::Instruction *)NULL, self());
 

--- a/compiler/x/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/x/codegen/OMRInstructionKindEnum.hpp
@@ -29,4 +29,4 @@ IsNotExtended, IsLabel, IsVirtualGuardNOP, IsFence, IsPadding, IsAlignment, IsBo
     IsVFPDedicate, IsVFPRelease, IsVFPCallCleanup, IsReg, IsRegReg, IsRegRegImm, IsRegRegReg, IsRegMaskRegReg,
     IsRegMaskRegRegImm, IsRegMaskReg, IsRegImm, IsRegImmSym, IsRegImm64, IsRegImm64Sym, IsRegMem, IsRegMemImm,
     IsRegRegMem, IsRegMaskMem, IsRegMaskRegMem, IsMem, IsMemTable, IsCallMem, IsMemImm, IsMemImmSym, IsMemImmSnippet,
-    IsMemReg, IsMemMaskReg, IsMemRegImm,
+    IsMemReg, IsMemMaskReg, IsMemRegImm, IsNoOperand,

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -1491,7 +1491,7 @@ static void generateRepMovsInstruction(OP::Mnemonic repmovs, TR::Node *node, TR:
             TR_ASSERT(false, "Invalid REP MOVS opcode [%d]", repmovs);
             break;
     }
-    Inst(repmovs, node, dependencies, cg);
+    Inst0(repmovs, node, dependencies, cg);
 }
 
 /** \brief
@@ -1782,7 +1782,7 @@ void OMR::X86::TreeEvaluator::arrayCopy64BitPrimitiveInlineSmallSizeWithoutREPMO
 
     // 40-64 Bytes
     generateMemoryCopyInstructions(node, dstReg, srcReg, sizeReg, tmpXmmYmmReg1, tmpXmmYmmReg2, 32, cg);
-    Inst(OP::VZEROUPPER, node, cg);
+    Inst0(OP::VZEROUPPER, node, cg);
     Inst_Label(OP::JMP4, node, mainEndLabel, cg);
 
     if (repMovsThresholdBytes == 64)
@@ -1795,7 +1795,7 @@ void OMR::X86::TreeEvaluator::arrayCopy64BitPrimitiveInlineSmallSizeWithoutREPMO
 
     // 72-128 Bytes
     generateMemoryCopyInstructions(node, dstReg, srcReg, sizeReg, tmpXmmYmmReg1, tmpXmmYmmReg2, 64, cg);
-    Inst(OP::VZEROUPPER, node, cg);
+    Inst0(OP::VZEROUPPER, node, cg);
     Inst_Label(OP::JMP4, node, mainEndLabel, cg);
 }
 
@@ -1907,7 +1907,7 @@ void OMR::X86::TreeEvaluator::arrayCopy32BitPrimitiveInlineSmallSizeWithoutREPMO
 
     // 36-64 Bytes
     generateMemoryCopyInstructions(node, dstReg, srcReg, sizeReg, tmpXmmYmmReg1, tmpXmmYmmReg2, 32, cg);
-    Inst(OP::VZEROUPPER, node, cg);
+    Inst0(OP::VZEROUPPER, node, cg);
     Inst_Label(OP::JMP4, node, mainEndLabel, cg);
 
     if (repMovsThresholdBytes == 64)
@@ -1920,7 +1920,7 @@ void OMR::X86::TreeEvaluator::arrayCopy32BitPrimitiveInlineSmallSizeWithoutREPMO
 
     // 68-128 Bytes
     generateMemoryCopyInstructions(node, dstReg, srcReg, sizeReg, tmpXmmYmmReg1, tmpXmmYmmReg2, 64, cg);
-    Inst(OP::VZEROUPPER, node, cg);
+    Inst0(OP::VZEROUPPER, node, cg);
     Inst_Label(OP::JMP4, node, mainEndLabel, cg);
 }
 
@@ -1961,7 +1961,7 @@ static void arrayCopy16BitPrimitive(TR::Node *node, TR::Register *dstReg, TR::Re
     Inst_Label(OP::label, node, mainBegLabel, cg);
     if (node->isForwardArrayCopy()) {
         Inst_RegImm(OP::SHRRegImm1(), node, sizeReg, 2, cg);
-        Inst(OP::REPMOVSD, node, cg);
+        Inst0(OP::REPMOVSD, node, cg);
         Inst_Label(OP::JAE1, node, mainEndLabel, cg);
         Inst_RegMem(OP::L2RegMem, node, sizeReg, MRef_Bdisp32(srcReg, 0, cg), cg);
         Inst_MemReg(OP::S2MemReg, node, MRef_Bdisp32(dstReg, 0, cg), sizeReg, cg);
@@ -1975,7 +1975,7 @@ static void arrayCopy16BitPrimitive(TR::Node *node, TR::Register *dstReg, TR::Re
         Inst_Label(OP::JB4, node, backwardLabel, cg); // jb, skip backward copy setup
 
         Inst_RegImm(OP::SHRRegImm1(), node, sizeReg, 2, cg);
-        Inst(OP::REPMOVSD, node, cg);
+        Inst0(OP::REPMOVSD, node, cg);
         Inst_Label(OP::JAE1, node, mainEndLabel, cg);
         Inst_RegMem(OP::L2RegMem, node, sizeReg, MRef_Bdisp32(srcReg, 0, cg), cg);
         Inst_MemReg(OP::S2MemReg, node, MRef_Bdisp32(dstReg, 0, cg), sizeReg, cg);
@@ -1984,9 +1984,9 @@ static void arrayCopy16BitPrimitive(TR::Node *node, TR::Register *dstReg, TR::Re
             TR_OutlinedInstructionsGenerator og(backwardLabel, node, cg);
             Inst_RegMem(OP::LEARegMem(), node, srcReg, MRef_BISdisp32(srcReg, sizeReg, 0, -2, cg), cg);
             Inst_RegMem(OP::LEARegMem(), node, dstReg, MRef_BISdisp32(dstReg, sizeReg, 0, -2, cg), cg);
-            Inst(OP::STD, node, cg);
+            Inst0(OP::STD, node, cg);
             generateRepMovsInstruction(OP::REPMOVSW, node, sizeReg, NULL, cg);
-            Inst(OP::CLD, node, cg);
+            Inst0(OP::CLD, node, cg);
             Inst_Label(OP::JMP4, node, mainEndLabel, cg);
             og.endOutlinedInstructionSequence();
         }
@@ -2123,7 +2123,7 @@ static void arrayCopy16BitPrimitiveInlineSmallSizeWithoutREPMOVSImplRoot16(TR::N
 
     // 34-64 Bytes
     generateMemoryCopyInstructions(node, dstReg, srcReg, sizeReg, tmpXmmYmmReg1, tmpXmmYmmReg2, 32, cg);
-    Inst(OP::VZEROUPPER, node, cg);
+    Inst0(OP::VZEROUPPER, node, cg);
     Inst_Label(OP::JMP4, node, mainEndLabel, cg);
 }
 
@@ -2262,7 +2262,7 @@ static void arrayCopy8BitPrimitiveInlineSmallSizeWithoutREPMOVSImplRoot8(TR::Nod
 
     // 33-64 Bytes
     generateMemoryCopyInstructions(node, dstReg, srcReg, sizeReg, tmpXmmYmmReg1, tmpXmmYmmReg2, 32, cg);
-    Inst(OP::VZEROUPPER, node, cg);
+    Inst0(OP::VZEROUPPER, node, cg);
     Inst_Label(OP::JMP4, node, mainEndLabel, cg);
 }
 
@@ -2374,7 +2374,7 @@ static void generateRepMovsInstructionBasedOnElementSize(uint8_t elementSize, bo
             TR_ASSERT_FATAL(repmovs == OP::REPMOVSQ, "Unsupported REP MOVS opcode %d for elementSize 8\n", repmovs);
 
             Inst_RegImm(OP::SHRRegImm1(), node, sizeReg, 3, cg);
-            Inst(OP::REPMOVSQ, node, dependencies, cg);
+            Inst0(OP::REPMOVSQ, node, dependencies, cg);
 
             break;
         }
@@ -2382,20 +2382,20 @@ static void generateRepMovsInstructionBasedOnElementSize(uint8_t elementSize, bo
             TR_ASSERT_FATAL(repmovs == OP::REPMOVSD, "Unsupported REP MOVS opcode %d for elementSize 4\n", repmovs);
 
             Inst_RegImm(OP::SHRRegImm1(), node, sizeReg, 2, cg);
-            Inst(OP::REPMOVSD, node, dependencies, cg);
+            Inst0(OP::REPMOVSD, node, dependencies, cg);
 
             break;
         }
         case 2: {
             if (repmovs == OP::REPMOVSD) {
                 Inst_RegImm(OP::SHRRegImm1(), node, sizeReg, 2, cg);
-                Inst(OP::REPMOVSD, node, cg);
+                Inst0(OP::REPMOVSD, node, cg);
                 Inst_Label(OP::JAE1, node, mainEndLabel, cg);
                 Inst_RegMem(OP::L2RegMem, node, sizeReg, MRef_Bdisp32(srcReg, 0, cg), cg);
                 Inst_MemReg(OP::S2MemReg, node, MRef_Bdisp32(dstReg, 0, cg), sizeReg, cg);
             } else if (repmovs == OP::REPMOVSW) {
                 Inst_Reg(OP::SHRReg1(), node, sizeReg, cg);
-                Inst(OP::REPMOVSW, node, dependencies, cg);
+                Inst0(OP::REPMOVSW, node, dependencies, cg);
             } else {
                 TR_ASSERT_FATAL(false, "Unsupported REP MOVS opcode %d for elementSize 2\n", repmovs);
             }
@@ -2405,7 +2405,7 @@ static void generateRepMovsInstructionBasedOnElementSize(uint8_t elementSize, bo
             TR_ASSERT_FATAL((repmovs == OP::REPMOVSB) && (elementSize == 1),
                 "Unsupported REP MOVS opcode %d for elementSize %u\n", repmovs, elementSize);
 
-            Inst(OP::REPMOVSB, node, dependencies, cg);
+            Inst0(OP::REPMOVSB, node, dependencies, cg);
             break;
         }
     }
@@ -2521,12 +2521,12 @@ static void arrayCopyPrimitiveInlineSmallSizeWithoutREPMOVS(TR::Node *node, TR::
                 cg);
             Inst_RegMem(OP::LEARegMem(), node, dstReg, MRef_BISdisp32(dstReg, sizeReg, 0, -(intptr_t)elementSize, cg),
                 cg);
-            Inst(OP::STD, node, cg);
+            Inst0(OP::STD, node, cg);
 
             generateRepMovsInstructionBasedOnElementSize(elementSize, false /* basedOnCPU */, node, dstReg, srcReg,
                 sizeReg, NULL, mainEndLabel, cg);
 
-            Inst(OP::CLD, node, cg);
+            Inst0(OP::CLD, node, cg);
             Inst_Label(OP::JMP4, node, mainEndLabel, cg);
             og.endOutlinedInstructionSequence();
         }
@@ -2835,7 +2835,7 @@ static void arrayCopyPrimitiveInlineSmallSizeConstantCopySize(TR::Node *node, TR
     }
 
     if (emitVzeroupper)
-        Inst(OP::VZEROUPPER, node, cg);
+        Inst0(OP::VZEROUPPER, node, cg);
 
     cg->stopUsingRegister(tmpReg1);
     cg->stopUsingRegister(tmpReg2);
@@ -2934,9 +2934,9 @@ static void arrayCopyDefault(TR::Node *node, uint8_t elementSize, TR::Register *
                 cg);
             Inst_RegMem(OP::LEARegMem(), node, dstReg, MRef_BISdisp32(dstReg, sizeReg, 0, -(intptr_t)elementSize, cg),
                 cg);
-            Inst(OP::STD, node, cg);
+            Inst0(OP::STD, node, cg);
             generateRepMovsInstruction(repmovs, node, sizeReg, NULL, cg);
-            Inst(OP::CLD, node, cg);
+            Inst0(OP::CLD, node, cg);
             Inst_Label(OP::JMP4, node, mainEndLabel, cg);
             og.endOutlinedInstructionSequence();
         }
@@ -3606,7 +3606,7 @@ static void arraySetDefault(TR::Node *node, uint8_t elementSize, TR::Register *a
 
     if (shiftAmount)
         Inst_RegImm(OP::SHRRegImm1(), node, sizeReg, shiftAmount, cg);
-    Inst(repOpcode, node, stosDependencies, cg);
+    Inst0(repOpcode, node, stosDependencies, cg);
     cg->stopUsingRegister(EAX);
 }
 
@@ -4498,7 +4498,7 @@ TR::Register *OMR::X86::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Code
     if (comp->getOption(TR_BreakBBStart)) {
         TR::Machine *machine = cg->machine();
         Inst_RegImm(OP::TEST4RegImm4, node, machine->getRealRegister(TR::RealRegister::esp), block->getNumber(), cg);
-        Inst(OP::INT3, node, cg);
+        Inst0(OP::INT3, node, cg);
     }
 
     cg->generateDebugCounter((node->getBlock()->isExtensionOfPreviousBlock()) ? "cg.blocks/extensions" : "cg.blocks", 1,
@@ -5015,7 +5015,7 @@ TR::Register *OMR::X86::TreeEvaluator::tstartEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::X86::TreeEvaluator::tfinishEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    Inst(OP::XEND, node, cg);
+    Inst0(OP::XEND, node, cg);
     return NULL;
 }
 

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -2977,6 +2977,24 @@ TR::Instruction *Inst(OP::Mnemonic op, TR::Node *node, TR::RegisterDependencyCon
     return new (cg->trHeapMemory()) TR::Instruction(cond, node, op, cg, encoding);
 }
 
+// X86NoOperandInstruction
+//
+TR::X86NoOperandInstruction *Inst0(TR::Instruction *prev, OP::Mnemonic op, TR::CodeGenerator *cg)
+{
+    return new (cg->trHeapMemory()) TR::X86NoOperandInstruction(prev, op, cg);
+}
+
+TR::X86NoOperandInstruction *Inst0(OP::Mnemonic op, TR::Node *node, TR::CodeGenerator *cg)
+{
+    return new (cg->trHeapMemory()) TR::X86NoOperandInstruction(op, node, cg);
+}
+
+TR::X86NoOperandInstruction *Inst0(OP::Mnemonic op, TR::Node *node, TR::RegisterDependencyConditions *cond,
+    TR::CodeGenerator *cg)
+{
+    return new (cg->trHeapMemory()) TR::X86NoOperandInstruction(op, node, cond, cg);
+}
+
 // X86AlignmentInstruction
 //
 TR::X86AlignmentInstruction *Inst_Alignment(TR::Node *node, uint8_t boundary, TR::CodeGenerator *cg)

--- a/compiler/x/codegen/OMRX86Instruction.hpp
+++ b/compiler/x/codegen/OMRX86Instruction.hpp
@@ -89,6 +89,34 @@ struct TR_AtomicRegion {
 
 namespace TR {
 
+/**
+ * @brief Instruction class for x86 instructions with no operands
+ */
+class X86NoOperandInstruction : public TR::Instruction {
+public:
+    X86NoOperandInstruction(OP::Mnemonic op, TR::Node *node, TR::CodeGenerator *cg)
+        : TR::Instruction(node, op, cg)
+    {}
+
+    X86NoOperandInstruction(TR::Instruction *precedingInstruction, OP::Mnemonic op, TR::CodeGenerator *cg)
+        : TR::Instruction(op, precedingInstruction, cg)
+    {}
+
+    X86NoOperandInstruction(OP::Mnemonic op, TR::Node *node, TR::RegisterDependencyConditions *cond,
+        TR::CodeGenerator *cg)
+        : TR::Instruction(cond, node, op, cg)
+    {}
+
+    X86NoOperandInstruction(TR::Instruction *precedingInstruction, OP::Mnemonic op,
+        TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
+        : TR::Instruction(cond, op, precedingInstruction, cg)
+    {}
+
+    virtual const char *description() { return "X86NoOperand"; }
+
+    virtual Kind getKind() { return IsNoOperand; }
+};
+
 class X86PaddingInstruction : public TR::Instruction {
     uint8_t _length;
     TR_PaddingProperties _properties;
@@ -2452,6 +2480,13 @@ TR::Instruction *Inst(TR::Instruction *prev, OP::Mnemonic op, TR::CodeGenerator 
     OMR::X86::Encoding encoding = OMR::X86::Default);
 TR::Instruction *Inst(OP::Mnemonic op, TR::Node *node, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg,
     OMR::X86::Encoding encoding = OMR::X86::Default);
+
+// X86NoOperandInstruction
+//
+TR::X86NoOperandInstruction *Inst0(OP::Mnemonic op, TR::Node *node, TR::CodeGenerator *cg);
+TR::X86NoOperandInstruction *Inst0(TR::Instruction *prev, OP::Mnemonic op, TR::CodeGenerator *cg);
+TR::X86NoOperandInstruction *Inst0(OP::Mnemonic op, TR::Node *node, TR::RegisterDependencyConditions *cond,
+    TR::CodeGenerator *cg);
 
 // X86AlignmentInstruction
 //

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -69,6 +69,9 @@ class Register;
 void TR_Debug::printx(OMR::Logger *log, TR::Instruction *instr)
 {
     switch (instr->getKind()) {
+        case TR::Instruction::IsNoOperand:
+            print(log, (TR::X86NoOperandInstruction *)instr);
+            break;
         case TR::Instruction::IsLabel:
             print(log, (TR::X86LabelInstruction *)instr);
             break;
@@ -408,6 +411,15 @@ void TR_Debug::print(OMR::Logger *log, TR::X86PatchableCodeAlignmentInstruction 
 
     log->prints("Align patchable code");
     printBoundaryAvoidanceInfo(log, instr);
+    dumpDependencies(log, instr);
+    log->flush();
+}
+
+void TR_Debug::print(OMR::Logger *log, TR::X86NoOperandInstruction *instr)
+{
+    printPrefix(log, instr);
+    log->printf("%-32s", getMnemonicName(&instr->getOpCode()));
+    printInstructionComment(log, 0, instr);
     dumpDependencies(log, instr);
     log->flush();
 }

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -2269,7 +2269,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::integerPairReturnEvaluator(TR::Node
     }
 
     if (linkageProperties.getCallerCleanup()) {
-        Inst(OP::RET, node, dependencies, cg);
+        Inst0(OP::RET, node, dependencies, cg);
     } else {
         Inst_Imm(OP::RETImm2, node, 0, dependencies, cg);
     }
@@ -3835,7 +3835,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::i2lEvaluator(TR::Node *node, TR::Co
         cdqDependencies->addPreCondition(highReg, TR::RealRegister::edx, cg);
         cdqDependencies->addPostCondition(childReg, TR::RealRegister::eax, cg);
         cdqDependencies->addPostCondition(highReg, TR::RealRegister::edx, cg);
-        Inst(OP::CDQAcc, node, cdqDependencies, cg);
+        Inst0(OP::CDQAcc, node, cdqDependencies, cg);
     } else {
         Inst_RegReg(OP::MOV4RegReg, node, highReg, childReg, cg);
         Inst_RegImm(OP::SAR4RegImm1, node, highReg, 31, cg);


### PR DESCRIPTION
Provide a specialized class for instructions that have no operands rather than
overloading the common base class (TR::Instruction).

This permits virtual function specialization for zero operand instructions.

Once all known downstream projects have converted to use the new `Inst0_` factory functions, the `Inst_` forms will be removed.  Virtual function overrides in the new X86NoOperand class will not be added until known downstream projects have converted or given notice that changes will be required.