### PR TITLE
Add portlib API to read /proc/diskstats

### DIFF
--- a/fvtest/porttest/si.cpp
+++ b/fvtest/porttest/si.cpp
@@ -19,6 +19,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
 
+/* Assisted-by: IBM Bob */
+
 /*
  * $RCSfile: si.c,v $
  * $Revision: 1.64 $
@@ -32,6 +34,7 @@
 #include <string.h>
 #include <stdio.h>
 #if defined(LINUX)
+#include <cinttypes>
 #include <linux/magic.h>
 #include <sys/vfs.h>
 #include <sched.h>
@@ -3216,3 +3219,176 @@ TEST(PortSysinfoTest, NumberOfContextSwitchesIncreasesMonotonically)
 	ASSERT_EQ(omrsysinfo_get_number_context_switches(&switches), OMRPORT_ERROR_SYSINFO_NOT_SUPPORTED);
 #endif /* defined(LINUX) */
 }
+
+#if defined(LINUX) && !defined(OMRZTPF)
+/**
+ * Test omrsysinfo_get_all_diskstats: basic call succeeds, returns at least one
+ * entry, and all entries have plausible major device numbers.
+ */
+TEST(PortSysinfoTest, sysinfo_test_get_all_diskstats_basic)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
+	const char *testName = "omrsysinfo_test_get_all_diskstats_basic";
+	OMRDiskStatsEntry *entries = NULL;
+	uintptr_t numEntries = 0;
+	int32_t rc = 0;
+
+	reportTestEntry(OMRPORTLIB, testName);
+
+	rc = omrsysinfo_get_all_diskstats(&entries, &numEntries);
+	if (0 != rc) {
+		outputErrorMessage(
+			PORTTEST_ERROR_ARGS,
+			"omrsysinfo_get_all_diskstats() failed with rc=%d\n", rc);
+		reportTestExit(OMRPORTLIB, testName);
+		return;
+	}
+
+	if (0 == numEntries) {
+		outputErrorMessage(
+			PORTTEST_ERROR_ARGS,
+			"omrsysinfo_get_all_diskstats() succeeded but returned zero entries\n");
+		omrmem_free_memory(entries);
+		reportTestExit(OMRPORTLIB, testName);
+		return;
+	}
+
+	if (NULL == entries) {
+		outputErrorMessage(
+			PORTTEST_ERROR_ARGS,
+			"omrsysinfo_get_all_diskstats() returned NULL array with numEntries=%zu\n",
+			numEntries);
+		reportTestExit(OMRPORTLIB, testName);
+		return;
+	}
+
+	portTestEnv->log("omrsysinfo_get_all_diskstats(): found %zu disk entries\n", numEntries);
+
+	/* Spot-check every entry: Linux major device numbers are in [1, 259]; 0 is
+	 * reserved and should not appear in /proc/diskstats. */
+	for (uintptr_t i = 0; i < numEntries; i++) {
+		portTestEnv->log(
+			LEVEL_VERBOSE,
+			"  [%zu] major=%u minor=%u rdIos=%llu wrIos=%llu\n",
+			i,
+			entries[i].majorNum,
+			entries[i].minorNum,
+			(unsigned long long)entries[i].stats.rdIos,
+			(unsigned long long)entries[i].stats.wrIos);
+		if (entries[i].majorNum > 259) {
+			outputErrorMessage(
+				PORTTEST_ERROR_ARGS,
+				"entry[%zu] has unexpected majorNum=%u (expected 1-259)\n",
+				i, entries[i].majorNum);
+		}
+	}
+
+	omrmem_free_memory(entries);
+	reportTestExit(OMRPORTLIB, testName);
+}
+
+#define J9SYSINFO_DISKSTATS_LINE_LENGTH 1024
+/**
+ * Test omrsysinfo_get_all_diskstats: the number of entries returned matches
+ * the number of parseable 13-field (post-sscanf) lines in /proc/diskstats.
+ */
+TEST(PortSysinfoTest, sysinfo_test_get_all_diskstats_count_matches_proc)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
+	const char *testName = "omrsysinfo_test_get_all_diskstats_count_matches_proc";
+	OMRDiskStatsEntry *entries = NULL;
+	uintptr_t numEntries = 0;
+	int32_t rc = 0;
+
+	reportTestEntry(OMRPORTLIB, testName);
+
+	rc = omrsysinfo_get_all_diskstats(&entries, &numEntries);
+	if (0 != rc) {
+		outputErrorMessage(
+			PORTTEST_ERROR_ARGS,
+			"omrsysinfo_get_all_diskstats() failed with rc=%d\n", rc);
+		reportTestExit(OMRPORTLIB, testName);
+		return;
+	}
+
+	/* Independently count parseable lines from /proc/diskstats using the same
+	 * sscanf pattern the implementation uses: major minor name(skipped) + 11
+	 * uint64 fields = 13 values matched by sscanf (name is consumed via %*s
+	 * but not counted in the return value).
+	 */
+	FILE *fp = fopen("/proc/diskstats", "r");
+	if (NULL == fp) {
+		outputErrorMessage(
+			PORTTEST_ERROR_ARGS,
+			"Could not open /proc/diskstats for cross-check\n");
+		omrmem_free_memory(entries);
+		reportTestExit(OMRPORTLIB, testName);
+		return;
+	}
+
+	uintptr_t lineCount = 0;
+	char line[J9SYSINFO_DISKSTATS_LINE_LENGTH];
+	while (NULL != fgets(line, sizeof(line), fp)) {
+		uint32_t maj = 0;
+		uint32_t min = 0;
+		uint64_t f[11];
+		int matched = sscanf(
+			line,
+			"%" SCNu32 " %" SCNu32 " %*s"
+			" %" SCNu64 " %" SCNu64 " %" SCNu64 " %" SCNu64
+			" %" SCNu64 " %" SCNu64 " %" SCNu64 " %" SCNu64
+			" %" SCNu64 " %" SCNu64 " %" SCNu64,
+			&maj, &min,
+			&f[0], &f[1], &f[2], &f[3],
+			&f[4], &f[5], &f[6], &f[7],
+			&f[8], &f[9], &f[10]);
+
+#define PROC_DISKSTATS_EXPECTED_NUMBER_OF_FIELDS 13
+
+		if (PROC_DISKSTATS_EXPECTED_NUMBER_OF_FIELDS == matched) {
+			lineCount += 1;
+		}
+	}
+	fclose(fp);
+
+	if (lineCount != numEntries) {
+		outputErrorMessage(
+			PORTTEST_ERROR_ARGS,
+			"omrsysinfo_get_all_diskstats() returned %zu entries but /proc/diskstats "
+			"has %zu parseable lines\n",
+			numEntries, lineCount);
+	} else {
+		portTestEnv->log(
+			"omrsysinfo_get_all_diskstats(): entry count %zu matches /proc/diskstats\n",
+			numEntries);
+	}
+
+	omrmem_free_memory(entries);
+	reportTestExit(OMRPORTLIB, testName);
+}
+#else /* defined(LINUX) && !defined(OMRZTPF) */
+/**
+ * Test omrsysinfo_get_all_diskstats: on unsupported platforms the function
+ * must return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM.
+ */
+TEST(PortSysinfoTest, sysinfo_test_get_all_diskstats_unsupported)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
+	const char *testName = "omrsysinfo_test_get_all_diskstats_unsupported";
+	OMRDiskStatsEntry *entries = NULL;
+	uintptr_t numEntries = 0;
+
+	reportTestEntry(OMRPORTLIB, testName);
+
+	int32_t rc = omrsysinfo_get_all_diskstats(&entries, &numEntries);
+	if (OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM != rc) {
+		outputErrorMessage(
+			PORTTEST_ERROR_ARGS,
+			"omrsysinfo_get_all_diskstats() expected OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM "
+			"(%d), got rc=%d\n",
+			OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM, rc);
+	}
+
+	reportTestExit(OMRPORTLIB, testName);
+}
+#endif /* defined(LINUX) && !defined(OMRZTPF) */

