### PR TITLE
AArch64: Remove deprecated generate*Instruction() functions

### DIFF
--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -53,12 +53,6 @@ class SymbolReference;
  */
 TR::Instruction *Inst(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Instruction *preced = NULL)
-{
-    return Inst(cg, op, node, preced);
-}
-
 /*
  * @brief Generates imm instruction
  * @param[in] cg : CodeGenerator
@@ -70,12 +64,6 @@ inline TR::Instruction *generateInstruction(TR::CodeGenerator *cg, OP::Mnemonic 
  */
 TR::ARM64ImmInstruction *Inst_Imm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uint32_t imm,
     TR::Instruction *preced = NULL);
-
-inline TR::ARM64ImmInstruction *generateImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    uint32_t imm, TR::Instruction *preced = NULL)
-{
-    return Inst_Imm(cg, op, node, imm, preced);
-}
 
 /*
  * @brief Generates relocatable imm instruction
@@ -90,12 +78,6 @@ inline TR::ARM64ImmInstruction *generateImmInstruction(TR::CodeGenerator *cg, OP
 TR::Instruction *Inst_RelocatableImm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uintptr_t imm,
     TR_ExternalRelocationTargetKind relocationKind, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    uintptr_t imm, TR_ExternalRelocationTargetKind relocationKind, TR::Instruction *preced = NULL)
-{
-    return Inst_RelocatableImm(cg, op, node, imm, relocationKind, preced);
-}
-
 /*
  * @brief Generates relocatable imm instruction
  * @param[in] cg : CodeGenerator
@@ -109,13 +91,6 @@ inline TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg,
  */
 TR::Instruction *Inst_RelocatableImm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uintptr_t imm,
     TR_ExternalRelocationTargetKind relocationKind, TR::SymbolReference *sr, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    uintptr_t imm, TR_ExternalRelocationTargetKind relocationKind, TR::SymbolReference *sr,
-    TR::Instruction *preced = NULL)
-{
-    return Inst_RelocatableImm(cg, op, node, imm, relocationKind, sr, preced);
-}
 
 /*
  * @brief Generates imm sym instruction
@@ -132,12 +107,6 @@ inline TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg,
 TR::Instruction *Inst_ImmSym(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uintptr_t imm,
     TR::RegisterDependencyConditions *cond, TR::SymbolReference *sr, TR::Snippet *s, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateImmSymInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uintptr_t imm,
-    TR::RegisterDependencyConditions *cond, TR::SymbolReference *sr, TR::Snippet *s, TR::Instruction *preced = NULL)
-{
-    return Inst_ImmSym(cg, op, node, imm, cond, sr, s, preced);
-}
-
 /*
  * @brief Generates label instruction
  * @param[in] cg : CodeGenerator
@@ -150,12 +119,6 @@ inline TR::Instruction *generateImmSymInstruction(TR::CodeGenerator *cg, OP::Mne
 // TO BE DEPRECATED
 TR::Instruction *Inst_Label(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
     TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::LabelSymbol *sym, TR::Instruction *preced = NULL)
-{
-    return Inst_Label(cg, op, node, sym, preced);
-}
 
 /*
  * @brief Generates label instruction with register dependency
@@ -170,12 +133,6 @@ inline TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, OP::Mnem
 // TO BE DEPRECATED
 TR::Instruction *Inst_Label(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
     TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL)
-{
-    return Inst_Label(cg, op, node, sym, cond, preced);
-}
 
 /*
  * @brief Generates label instruction
@@ -235,12 +192,6 @@ TR::Instruction *Inst_Branch(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSym
 TR::Instruction *Inst_ConditionalBranch(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *sym,
     TR::ARM64ConditionCode cc, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::Node *node,
-    TR::LabelSymbol *sym, TR::ARM64ConditionCode cc, TR::Instruction *preced = NULL)
-{
-    return Inst_ConditionalBranch(cg, node, sym, cc, preced);
-}
-
 /*
  * @brief Generates conditional branch instruction with register dependency
  * @param[in] cg : CodeGenerator
@@ -254,13 +205,6 @@ inline TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *
 TR::Instruction *Inst_ConditionalBranch(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *sym,
     TR::ARM64ConditionCode cc, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::Node *node,
-    TR::LabelSymbol *sym, TR::ARM64ConditionCode cc, TR::RegisterDependencyConditions *cond,
-    TR::Instruction *preced = NULL)
-{
-    return Inst_ConditionalBranch(cg, node, sym, cc, cond, preced);
-}
-
 /*
  * @brief Generates compare and branch instruction
  * @param[in] cg : CodeGenerator
@@ -273,12 +217,6 @@ inline TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *
  */
 TR::Instruction *Inst_CompareBranch(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *sreg,
     TR::LabelSymbol *sym, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *sreg, TR::LabelSymbol *sym, TR::Instruction *preced = NULL)
-{
-    return Inst_CompareBranch(cg, op, node, sreg, sym, preced);
-}
 
 /*
  * @brief Generates compare and branch instruction
@@ -294,12 +232,6 @@ inline TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, 
 TR::Instruction *Inst_CompareBranch(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *sreg,
     TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *sreg, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL)
-{
-    return Inst_CompareBranch(cg, op, node, sreg, sym, cond, preced);
-}
-
 /*
  * @brief Generates test bit and branch instruction
  * @param[in] cg : CodeGenerator
@@ -313,12 +245,6 @@ inline TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, 
  */
 TR::Instruction *Inst_TestBitBranch(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *sreg,
     uint32_t bitpos, TR::LabelSymbol *sym, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *sreg, uint32_t bitpos, TR::LabelSymbol *sym, TR::Instruction *preced = NULL)
