### PR TITLE
Notify compilation when unused monitor autos are pruned

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -378,6 +378,20 @@ public:
      */
     bool validateTargetToBeInlined(TR_ResolvedMethod *implementer) { return true; }
 
+    /**
+     * @brief removes a monitor temporary from the compilation's bookkeeping.
+     *
+     * A monitor temporary is a local variable (automatic symbol) used to
+     * hold a reference to a monitored object across a synchronized region.
+     * This base implementation is a no-op.  Downstream compilers that track
+     * monitor autos (for example, to support locking-order analysis or
+     * relocatable compilations) should override this method.
+     *
+     * @param sym the automatic symbol representing the monitor temporary
+     *            to be removed
+     */
+    void removeMonitorAuto(TR::RegisterMappedSymbol *sym) {}
+
     // ..........................................................................
     // Optimizer mechanics
     int16_t getOptIndex() { return _currentOptIndex; }

--- a/compiler/il/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/OMRResolvedMethodSymbol.cpp
@@ -2065,6 +2065,12 @@ void OMR::ResolvedMethodSymbol::removeUnusedLocals()
 #ifdef DEBUG
             removedSize += (uint32_t)local->getSize();
 #endif
+            // If the unused local was used to hold a monitored object, notify
+            // the compilation so it can remove it from any monitor-auto bookkeeping
+            if (local->holdsMonitoredObject()) {
+                self()->comp()->removeMonitorAuto(local);
+            }
+
             _automaticList.removeNext(prev);
 
             if (prev) {


### PR DESCRIPTION
Downstream projects may maintain a separate list for monitor autos that is a subset of _automaticList. removeUnusedLocals() would remove locals with ref count 0, and that would then result in the downstream implementation's monitor autos list containing stale entries.

This commit introduces a no-op helper removeMonitorAuto that downstream projects can override. This helper gets called in removeUnusedLocals() if the local about to be removed holds a monitored object.

Related Issue: https://github.com/eclipse-openj9/openj9/issues/23934

Relevant part of the discussion: https://github.com/eclipse-openj9/openj9/issues/23934#issuecomment-5331976664