--- a/fvtest/porttest/si.cpp
+++ b/fvtest/porttest/si.cpp
@@ -3264,8 +3264,45 @@ TEST(PortSysinfoTest, sysinfo_test_get_all_diskstats_basic)
 
 	portTestEnv->log("omrsysinfo_get_all_diskstats(): found %zu disk entries\n", numEntries);
 
-	/* Spot-check every entry: Linux major device numbers are in [1, 259]; 0 is
-	 * reserved and should not appear in /proc/diskstats. */
+	/* Determine the highest block device major number registered on this kernel
+	 * by reading /proc/devices, so the check stays valid as new major numbers
+	 * are allocated in future kernel releases.
+	 */
+	uint32_t maxMajorNum = 0;
+	FILE *devfp = fopen("/proc/devices", "r");
+
+#define J9SYSINFO_PROC_DEVICES_LINE_LENGTH 128
+
+	if (NULL != devfp) {
+		char devline[J9SYSINFO_PROC_DEVICES_LINE_LENGTH];
+		BOOLEAN inBlockSection = FALSE;
+		while (NULL != fgets(devline, sizeof(devline), devfp)) {
+			if (0 == strncmp(devline, "Block devices:", 14)) {
+				inBlockSection = TRUE;
+				continue;
+			}
+			if (inBlockSection) {
+				uint32_t maj = 0;
+				if (1 == sscanf(devline, " %u ", &maj)) {
+					if (maj > maxMajorNum) {
+						maxMajorNum = maj;
+					}
+				}
+			}
+		}
+		fclose(devfp);
+	}
+	if (0 == maxMajorNum) {
+		/* /proc/devices unreadable or empty — fall back to the theoretical
+		 * kernel maximum: major numbers are 12 bits wide (MINORBITS=20).
+		 */
+		maxMajorNum = (1U << 12) - 1;
+	}
+	portTestEnv->log("omrsysinfo_get_all_diskstats(): highest registered block major=%u\n", maxMajorNum);
+
+	/* Spot-check every entry: major 0 is reserved and should not appear in
+	 * /proc/diskstats; upper bound is determined dynamically above.
+	 */
 	for (uintptr_t i = 0; i < numEntries; i++) {
 		portTestEnv->log(
 			LEVEL_VERBOSE,
@@ -3275,11 +3312,11 @@ TEST(PortSysinfoTest, sysinfo_test_get_all_diskstats_basic)
 			entries[i].minorNum,
 			(unsigned long long)entries[i].stats.rdIos,
 			(unsigned long long)entries[i].stats.wrIos);
-		if (entries[i].majorNum > 259) {
+		if ((0 == entries[i].majorNum) || (entries[i].majorNum > maxMajorNum)) {
 			outputErrorMessage(
 				PORTTEST_ERROR_ARGS,
-				"entry[%zu] has unexpected majorNum=%u (expected 1-259)\n",
-				i, entries[i].majorNum);
+				"entry[%zu] has unexpected majorNum=%u (expected 1-%u)\n",
+				i, entries[i].majorNum, maxMajorNum);
 		}
 	}
 