-{
-    return Inst_TestBitBranch(cg, op, node, sreg, bitpos, sym, preced);
-}
 
 /*
  * @brief Generates test bit and branch instruction
@@ -335,13 +261,6 @@ inline TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, 
 TR::Instruction *Inst_TestBitBranch(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *sreg,
     uint32_t bitpos, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *sreg, uint32_t bitpos, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond,
-    TR::Instruction *preced = NULL)
-{
-    return Inst_TestBitBranch(cg, op, node, sreg, bitpos, sym, cond, preced);
-}
-
 /*
  * @brief Generates branch-to-register instruction
  * @param[in] cg : CodeGenerator
@@ -353,12 +272,6 @@ inline TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, 
  */
 TR::Instruction *Inst_RegBranch(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Instruction *preced = NULL)
-{
-    return Inst_RegBranch(cg, op, node, treg, preced);
-}
 
 /*
  * @brief Generates branch-to-register instruction with register dependency
@@ -373,12 +286,6 @@ inline TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, OP::
 TR::Instruction *Inst_RegBranch(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL)
-{
-    return Inst_RegBranch(cg, op, node, treg, cond, preced);
-}
-
 /*
  * @brief Generates admin instruction
  * @param[in] cg : CodeGenerator
@@ -390,12 +297,6 @@ inline TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, OP::
  */
 TR::Instruction *Inst_Admin(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Node *fenceNode = NULL,
     TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Node *fenceNode = NULL, TR::Instruction *preced = NULL)
-{
-    return Inst_Admin(cg, op, node, fenceNode, preced);
-}
 
 /*
  * @brief Generates admin instruction with register dependency
@@ -410,12 +311,6 @@ inline TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, OP::Mnem
 TR::Instruction *Inst_Admin(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::RegisterDependencyConditions *cond, TR::Node *fenceNode = NULL, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::RegisterDependencyConditions *cond, TR::Node *fenceNode = NULL, TR::Instruction *preced = NULL)
-{
-    return Inst_Admin(cg, op, node, cond, fenceNode, preced);
-}
-
 /*
  * @brief Generates imm-to-trg instruction
  * @param[in] cg : CodeGenerator
@@ -428,12 +323,6 @@ inline TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, OP::Mnem
  */
 TR::Instruction *Inst_Trg1Imm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm,
     TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateTrg1ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, uint32_t imm, TR::Instruction *preced = NULL)
-{
-    return Inst_Trg1Imm(cg, op, node, treg, imm, preced);
-}
 
 /*
  * @brief Generates shifted imm-to-trg instruction
@@ -449,12 +338,6 @@ inline TR::Instruction *generateTrg1ImmInstruction(TR::CodeGenerator *cg, OP::Mn
 TR::Instruction *Inst_Trg1ImmShifted(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     uint32_t imm, uint32_t shiftAmount, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateTrg1ImmShiftedInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, uint32_t imm, uint32_t shiftAmount, TR::Instruction *preced = NULL)
-{
-    return Inst_Trg1ImmShifted(cg, op, node, treg, imm, shiftAmount, preced);
-}
-
 /*
  * @brief Generates imm-to-trg label instruction
  * @param[in] cg : CodeGenerator
@@ -469,12 +352,6 @@ inline TR::Instruction *generateTrg1ImmShiftedInstruction(TR::CodeGenerator *cg,
 TR::Instruction *Inst_Trg1ImmSym(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     uint32_t imm, TR::Symbol *sym, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateTrg1ImmSymInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, uint32_t imm, TR::Symbol *sym, TR::Instruction *preced = NULL)
-{
-    return Inst_Trg1ImmSym(cg, op, node, treg, imm, sym, preced);
-}
-
 /*
  * @brief Generates src1-to-trg instruction
  * @param[in] cg : CodeGenerator
@@ -487,12 +364,6 @@ inline TR::Instruction *generateTrg1ImmSymInstruction(TR::CodeGenerator *cg, OP:
  */
 TR::Instruction *Inst_Trg1Src1(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *s1reg, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateTrg1Src1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Instruction *preced = NULL)
-{
-    return Inst_Trg1Src1(cg, op, node, treg, s1reg, preced);
-}
 
 /*
  * @brief Generates src1-and-imm-to-trg instruction
@@ -508,12 +379,6 @@ inline TR::Instruction *generateTrg1Src1Instruction(TR::CodeGenerator *cg, OP::M
 TR::Instruction *Inst_Trg1Src1Imm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *s1reg, uint32_t imm, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateTrg1Src1ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, uint32_t imm, TR::Instruction *preced = NULL)
-{
-    return Inst_Trg1Src1Imm(cg, op, node, treg, s1reg, imm, preced);
-}
-
 /*
  * @brief Generates src2-to-trg instruction
  * @param[in] cg : CodeGenerator
@@ -527,12 +392,6 @@ inline TR::Instruction *generateTrg1Src1ImmInstruction(TR::CodeGenerator *cg, OP
  */
 TR::Instruction *Inst_Trg1Src2(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced = NULL)
-{
-    return Inst_Trg1Src2(cg, op, node, treg, s1reg, s2reg, preced);
-}
 
 /*
  * @brief Generates src2-to-trg instruction (Conditional register)
@@ -549,13 +408,6 @@ inline TR::Instruction *generateTrg1Src2Instruction(TR::CodeGenerator *cg, OP::M
 TR::Instruction *Inst_CondTrg1Src2(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ConditionCode cc, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ConditionCode cc,
-    TR::Instruction *preced = NULL)
-{
-    return Inst_CondTrg1Src2(cg, op, node, treg, s1reg, s2reg, cc, preced);
-}
-
 /*
  * @brief Generates src2-to-trg imm instruction
  * @param[in] cg : CodeGenerator
@@ -570,12 +422,6 @@ inline TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, O
  */
 TR::Instruction *Inst_Trg1Src2Imm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *s1reg, TR::Register *s2reg, uint32_t imm, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateTrg1Src2ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, uint32_t imm, TR::Instruction *preced = NULL)
