### PR TITLE
Add getter in OMROptions for recomp trigger count

### DIFF
--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -2262,6 +2262,8 @@ public:
      */
     int32_t getJProfilingLoopRecompThreshold() { return _jProfilingLoopRecompThreshold; }
 
+    int32_t getColdPatRecompTriggerCount() { return _coldPathRecompTriggerCount; }
+
     inline static float getMinProfiledCheckcastFrequency() { return _minProfiledCheckcastFrequency / ((float)100.0); }
 
     static bool isQuickstartDetected() { return _quickstartDetected; }


### PR DESCRIPTION
In https://github.com/eclipse-omr/omr/pull/8404, new OMR options to control counter value to trigger recompilation due to phase change was introduced. This commit adds the required getter for the value so that it can be used by the recompilation infrastructure.