### PR TITLE
Add test to recompile method if cold version of loop is executed

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -3655,7 +3655,10 @@ void OMR::Options::jitPreProcess()
     _blockShufflingSequence = (char *)"S";
     _delayCompileWithCPUBurn = 0;
     _largeNumberOfLoops = 6500;
-    _coldPathRecompTriggerCount = 100;
+    // Value set to positive non zero through JIT option will enable the code
+    // that inserts the call to recompilation method in cold path in various
+    // optimization.
+    _coldPathRecompTriggerCount = -1;
     _serverInlinerBorderFrequency = -1;
     _serverInlinerVeryColdBorderFrequency = -1;
 

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -4499,6 +4499,20 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
         properRegion->removeExternalEdgeTo(predBlock->getStructureOf(), succBlock->getStructureOf()->getNumber());
     }
 
+#ifdef J9_PROJECT_SPECIFIC
+    // Phase-change recompilation trigger.
+    //
+    if (comp()->getMethodHotness() >= hot && comp()->getRecompilationInfo() != NULL
+        && comp()->getOptions()->getColdPathRecompTriggerCount() > 0
+        && !(comp()->getOptimizationPlan()->getDoNotInsertPhaseChangeRecomp() || comp()->isProfilingCompilation())
+        && !shouldOnlySpecializeLoops() && !_neitherLoopCold
+        && performTransformation(comp(),
+            "%s Inserting phase-change recompilation counter into cold loop pre-header block_%d\n",
+            OPT_DETAILS_LOOP_VERSIONER, clonedLoopInvariantBlock)) {
+        TR::TransformUtil::insertColdPathCounterRecompilation(comp(), clonedLoopInvariantBlock);
+    }
+#endif
+
     if (trace())
         comp()->dumpMethodTrees(log, "Trees after this versioning");
 }


### PR DESCRIPTION
This PR adds following two commits. 

1.  Set default value of the coldPathRecompTrigger to -1 : Set coldPathRecompTrigger option value -1 by default to disable insertion of the recompilation trigger in cold code by optimizer.
Different optimization wishes to emit the recompilation trigger in cold path should check if the value is set to non zero positive integer to insert recompilation trigger in cold path.

2. Add test to recompile method if cold version of loop is executed : Controlled by coldPathRecompTriggerCount value, a non zero positive coldPathRecompTriggerCount will enable LoopVersion to emit the test in a versioned cold loop to recompile the method if cold path is executed coldPathRecompTriggerCount times.