-{
-    return Inst_Trg1Src2Imm(cg, op, node, treg, s1reg, s2reg, imm, preced);
-}
 
 /*
  * @brief Generates src2-to-trg instruction (shifted register)
@@ -594,13 +440,6 @@ TR::Instruction *Inst_Trg1Src2Shifted(TR::CodeGenerator *cg, OP::Mnemonic op, TR
     TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ShiftCode shiftType, uint32_t shiftAmount,
     TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateTrg1Src2ShiftedInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ShiftCode shiftType, uint32_t shiftAmount,
-    TR::Instruction *preced = NULL)
-{
-    return Inst_Trg1Src2Shifted(cg, op, node, treg, s1reg, s2reg, shiftType, shiftAmount, preced);
-}
-
 /*
  * @brief Generates src2-to-trg instruction (extended register)
  * @param[in] cg : CodeGenerator
@@ -618,13 +457,6 @@ TR::Instruction *Inst_Trg1Src2Extended(TR::CodeGenerator *cg, OP::Mnemonic op, T
     TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ExtendCode extendType, uint32_t shiftAmount,
     TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateTrg1Src2ExtendedInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ExtendCode extendType, uint32_t shiftAmount,
-    TR::Instruction *preced = NULL)
-{
-    return Inst_Trg1Src2Extended(cg, op, node, treg, s1reg, s2reg, extendType, shiftAmount, preced);
-}
-
 /*
  * @brief Generates src2-to-trg indexed element instruction
  * @param[in] cg : CodeGenerator
@@ -639,13 +471,6 @@ inline TR::Instruction *generateTrg1Src2ExtendedInstruction(TR::CodeGenerator *c
  */
 TR::Instruction *Inst_Trg1Src2IndexedElement(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *s1reg, TR::Register *s2reg, uint32_t index, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateTrg1Src2IndexedElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op,
-    TR::Node *node, TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, uint32_t index,
-    TR::Instruction *preced = NULL)
-{
-    return Inst_Trg1Src2IndexedElement(cg, op, node, treg, s1reg, s2reg, index, preced);
-}
 
 /*
  * @brief Generates src3-to-trg instruction
@@ -662,12 +487,6 @@ inline TR::Instruction *generateTrg1Src2IndexedElementInstruction(TR::CodeGenera
 TR::Instruction *Inst_Trg1Src3(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *s1reg, TR::Register *s2reg, TR::Register *s3reg, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::Register *s3reg, TR::Instruction *preced = NULL)
-{
-    return Inst_Trg1Src3(cg, op, node, treg, s1reg, s2reg, s3reg, preced);
-}
-
 /*
  * @brief Generates mem-to-trg instruction
  * @param[in] cg : CodeGenerator
@@ -680,12 +499,6 @@ inline TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, OP::M
  */
 TR::Instruction *Inst_Trg1Mem(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::MemoryReference *mr, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateTrg1MemInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::MemoryReference *mr, TR::Instruction *preced = NULL)
-{
-    return Inst_Trg1Mem(cg, op, node, treg, mr, preced);
-}
 
 /*
  * @brief Generates mem-to-trg2 instruction
@@ -701,12 +514,6 @@ inline TR::Instruction *generateTrg1MemInstruction(TR::CodeGenerator *cg, OP::Mn
 TR::Instruction *Inst_Trg2Mem(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg1,
     TR::Register *treg2, TR::MemoryReference *mr, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateTrg2MemInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg1, TR::Register *treg2, TR::MemoryReference *mr, TR::Instruction *preced = NULL)
-{
-    return Inst_Trg2Mem(cg, op, node, treg1, treg2, mr, preced);
-}
-
 /*
  * @brief Generates mem-imm instruction
  * @param[in] cg : CodeGenerator
@@ -720,12 +527,6 @@ inline TR::Instruction *generateTrg2MemInstruction(TR::CodeGenerator *cg, OP::Mn
 TR::Instruction *Inst_MemImm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr,
     uint32_t imm, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateMemImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::MemoryReference *mr, uint32_t imm, TR::Instruction *preced = NULL)
-{
-    return Inst_MemImm(cg, op, node, mr, imm, preced);
-}
-
 /*
  * @brief Generates src-to-mem instruction
  * @param[in] cg : CodeGenerator
@@ -738,12 +539,6 @@ inline TR::Instruction *generateMemImmInstruction(TR::CodeGenerator *cg, OP::Mne
  */
 TR::Instruction *Inst_MemSrc1(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr,
     TR::Register *sreg, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateMemSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::MemoryReference *mr, TR::Register *sreg, TR::Instruction *preced = NULL)
-{
-    return Inst_MemSrc1(cg, op, node, mr, sreg, preced);
-}
 
 /*
  * @brief Generates src2-to-mem instruction
@@ -759,12 +554,6 @@ inline TR::Instruction *generateMemSrc1Instruction(TR::CodeGenerator *cg, OP::Mn
 TR::Instruction *Inst_MemSrc2(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr,
     TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateMemSrc2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::MemoryReference *mr, TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced = NULL)
-{
-    return Inst_MemSrc2(cg, op, node, mr, s1reg, s2reg, preced);
-}
-
 /*
  * @brief Generates "store exclusive" instruction
  * @param[in] cg : CodeGenerator
@@ -779,12 +568,6 @@ inline TR::Instruction *generateMemSrc2Instruction(TR::CodeGenerator *cg, OP::Mn
 TR::Instruction *Inst_Trg1MemSrc1(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::MemoryReference *mr, TR::Register *sreg, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateTrg1MemSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::MemoryReference *mr, TR::Register *sreg, TR::Instruction *preced = NULL)
-{
-    return Inst_Trg1MemSrc1(cg, op, node, treg, mr, sreg, preced);
-}
-
 /*
  * @brief Generates src1 instruction
  * @param[in] cg : CodeGenerator
@@ -796,12 +579,6 @@ inline TR::Instruction *generateTrg1MemSrc1Instruction(TR::CodeGenerator *cg, OP
  */
 TR::Instruction *Inst_Src1(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *s1reg,
     TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *s1reg, TR::Instruction *preced = NULL)