@@ -3328,10 +3365,14 @@ TEST(PortSysinfoTest, sysinfo_test_get_all_diskstats_count_matches_proc)
 
 	uintptr_t lineCount = 0;
 	char line[J9SYSINFO_DISKSTATS_LINE_LENGTH];
+
+#define PROC_DISKSTATS_EXPECTED_NUMBER_OF_FIELDS 13
+
 	while (NULL != fgets(line, sizeof(line), fp)) {
 		uint32_t maj = 0;
 		uint32_t min = 0;
-		uint64_t f[11];
+		/* Storage for remaining fields */
+		uint64_t f[PROC_DISKSTATS_EXPECTED_NUMBER_OF_FIELDS - 2];
 		int matched = sscanf(
 			line,
 			"%" SCNu32 " %" SCNu32 " %*s"
@@ -3342,8 +3383,6 @@ TEST(PortSysinfoTest, sysinfo_test_get_all_diskstats_count_matches_proc)
 			&f[0], &f[1], &f[2], &f[3],
 			&f[4], &f[5], &f[6], &f[7],
 			&f[8], &f[9], &f[10]);
-
-#define PROC_DISKSTATS_EXPECTED_NUMBER_OF_FIELDS 13
 
 		if (PROC_DISKSTATS_EXPECTED_NUMBER_OF_FIELDS == matched) {
 			lineCount += 1;

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1399,20 +1399,30 @@ typedef struct OMROSKernelInfo {
  * Structure to hold block device statistics.
  * Primarily derived from Linux's /proc/diskstats and /sys/block/<device>/stat.
  * Used by omrsysinfo_get_block_device_stats.
+ * See the Linux kernel's Documentation/admin-guide/iostats.rst for details.
  */
 typedef struct OMRBlockDeviceStats {
-	uint64_t rdIos;
-	uint64_t rdMerges;
-	uint64_t rdSectors;
-	uint64_t rdTicksMs;
-	uint64_t wrIos;
-	uint64_t wrMerges;
-	uint64_t wrSectors;
-	uint64_t wrTicksMs;
-	uint64_t inFlight;
-	uint64_t ioTicksMs;
-	uint64_t timeInQueueMs;
+	uint64_t rdIos; /**< Total number of reads completed successfully. */
+	uint64_t rdMerges; /**< Adjacent reads may be merged, this counts how many times it was done. */
+	uint64_t rdSectors; /**< Total number of sectors read successfully. */
+	uint64_t rdTicksMs; /**< Total number of milliseconds spent on all reads. */
+	uint64_t wrIos; /**< Total number of writes completed successfully. */
+	uint64_t wrMerges; /**< Adjacent writes may be merged, this counts how many times it was done. */
+	uint64_t wrSectors; /**< Total number of sectors written successfully. */
+	uint64_t wrTicksMs; /**< Total number of milliseconds spent on all writes. */
+	uint64_t inFlight; /**<  Number of I/Os currently in progress. */
+	uint64_t ioTicksMs; /**< Number of milliseconds spent doing I/Os, increases as long as inFlight is non-zero. */
+	uint64_t timeInQueueMs; /**< Weighted number of milliseconds spent doing I/Os. */
 } OMRBlockDeviceStats;
+
+/**
+ * Structure to hold a single block device statistics entry from /proc/diskstats.
+ */
+typedef struct OMRDiskStatsEntry {
+	uint32_t majorNum; /**< Linux device major number */
+	uint32_t minorNum; /**< Linux device minor number */
+	OMRBlockDeviceStats stats; /**< @see OMRBlockDeviceStats */
+} OMRDiskStatsEntry;
 
 /* bitwise flags indicating cgroup subsystems supported by portlibrary */
 #define OMR_CGROUP_SUBSYSTEM_CPU ((uint64_t)0x1)
@@ -2666,6 +2676,8 @@ typedef struct OMRPortLibrary {
 	void (*sysinfo_cgroup_subsystem_iterator_destroy)(struct OMRPortLibrary *portLibrary, struct OMRCgroupMetricIteratorState *state);
 	/** see @ref omrsysinfo.c::omrsysinfo_get_block_device_stats "omrsysinfo_get_block_device_stats"*/
 	int32_t (*sysinfo_get_block_device_stats)(struct OMRPortLibrary *portLibrary, const char *device, struct OMRBlockDeviceStats *stats);
+	/** see @ref omrsysinfo.c::omrsysinfo_get_all_diskstats "omrsysinfo_get_all_diskstats"*/
+	int32_t (*sysinfo_get_all_diskstats)(struct OMRPortLibrary *portLibrary, OMRDiskStatsEntry **diskStatsArray, uintptr_t *numEntries);
 	/** see @ref omrsysinfo.c::omrsysinfo_get_block_device_for_path "omrsysinfo_get_block_device_for_path"*/
 	char* (*sysinfo_get_block_device_for_path)(struct OMRPortLibrary *portLibrary, const char *path);
 	/** see @ref omrsysinfo.c::omrsysinfo_get_block_device_for_swap "omrsysinfo_get_block_device_for_swap"*/
@@ -3326,6 +3338,7 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrsysinfo_cgroup_subsystem_iterator_destroy(param1) privateOmrPortLibrary->sysinfo_cgroup_subsystem_iterator_destroy(privateOmrPortLibrary, param1)
 #define omrsysinfo_get_process_start_time(param1, param2) privateOmrPortLibrary->sysinfo_get_process_start_time(privateOmrPortLibrary, param1, param2)
 #define omrsysinfo_get_block_device_stats(param1, param2) privateOmrPortLibrary->sysinfo_get_block_device_stats(privateOmrPortLibrary, (param1), (param2))
+#define omrsysinfo_get_all_diskstats(param1, param2) privateOmrPortLibrary->sysinfo_get_all_diskstats(privateOmrPortLibrary, (param1), (param2))
 #define omrsysinfo_get_block_device_for_path(param1) privateOmrPortLibrary->sysinfo_get_block_device_for_path(privateOmrPortLibrary, (param1))
 #define omrsysinfo_get_block_device_for_swap() privateOmrPortLibrary->sysinfo_get_block_device_for_swap(privateOmrPortLibrary)
 #define omrsysinfo_get_number_context_switches(param1) privateOmrPortLibrary->sysinfo_get_number_context_switches(privateOmrPortLibrary, param1)

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -342,6 +342,7 @@ static OMRPortLibrary MainPortLibraryTable = {
 	omrsysinfo_cgroup_subsystem_iterator_next, /* sysinfo_cgroup_subsystem_iterator_next */
 	omrsysinfo_cgroup_subsystem_iterator_destroy, /* sysinfo_cgroup_subsystem_iterator_destroy */
 	omrsysinfo_get_block_device_stats, /* sysinfo_get_block_device_stats */
+	omrsysinfo_get_all_diskstats, /* sysinfo_get_all_diskstats */
 	omrsysinfo_get_block_device_for_path, /* sysinfo_get_block_device_for_path */
 	omrsysinfo_get_block_device_for_swap, /* sysinfo_get_block_device_for_swap */
 	omrsysinfo_get_process_start_time, /* sysinfo_get_process_start_time */

--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -1231,7 +1231,26 @@ omrsysinfo_cgroup_subsystem_iterator_destroy(struct OMRPortLibrary *portLibrary,
  * @return 0 on success, error code on failure
  */
 int32_t
-omrsysinfo_get_block_device_stats(struct OMRPortLibrary *portLibrary, const char *device, struct OMRBlockDeviceStats *stats)
+omrsysinfo_get_block_device_stats(struct OMRPortLibrary *portLibrary, const char *device, OMRBlockDeviceStats *stats)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}
+
+/**
+ * Read /proc/diskstats and return an array of disk statistics.
+ *
+ * The /proc/diskstats file contains one line per block device. To get stats for a single device @see omrsysinfo_get_block_device_stats().
+ * A block device is a device that provides a contiguous sequence of bytes, such as a disk or a partition.
+ *
+ * @param[in] portLibrary The port library
+ * @param[out] diskStatsArray Pointer to receive the allocated array of OMRDiskStatsEntry structures.
+ *                            Caller must free this memory using portLibrary->mem_free_memory.
+ * @param[out] numEntries Pointer to receive the number of entries in the array.
+ *
+ * @return 0 on success, error code on failure
+ */
+int32_t
+omrsysinfo_get_all_diskstats(struct OMRPortLibrary *portLibrary, OMRDiskStatsEntry **diskStatsArray, uintptr_t *numEntries)
 {
 	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
 }

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -671,6 +671,8 @@ extern J9_CFUNC void
 omrsysinfo_cgroup_subsystem_iterator_destroy(struct OMRPortLibrary *portLibrary, struct OMRCgroupMetricIteratorState *state);
 extern J9_CFUNC int32_t
 omrsysinfo_get_block_device_stats(struct OMRPortLibrary *portLibrary, const char *device, struct OMRBlockDeviceStats *stats);
+extern J9_CFUNC int32_t
+omrsysinfo_get_all_diskstats(struct OMRPortLibrary *portLibrary, OMRDiskStatsEntry **diskStatsArray, uintptr_t *numEntries);
 extern J9_CFUNC char*
 omrsysinfo_get_block_device_for_path(struct OMRPortLibrary *portLibrary, const char *path);
 extern J9_CFUNC char*

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -8206,8 +8206,8 @@ getBlockDeviceFromDevNode(struct OMRPortLibrary *portLibrary, const char *path)
 {
 	struct stat st;
 	dev_t rdev;
-	uint32_t majorNum;
-	uint32_t minorNum;
+	uint32_t majorNum = 0;
+	uint32_t minorNum = 0;
 
 	if (0 != stat(path, &st) || !S_ISBLK(st.st_mode)) {
 		return NULL;

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -8092,6 +8092,110 @@ omrsysinfo_get_block_device_stats(struct OMRPortLibrary *portLibrary, const char
 #endif /* defined(LINUX) && !defined(OMRZTPF) */
 }
 
+int32_t
+omrsysinfo_get_all_diskstats(struct OMRPortLibrary *portLibrary, OMRDiskStatsEntry **diskStatsArray, uintptr_t *numEntries)
+{
+#if defined(LINUX) && !defined(OMRZTPF)
+	FILE *fp = NULL;
+	BOOLEAN fileError = FALSE;
+	char line[1024];
+	OMRDiskStatsEntry *entries = NULL;
+	uintptr_t entryCount = 0;
+	uintptr_t entryCapacity = 32; /* Initial capacity */
+
+	Assert_PRT_true(NULL != diskStatsArray);
+	Assert_PRT_true(NULL != numEntries);
+
+	*diskStatsArray = NULL;
+	*numEntries = 0;
+
+	fp = fopen("/proc/diskstats", "r");
+	if (NULL == fp) {
+		return OMRPORT_ERROR_SYSINFO_GET_STATS_FAILED;
+	}
+
+	/* Allocate initial array */
+	entries = portLibrary->mem_allocate_memory(portLibrary, entryCapacity * sizeof(OMRDiskStatsEntry), OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
+	if (NULL == entries) {
+		fclose(fp);
+		return OMRPORT_ERROR_SYSINFO_MEMORY_ALLOC_FAILED;
+	}
+
+	while (NULL != fgets(line, sizeof(line), fp)) {
+		OMRDiskStatsEntry *entry = NULL;
+		int32_t fieldsScanned = -1;
+
+		/* Expand array if needed */
+		if (entryCount >= entryCapacity) {
+			OMRDiskStatsEntry *newEntries = NULL;
+			entryCapacity *= 2;
+			newEntries = portLibrary->mem_allocate_memory(portLibrary, entryCapacity * sizeof(OMRDiskStatsEntry), OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
+			if (NULL == newEntries) {
+				portLibrary->mem_free_memory(portLibrary, entries);
+				fclose(fp);
+				return OMRPORT_ERROR_SYSINFO_MEMORY_ALLOC_FAILED;
+			}
+			memcpy(newEntries, entries, entryCount * sizeof(OMRDiskStatsEntry));
+			portLibrary->mem_free_memory(portLibrary, entries);
+			entries = newEntries;
+		}
+
+		entry = &entries[entryCount];
+		memset(entry, 0, sizeof(*entry));
+
+		/**
+		 * /proc/diskstats will contain stats for all block devices, including loopback devices, so for some devices some fields may not have any useful information.
+		 * Example lines:
+		 *    7       0 loop0 14 0 34 0 0 0 0 0 0 12 0 0 0 0 0 0 0
+		 *  253       0 vda 253577 692 10152429 257844 220542 76769 27042797 1186350 0 225343 1452673 58162 3 319974328 3535 17383 4942
+		 *  259       3 nvme0n1 3542726956 60899914 362789954336 1459512716 3910333145 79029193 825867034897 846565026 0 310821636 2306077743 0 0 0 0
+		 * Note: device name (3rd field) is skipped.
+		 */
+		fieldsScanned = sscanf(
+			line,
+			"%" SCNu32 " %" SCNu32 " %*s %" SCNu64 " %" SCNu64 " %" SCNu64 " %" SCNu64 " %" SCNu64 " %" SCNu64 " %" SCNu64 " %" SCNu64 " %" SCNu64 " %" SCNu64 " %" SCNu64,
+			&entry->majorNum,
+			&entry->minorNum,
+			/* The device name appears in this field in the diskstats output but is skipped because we don't need it for anything. */
+			&entry->stats.rdIos,
+			&entry->stats.rdMerges,
+			&entry->stats.rdSectors,
+			&entry->stats.rdTicksMs,
+			&entry->stats.wrIos,
+			&entry->stats.wrMerges,
+			&entry->stats.wrSectors,
+			&entry->stats.wrTicksMs,
+			&entry->stats.inFlight,
+			&entry->stats.ioTicksMs,
+			&entry->stats.timeInQueueMs);
+
+#define PROC_DISKSTATS_EXPECTED_NUMBER_OF_FIELDS 13
+
+		if (PROC_DISKSTATS_EXPECTED_NUMBER_OF_FIELDS == fieldsScanned) {
+			entryCount += 1;
+		}
+	}
+
+	/* Check if fgets() saw an error (as opposed to EOF), before closing the stream. */
+	fileError = (0 != ferror(fp));
+
+	fclose(fp);
+
+	if ((TRUE == fileError) || (0 == entryCount)) {
+		/* Error while reading or no valid entries found. */
+		portLibrary->mem_free_memory(portLibrary, entries);
+		return OMRPORT_ERROR_SYSINFO_GET_STATS_FAILED;
+	}
+
+	*diskStatsArray = entries;
+	*numEntries = entryCount;
+	return 0;
+
+#else /* defined(LINUX) && !defined(OMRZTPF) */
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+#endif /* defined(LINUX) && !defined(OMRZTPF) */
+}
+
 #if defined(LINUX) && !defined(OMRZTPF)
 /**
  * Helper: resolve /sys/dev/block/<maj>:<min> to /sys/block/<dev>
@@ -8251,8 +8355,11 @@ omrsysinfo_get_block_device_for_swap(struct OMRPortLibrary *portLibrary)
 
 		int32_t fieldsScanned = sscanf(line, "%s %31s %" SCNu64 " %" SCNu64 " %" SCNd32,
 									   path, type, &size, &used, &priority);
+
+#define PROC_SWAPS_EXPECTED_NUMBER_OF_FIELDS 5
+
 		/* Skip malformed lines */
-		if (5 != fieldsScanned) {
+		if (PROC_SWAPS_EXPECTED_NUMBER_OF_FIELDS != fieldsScanned) {
 			continue;
 		}
 

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -8040,14 +8040,15 @@ omrsysinfo_get_process_name(struct OMRPortLibrary *portLibrary, uintptr_t pid)
 int32_t
 omrsysinfo_get_block_device_stats(struct OMRPortLibrary *portLibrary, const char *device, struct OMRBlockDeviceStats *stats)
 {
-	Assert_PRT_true(NULL != device);
-	Assert_PRT_true(NULL != stats);
 #if defined(LINUX) && !defined(OMRZTPF)
 	char pathBuf[PATH_MAX];
 	char contentBuf[1024];
 	intptr_t fd = -1;
 	intptr_t bytesRead = -1;
 	int32_t fieldsScanned = -1;
+
+	Assert_PRT_true(NULL != device);
+	Assert_PRT_true(NULL != stats);
 
 	portLibrary->str_printf(portLibrary, pathBuf, sizeof(pathBuf), "/sys/block/%s/stat", device);
 

--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -2208,6 +2208,12 @@ omrsysinfo_get_block_device_stats(struct OMRPortLibrary *portLibrary, const char
 	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
 }
 
+int32_t
+omrsysinfo_get_all_diskstats(struct OMRPortLibrary *portLibrary, OMRDiskStatsEntry **diskStatsArray, uintptr_t *numEntries)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}
+
 char *
 omrsysinfo_get_block_device_for_path(struct OMRPortLibrary *portLibrary, const char *path)
 {


### PR DESCRIPTION
This PR is primarily to add an API to read the contents of `/proc/diskstats` on Linux systems. This complements the similar APIs introduced in https://github.com/eclipse-omr/omr/pull/8119. Those APIs don't work well in containers because the actual block device a file resides on may be obscured by an intermediate filesystem like overlayfs, or `/sys/block` and/or `/sys/dev/block` may not be mounted into the container. This API allows the user to see the contents of `/proc/diskstats` which shows stats for all devices and is more likely to be mounted in containers.

This PR also includes two minor changes based on feedback in https://github.com/eclipse-omr/omr/pull/8119.

This PR includes test cases developed with the help of generative AI.