### PR TITLE
Fix initialization of compilation classes and structures

### DIFF
--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1235,19 +1235,18 @@ class TR_FilterBST {
 public:
     void *operator new(size_t size, TR::PersistentAllocator &allocator);
 
-    TR_FilterBST(int32_t type, int32_t optionSet)
+    TR_FilterBST(int32_t type, int32_t optionSet, int32_t lineNumber = 0)
+        : _name(NULL)
+        , _class(NULL)
+        , _signature(NULL)
+        , _regex(NULL)
+        , _optionSet(optionSet)
+        , _lineNumber(lineNumber)
+        , _nameLen(0)
+        , _filterType((char)type)
+        , subGroup(NULL)
     {
-        memset(this, 0, sizeof(TR_FilterBST));
-        _filterType = (char)type;
-        _optionSet = optionSet;
-    }
-
-    TR_FilterBST(int32_t type, int32_t optionSet, int32_t lineNumber)
-    {
-        memset(this, 0, sizeof(TR_FilterBST));
-        _filterType = (char)type;
-        _optionSet = optionSet;
-        _lineNumber = lineNumber;
+        memset(_child, 0, sizeof(_child)); ///< in C++11 notation: _child = {0};
     }
 
     bool isExclude() { return _filterType <= TR_FILTER_EXCLUDE_MAX; }

--- a/compiler/infra/Statistics.hpp
+++ b/compiler/infra/Statistics.hpp
@@ -303,7 +303,15 @@ public:
         NAME_LEN = 31
     };
 
-    TR_StatsEvents() {}
+    TR_StatsEvents()
+        : _binNames(NULL)
+        , _minEventId(0)
+        , _numSamples(0)
+        , _numInvalidSamples(0)
+    {
+        memset(_name, 0, sizeof(_name)); ///< in C++11 notation: _name = {0};
+        memset(_bins, 0, sizeof(_bins)); ///< in C++11 notation: _bins = {0};
+    }
 
     TR_StatsEvents(const char *name, const char **binNames, int minEventId) { init(name, binNames, minEventId); }
 


### PR DESCRIPTION
Paired with OpenJ9 commit with the same title

It is just to properly initialize structs that the https://github.com/eclipse-openj9/openj9/pull/24564 needs properly initialized.

Related to the closed https://github.com/eclipse-openj9/openj9-omr/pull/286