-{
-    return Inst_Src1(cg, op, node, s1reg, preced);
-}
 
 /*
  * @brief Generates src2 instruction
@@ -815,12 +592,6 @@ inline TR::Instruction *generateSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemo
  */
 TR::Instruction *Inst_Src2(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *s1reg,
     TR::Register *s2reg, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateSrc2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced = NULL)
-{
-    return Inst_Src2(cg, op, node, s1reg, s2reg, preced);
-}
 
 /*
  * @brief Generates ASR instruction
@@ -836,12 +607,6 @@ inline TR::Instruction *generateSrc2Instruction(TR::CodeGenerator *cg, OP::Mnemo
 TR::Instruction *Inst_ArithmeticShiftRightImm(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
     TR::Register *sreg, uint32_t shiftAmount, bool is64bit = true, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateArithmeticShiftRightImmInstruction(TR::CodeGenerator *cg, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, bool is64bit = true, TR::Instruction *preced = NULL)
-{
-    return Inst_ArithmeticShiftRightImm(cg, node, treg, sreg, shiftAmount, is64bit, preced);
-}
-
 /*
  * @brief Generates LSR instruction
  * @param[in] cg : CodeGenerator
@@ -856,12 +621,6 @@ inline TR::Instruction *generateArithmeticShiftRightImmInstruction(TR::CodeGener
 TR::Instruction *Inst_LogicalShiftRightImm(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
     TR::Register *sreg, uint32_t shiftAmount, bool is64bit = true, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateLogicalShiftRightImmInstruction(TR::CodeGenerator *cg, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, bool is64bit = true, TR::Instruction *preced = NULL)
-{
-    return Inst_LogicalShiftRightImm(cg, node, treg, sreg, shiftAmount, is64bit, preced);
-}
-
 /*
  * @brief Generates LSL instruction
  * @param[in] cg : CodeGenerator
@@ -875,12 +634,6 @@ inline TR::Instruction *generateLogicalShiftRightImmInstruction(TR::CodeGenerato
  */
 TR::Instruction *Inst_LogicalShiftLeftImm(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
     uint32_t shiftAmount, bool is64bit = true, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateLogicalShiftLeftImmInstruction(TR::CodeGenerator *cg, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, bool is64bit = true, TR::Instruction *preced = NULL)
-{
-    return Inst_LogicalShiftLeftImm(cg, node, treg, sreg, shiftAmount, is64bit, preced);
-}
 
 /*
  * @brief Generates logical immediate instruction
@@ -897,12 +650,6 @@ inline TR::Instruction *generateLogicalShiftLeftImmInstruction(TR::CodeGenerator
 TR::Instruction *Inst_LogicalImm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *s1reg, bool N, uint32_t imm, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateLogicalImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, bool N, uint32_t imm, TR::Instruction *preced = NULL)
-{
-    return Inst_LogicalImm(cg, op, node, treg, s1reg, N, imm, preced);
-}
-
 /*
  * @brief Generates CMP (immediate) instruction
  * @param[in] cg : CodeGenerator
@@ -916,12 +663,6 @@ inline TR::Instruction *generateLogicalImmInstruction(TR::CodeGenerator *cg, OP:
 TR::Instruction *Inst_CompareImm(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg, int32_t imm,
     bool is64bit = false, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateCompareImmInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg,
-    int32_t imm, bool is64bit = false, TR::Instruction *preced = NULL)
-{
-    return Inst_CompareImm(cg, node, sreg, imm, is64bit, preced);
-}
-
 /*
  * @brief Generates CMP (register) instruction
  * @param[in] cg : CodeGenerator
@@ -934,12 +675,6 @@ inline TR::Instruction *generateCompareImmInstruction(TR::CodeGenerator *cg, TR:
  */
 TR::Instruction *Inst_Compare(TR::CodeGenerator *cg, TR::Node *node, TR::Register *s1reg, TR::Register *s2reg,
     bool is64bit = false, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateCompareInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *s1reg,
-    TR::Register *s2reg, bool is64bit = false, TR::Instruction *preced = NULL)
-{
-    return Inst_Compare(cg, node, s1reg, s2reg, is64bit, preced);
-}
 
 /**
  * @brief Generates CCMP or CCMN (immediate) instruction
@@ -959,13 +694,6 @@ TR::Instruction *Inst_ConditionalCompareImm(TR::CodeGenerator *cg, TR::Node *nod
     uint32_t conditionFlags, TR::ARM64ConditionCode cc, bool is64bit = false, bool isNegative = false,
     TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateConditionalCompareImmInstruction(TR::CodeGenerator *cg, TR::Node *node,
-    TR::Register *sreg, uint32_t imm, uint32_t conditionFlags, TR::ARM64ConditionCode cc, bool is64bit = false,
-    bool isNegative = false, TR::Instruction *preced = NULL)
-{
-    return Inst_ConditionalCompareImm(cg, node, sreg, imm, conditionFlags, cc, is64bit, isNegative, preced);
-}
-
 /**
  * @brief Generates CCMP or CCMN (register) instruction
  *
@@ -984,13 +712,6 @@ TR::Instruction *Inst_ConditionalCompare(TR::CodeGenerator *cg, TR::Node *node, 
     TR::Register *sreg2, uint32_t conditionFlags, TR::ARM64ConditionCode cc, bool is64bit = false,
     bool isNegative = false, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateConditionalCompareInstruction(TR::CodeGenerator *cg, TR::Node *node,
-    TR::Register *sreg1, TR::Register *sreg2, uint32_t conditionFlags, TR::ARM64ConditionCode cc, bool is64bit = false,
-    bool isNegative = false, TR::Instruction *preced = NULL)
-{
-    return Inst_ConditionalCompare(cg, node, sreg1, sreg2, conditionFlags, cc, is64bit, isNegative, preced);
-}
-
 /*
  * @brief Generates TST (immediate) instruction
  * @param[in] cg : CodeGenerator
@@ -1005,12 +726,6 @@ inline TR::Instruction *generateConditionalCompareInstruction(TR::CodeGenerator 
 TR::Instruction *Inst_TestImm(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg, int32_t imm, bool N = false,
     bool is64bit = false, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateTestImmInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg,
-    int32_t imm, bool N = false, bool is64bit = false, TR::Instruction *preced = NULL)
-{
-    return Inst_TestImm(cg, node, sreg, imm, N, is64bit, preced);
-}
-
 /*
  * @brief Generates TST (register) instruction
  * @param[in] cg : CodeGenerator
@@ -1023,12 +738,6 @@ inline TR::Instruction *generateTestImmInstruction(TR::CodeGenerator *cg, TR::No
  */
 TR::Instruction *Inst_Test(TR::CodeGenerator *cg, TR::Node *node, TR::Register *s1reg, TR::Register *s2reg,
     bool is64bit = false, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateTestInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *s1reg,
-    TR::Register *s2reg, bool is64bit = false, TR::Instruction *preced = NULL)
-{
-    return Inst_Test(cg, node, s1reg, s2reg, is64bit, preced);
-}
 
 /*
  * @brief Generates MOV (register) instruction
@@ -1043,12 +752,6 @@ inline TR::Instruction *generateTestInstruction(TR::CodeGenerator *cg, TR::Node 
 TR::Instruction *Inst_Mov(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
     bool is64bit = true, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateMovInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
-    TR::Register *sreg, bool is64bit = true, TR::Instruction *preced = NULL)
-{
-    return Inst_Mov(cg, node, treg, sreg, is64bit, preced);
-}
-
 /*
  * @brief Generates MVN (register) instruction
  * @param[in] cg : CodeGenerator
@@ -1062,12 +765,6 @@ inline TR::Instruction *generateMovInstruction(TR::CodeGenerator *cg, TR::Node *
 TR::Instruction *Inst_Mvn(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
     bool is64bit = true, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateMvnInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
-    TR::Register *sreg, bool is64bit = true, TR::Instruction *preced = NULL)
-{
-    return Inst_Mvn(cg, node, treg, sreg, is64bit, preced);
-}
-
 /*
  * @brief Generates NEG (register) instruction
  * @param[in] cg : CodeGenerator
@@ -1080,12 +777,6 @@ inline TR::Instruction *generateMvnInstruction(TR::CodeGenerator *cg, TR::Node *
  */
 TR::Instruction *Inst_Neg(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
     bool is64bit = false, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateNegInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
-    TR::Register *sreg, bool is64bit = false, TR::Instruction *preced = NULL)
-{
-    return Inst_Neg(cg, node, treg, sreg, is64bit, preced);
-}
 
 /*
  * @brief Generates MOV (bitmask immediate) instruction
@@ -1101,12 +792,6 @@ inline TR::Instruction *generateNegInstruction(TR::CodeGenerator *cg, TR::Node *
 TR::Instruction *Inst_MovBitMask(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, bool N, uint32_t imm,
     bool is64bit = true, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateMovBitMaskInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, bool N,
-    uint32_t imm, bool is64bit = true, TR::Instruction *preced = NULL)
-{
-    return Inst_MovBitMask(cg, node, treg, N, imm, is64bit, preced);
-}
-
 /*
  * @brief Generates MUL (register) instruction
  * @param[in] cg : CodeGenerator
@@ -1119,12 +804,6 @@ inline TR::Instruction *generateMovBitMaskInstruction(TR::CodeGenerator *cg, TR:
  */
 TR::Instruction *Inst_Mul(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
     TR::Register *s2reg, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
-    TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced = NULL)
-{
-    return Inst_Mul(cg, node, treg, s1reg, s2reg, preced);
-}
 
 /*
  * @brief Generates MUL (register) instruction
@@ -1140,12 +819,6 @@ inline TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *
 TR::Instruction *Inst_Mul(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
     TR::Register *s2reg, bool is64bit, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
-    TR::Register *s1reg, TR::Register *s2reg, bool is64bit, TR::Instruction *preced = NULL)
-{
-    return Inst_Mul(cg, node, treg, s1reg, s2reg, is64bit, preced);
-}
-
 /*
  * @brief Generates CSET instruction
  * @param[in] cg : CodeGenerator
@@ -1158,12 +831,6 @@ inline TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *
  */
 TR::Instruction *Inst_CSet(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::ARM64ConditionCode cc,
     bool is64bit = true, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateCSetInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
-    TR::ARM64ConditionCode cc, bool is64bit = true, TR::Instruction *preced = NULL)
-{
-    return Inst_CSet(cg, node, treg, cc, is64bit, preced);
-}
 
 /*
  * @brief Generates CINC instruction
@@ -1179,12 +846,6 @@ inline TR::Instruction *generateCSetInstruction(TR::CodeGenerator *cg, TR::Node 
 TR::Instruction *Inst_CInc(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
     TR::ARM64ConditionCode cc, bool is64bit, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateCIncInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
-    TR::Register *sreg, TR::ARM64ConditionCode cc, bool is64bit, TR::Instruction *preced = NULL)
-{
-    return Inst_CInc(cg, node, treg, sreg, cc, is64bit, preced);
-}
-
 /*
  * @brief Generates data synchronization instruction
  * @param[in] cg : CodeGenerator
@@ -1197,12 +858,6 @@ inline TR::Instruction *generateCIncInstruction(TR::CodeGenerator *cg, TR::Node 
 TR::ARM64SynchronizationInstruction *Inst_Synchronization(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     OP::AArch64BarrierLimitation lim, TR::Instruction *preced = NULL);
 
-inline TR::ARM64SynchronizationInstruction *generateSynchronizationInstruction(TR::CodeGenerator *cg, OP::Mnemonic op,
-    TR::Node *node, OP::AArch64BarrierLimitation lim, TR::Instruction *preced = NULL)
-{
-    return Inst_Synchronization(cg, op, node, lim, preced);
-}
-
 /*
  * @brief Generates exception generating instruction
  * @param[in] cg : CodeGenerator
@@ -1214,12 +869,6 @@ inline TR::ARM64SynchronizationInstruction *generateSynchronizationInstruction(T
  */
 TR::ARM64ExceptionInstruction *Inst_Exception(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uint32_t imm,
     TR::Instruction *preced = NULL);
-
-inline TR::ARM64ExceptionInstruction *generateExceptionInstruction(TR::CodeGenerator *cg, OP::Mnemonic op,
-    TR::Node *node, uint32_t imm, TR::Instruction *preced = NULL)
-{
-    return Inst_Exception(cg, op, node, imm, preced);
-}
 
 /**
  * @brief Generates ubfx instruction
@@ -1242,12 +891,6 @@ inline TR::ARM64ExceptionInstruction *generateExceptionInstruction(TR::CodeGener
 TR::Instruction *Inst_UBFX(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t lsb,
     uint32_t width, bool is64bit, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateUBFXInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
-    TR::Register *sreg, uint32_t lsb, uint32_t width, bool is64bit, TR::Instruction *preced = NULL)
-{
-    return Inst_UBFX(cg, node, treg, sreg, lsb, width, is64bit, preced);
-}
-
 /**
  * @brief Generates ubfiz instruction
  *
@@ -1268,12 +911,6 @@ inline TR::Instruction *generateUBFXInstruction(TR::CodeGenerator *cg, TR::Node 
  */
 TR::Instruction *Inst_UBFIZ(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t lsb,
     uint32_t width, bool is64bit, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateUBFIZInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
-    TR::Register *sreg, uint32_t lsb, uint32_t width, bool is64bit, TR::Instruction *preced = NULL)
-{
-    return Inst_UBFIZ(cg, node, treg, sreg, lsb, width, is64bit, preced);
-}
 
 /**
  * @brief Generates bfi instruction
@@ -1296,12 +933,6 @@ inline TR::Instruction *generateUBFIZInstruction(TR::CodeGenerator *cg, TR::Node
 TR::Instruction *Inst_BFI(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t lsb,
     uint32_t width, bool is64bit, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateBFIInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
-    TR::Register *sreg, uint32_t lsb, uint32_t width, bool is64bit, TR::Instruction *preced = NULL)
-{
-    return Inst_BFI(cg, node, treg, sreg, lsb, width, is64bit, preced);
-}
-
 /**
  * @brief Generates vector shift left immediate instruction
  *
@@ -1316,12 +947,6 @@ inline TR::Instruction *generateBFIInstruction(TR::CodeGenerator *cg, TR::Node *
  */
 TR::Instruction *Inst_VectorShiftImmediate(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *sreg, uint32_t shiftAmount, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateVectorShiftImmediateInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, TR::Instruction *preced = NULL)
-{
-    return Inst_VectorShiftImmediate(cg, op, node, treg, sreg, shiftAmount, preced);
-}
 
 /**
  * @brief Generates vector unsigned extend long instruction
@@ -1338,12 +963,6 @@ inline TR::Instruction *generateVectorShiftImmediateInstruction(TR::CodeGenerato
 TR::Instruction *Inst_VectorUXTL(TR::CodeGenerator *cg, TR::DataType elementType, TR::Node *node, TR::Register *treg,
     TR::Register *sreg, bool isUXTL2, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateVectorUXTLInstruction(TR::CodeGenerator *cg, TR::DataType elementType, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, bool isUXTL2, TR::Instruction *preced = NULL)
-{
-    return Inst_VectorUXTL(cg, elementType, node, treg, sreg, isUXTL2, preced);
-}
-
 /**
  * @brief Generates duplicate vector element instruction
  *
@@ -1358,12 +977,6 @@ inline TR::Instruction *generateVectorUXTLInstruction(TR::CodeGenerator *cg, TR:
  */
 TR::Instruction *Inst_VectorDupElement(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateVectorDupElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced = NULL)
-{
-    return Inst_VectorDupElement(cg, op, node, treg, sreg, srcIndex, preced);
-}
 
 /**
  * @brief Generates signed or unsigned move vector element to general purpose register instruction
@@ -1380,12 +993,6 @@ inline TR::Instruction *generateVectorDupElementInstruction(TR::CodeGenerator *c
 TR::Instruction *Inst_MovVectorElementToGPR(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced = NULL);
 
-inline TR::Instruction *generateMovVectorElementToGPRInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced = NULL)
-{
-    return Inst_MovVectorElementToGPR(cg, op, node, treg, sreg, srcIndex, preced);
-}
-
 /**
  * @brief Generates move general purpose register to vector element instruction
  *
@@ -1400,12 +1007,6 @@ inline TR::Instruction *generateMovVectorElementToGPRInstruction(TR::CodeGenerat
  */
 TR::Instruction *Inst_MovGPRToVectorElement(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *sreg, uint32_t trgIndex, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateMovGPRToVectorElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, uint32_t trgIndex, TR::Instruction *preced = NULL)
-{
-    return Inst_MovGPRToVectorElement(cg, op, node, treg, sreg, trgIndex, preced);
-}
 
 /**
  * @brief Generates move vector element instruction
@@ -1422,12 +1023,6 @@ inline TR::Instruction *generateMovGPRToVectorElementInstruction(TR::CodeGenerat
  */
 TR::Instruction *Inst_MovVectorElement(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *sreg, uint32_t trgIndex, uint32_t srcIndex, TR::Instruction *preced = NULL);
-
-inline TR::Instruction *generateMovVectorElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, uint32_t trgIndex, uint32_t srcIndex, TR::Instruction *preced = NULL)
-{
-    return Inst_MovVectorElement(cg, op, node, treg, sreg, trgIndex, srcIndex, preced);
-}
 
 #ifdef J9_PROJECT_SPECIFIC
 /*

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -7442,7 +7442,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::Code
         TR::Instruction *lastInstruction = cg->getAppendInstruction();
         if (lastInstruction->getOpCodeValue() == OP::bl
             && lastInstruction->getNode()->getSymbolReference()->getReferenceNumber() == TR_aThrow) {
-            lastInstruction = generateInstruction(cg, OP::bad, node, lastInstruction);
+            lastInstruction = Inst(cg, OP::bad, node, lastInstruction);
         }
     }
 

--- a/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
@@ -51,7 +51,7 @@ TEST_P(ARM64Trg1ImmEncodingTest, encode) {
     auto trgReg = cg()->machine()->getRealRegister(std::get<1>(GetParam()));
     auto imm = std::get<2>(GetParam());
 
-    auto instr = generateTrg1ImmInstruction(cg(), std::get<0>(GetParam()), fakeNode, trgReg, imm);
+    auto instr = Inst_Trg1Imm(cg(), std::get<0>(GetParam()), fakeNode, trgReg, imm);
 
     ASSERT_EQ(std::get<3>(GetParam()), encodeInstruction(instr));
 }
@@ -63,7 +63,7 @@ TEST_P(ARM64Trg1ImmShiftedEncodingTest, encode) {
     auto imm = std::get<2>(GetParam());
     auto shiftAmount = std::get<3>(GetParam());
 
-    auto instr = generateTrg1ImmShiftedInstruction(cg(), std::get<0>(GetParam()), fakeNode, trgReg, imm, shiftAmount);
+    auto instr = Inst_Trg1ImmShifted(cg(), std::get<0>(GetParam()), fakeNode, trgReg, imm, shiftAmount);
 
     ASSERT_EQ(std::get<4>(GetParam()), encodeInstruction(instr));
 }
@@ -74,7 +74,7 @@ TEST_P(ARM64Trg1Src1EncodingTest, encode) {
     auto trgReg = cg()->machine()->getRealRegister(std::get<1>(GetParam()));
     auto src1Reg = cg()->machine()->getRealRegister(std::get<2>(GetParam()));
 
-    auto instr = generateTrg1Src1Instruction(cg(), std::get<0>(GetParam()), fakeNode, trgReg, src1Reg);
+    auto instr = Inst_Trg1Src1(cg(), std::get<0>(GetParam()), fakeNode, trgReg, src1Reg);
 
     ASSERT_EQ(std::get<3>(GetParam()), encodeInstruction(instr));
 }
@@ -86,7 +86,7 @@ TEST_P(ARM64Trg1Src2EncodingTest, encode) {
     auto src1Reg = cg()->machine()->getRealRegister(std::get<2>(GetParam()));
     auto src2Reg = cg()->machine()->getRealRegister(std::get<3>(GetParam()));
 
-    auto instr = generateTrg1Src2Instruction(cg(), std::get<0>(GetParam()), fakeNode, trgReg, src1Reg, src2Reg);
+    auto instr = Inst_Trg1Src2(cg(), std::get<0>(GetParam()), fakeNode, trgReg, src1Reg, src2Reg);
 
     ASSERT_EQ(std::get<4>(GetParam()), encodeInstruction(instr));
 }
@@ -98,7 +98,7 @@ TEST_P(ARM64Trg1Src2IndexedElementEncodingTest, encode) {
     auto src1Reg = cg()->machine()->getRealRegister(std::get<2>(GetParam()));
     auto src2Reg = cg()->machine()->getRealRegister(std::get<3>(GetParam()));
 
-    auto instr = generateTrg1Src2IndexedElementInstruction(cg(), std::get<0>(GetParam()), fakeNode, trgReg, src1Reg, src2Reg, std::get<4>(GetParam()));
+    auto instr = Inst_Trg1Src2IndexedElement(cg(), std::get<0>(GetParam()), fakeNode, trgReg, src1Reg, src2Reg, std::get<4>(GetParam()));
 
     ASSERT_EQ(std::get<5>(GetParam()), encodeInstruction(instr));
 }
@@ -110,7 +110,7 @@ TEST_P(ARM64Trg1Src2ImmEncodingTest, encode) {
     auto src1Reg = cg()->machine()->getRealRegister(std::get<2>(GetParam()));
     auto src2Reg = cg()->machine()->getRealRegister(std::get<3>(GetParam()));
 
-    auto instr = generateTrg1Src2ImmInstruction(cg(), std::get<0>(GetParam()), fakeNode, trgReg, src1Reg, src2Reg, std::get<4>(GetParam()));
+    auto instr = Inst_Trg1Src2Imm(cg(), std::get<0>(GetParam()), fakeNode, trgReg, src1Reg, src2Reg, std::get<4>(GetParam()));
 
     ASSERT_EQ(std::get<5>(GetParam()), encodeInstruction(instr));
 }
@@ -122,7 +122,7 @@ TEST_P(ARM64VectorShiftImmediateEncodingTest, encode) {
     auto trgReg = cg()->machine()->getRealRegister(std::get<1>(GetParam()));
     auto src1Reg = cg()->machine()->getRealRegister(std::get<2>(GetParam()));
 
-    auto instr = generateVectorShiftImmediateInstruction(cg(), std::get<0>(GetParam()), fakeNode, trgReg, src1Reg, std::get<3>(GetParam()));
+    auto instr = Inst_VectorShiftImmediate(cg(), std::get<0>(GetParam()), fakeNode, trgReg, src1Reg, std::get<3>(GetParam()));
 
     ASSERT_EQ(std::get<4>(GetParam()), encodeInstruction(instr));
 }
@@ -154,7 +154,7 @@ TEST_P(ARM64VectorDupElementEncodingTest, encode) {
     auto op = std::get<0>(GetParam());
     auto srcIndex = std::get<3>(GetParam());
 
-    auto instr = generateVectorDupElementInstruction(cg(), op, fakeNode, trgReg, srcReg, srcIndex);
+    auto instr = Inst_VectorDupElement(cg(), op, fakeNode, trgReg, srcReg, srcIndex);
 
     ASSERT_EQ(encodeInstruction(instr), std::get<4>(GetParam()));
 }
@@ -167,7 +167,7 @@ TEST_P(ARM64MovVectorElementToGPREncodingTest, encode) {
     auto op = std::get<0>(GetParam());
     auto srcIndex = std::get<3>(GetParam());
 
-    auto instr = generateMovVectorElementToGPRInstruction(cg(), op, fakeNode, trgReg, srcReg, srcIndex);
+    auto instr = Inst_MovVectorElementToGPR(cg(), op, fakeNode, trgReg, srcReg, srcIndex);
 
     ASSERT_EQ(encodeInstruction(instr), std::get<4>(GetParam()));
 }
@@ -180,7 +180,7 @@ TEST_P(ARM64MovGPRToVectorElementEncodingTest, encode) {
     auto op = std::get<0>(GetParam());
     auto trgIndex = std::get<3>(GetParam());
 
-    auto instr = generateMovGPRToVectorElementInstruction(cg(), op, fakeNode, trgReg, srcReg, trgIndex);
+    auto instr = Inst_MovGPRToVectorElement(cg(), op, fakeNode, trgReg, srcReg, trgIndex);
 
     ASSERT_EQ(encodeInstruction(instr), std::get<4>(GetParam()));
 }
@@ -194,7 +194,7 @@ TEST_P(ARM64MovVectorElementEncodingTest, encode) {
     auto trgIndex = std::get<3>(GetParam());
     auto srcIndex = std::get<4>(GetParam());
 
-    auto instr = generateMovVectorElementInstruction(cg(), op, fakeNode, trgReg, srcReg, trgIndex, srcIndex);
+    auto instr = Inst_MovVectorElement(cg(), op, fakeNode, trgReg, srcReg, trgIndex, srcIndex);
 
     ASSERT_EQ(encodeInstruction(instr), std::get<5>(GetParam()));
 }
@@ -210,7 +210,7 @@ TEST_P(ARM64Src1ImmCondEncodingTest, encode) {
     auto isNegative = (op == TR::InstOpCode::ccmnimmx || op == TR::InstOpCode::ccmnimmw);
     auto is64bit = (op == TR::InstOpCode::ccmpimmx || op == TR::InstOpCode::ccmnimmx);
 
-    auto instr = generateConditionalCompareImmInstruction(cg(), fakeNode, srcReg, imm, conditionFlags, cc, is64bit, isNegative);
+    auto instr = Inst_ConditionalCompareImm(cg(), fakeNode, srcReg, imm, conditionFlags, cc, is64bit, isNegative);
     ASSERT_EQ(encodeInstruction(instr), std::get<5>(GetParam()));
 }
 
@@ -225,7 +225,7 @@ TEST_P(ARM64Src2CondEncodingTest, encode) {
     auto isNegative = (op == TR::InstOpCode::ccmnx || op == TR::InstOpCode::ccmnw);
     auto is64bit = (op == TR::InstOpCode::ccmpx || op == TR::InstOpCode::ccmnx);
 
-    auto instr = generateConditionalCompareInstruction(cg(), fakeNode, srcReg1, srcReg2, conditionFlags, cc, is64bit, isNegative);
+    auto instr = Inst_ConditionalCompare(cg(), fakeNode, srcReg1, srcReg2, conditionFlags, cc, is64bit, isNegative);
     ASSERT_EQ(encodeInstruction(instr), std::get<5>(GetParam()));
 }
 
@@ -237,7 +237,7 @@ TEST_P(ARM64CINCEncodingTest, encode) {
     auto is64bit = std::get<0>(GetParam());
     auto cc = std::get<3>(GetParam());
 
-    auto instr = generateCIncInstruction(cg(), fakeNode, trgReg, srcReg, cc, is64bit);
+    auto instr = Inst_CInc(cg(), fakeNode, trgReg, srcReg, cc, is64bit);
     ASSERT_EQ(encodeInstruction(instr), std::get<4>(GetParam()));
 }
 


### PR DESCRIPTION
This commit removes `generate*Instruction()` functions for AArch64 that are replaced by `Inst_*()` instructions.