### PR TITLE
Change doxygen comments in port/common/omrtime.c

### DIFF
--- a/port/common/omrtime.c
+++ b/port/common/omrtime.c
@@ -34,9 +34,9 @@
  * Retrieve the current value of system clock and convert to milliseconds since
  * January 1st 1970 UTC.
  *
- * @param[in] portLibrary The port library.
+ * @param[in] portLibrary The port library
  *
- * @return 0 on failure, time value in milliseconds on success.
+ * @return 0 on failure, time value in milliseconds on success
  */
 int64_t
 omrtime_current_time_millis(struct OMRPortLibrary *portLibrary)
@@ -48,9 +48,10 @@ omrtime_current_time_millis(struct OMRPortLibrary *portLibrary)
  * Query OS for timestamp.
  * Retrieve the current value of a high resolution counter in nanoseconds.
  *
- * @param[in] portLibrary The port library.
+ * @param[in] portLibrary The port library
  *
- * @return platform-dependent time value in nanoseconds. 0 or -ve numbers may be returned.
+ * @return platform-dependent high-resolution time value in nanoseconds;
+ *  the absolute value and sign should not be relied upon
  */
 int64_t
 omrtime_nano_time(struct OMRPortLibrary *portLibrary)
@@ -62,35 +63,37 @@ omrtime_nano_time(struct OMRPortLibrary *portLibrary)
  * Query OS for timestamp.
  * Retrieve the current value of the high-resolution performance counter.
  *
- * @param[in] portLibrary The port library.
+ * @param[in] portLibrary The port library
  *
- * @return 0 on failure, time value on success.
+ * @return 0 on failure, time value on success
  */
 uint64_t
 omrtime_hires_clock(struct OMRPortLibrary *portLibrary)
 {
 	return 0;
 }
+
 /**
  * Query OS for clock frequency
  * Retrieves the frequency of the high-resolution performance counter.
  *
- * @param[in] portLibrary The port library.
+ * @param[in] portLibrary The port library
  *
- * @return 0 on failure, number of ticks per second on success.
+ * @return 0 on failure, number of ticks per second on success
  */
 uint64_t
 omrtime_hires_frequency(struct OMRPortLibrary *portLibrary)
 {
 	return 0;
 }
+
 /**
  * Calculate time difference between two hires clock timer values @ref omrtime_hires_clock.
  *
  * Given a start and end time determine how much time elapsed.  Return the value as
  * requested by the required resolution
  *
- * @param[in] portLibrary The port library.
+ * @param[in] portLibrary The port library
  * @param[in] startTime Timer value at start of timing interval
  * @param[in] endTime Timer value at end of timing interval
  * @param[in] requiredResolution Returned timer resolution as a fraction of a second.  For example:
@@ -98,7 +101,7 @@ omrtime_hires_frequency(struct OMRPortLibrary *portLibrary)
  *  \arg 1,000 to report elapsed time in milliseconds
  *  \arg 1,000,000 to report elapsed time in microseconds
  *
- * @return 0 on failure, time difference on success.
+ * @return 0 on failure, time difference on success
  *
  * @note helper macros are available for commonly requested resolution
  *  \arg OMRPORT_TIME_DELTA_IN_SECONDS return timer value in seconds.
@@ -111,13 +114,15 @@ omrtime_hires_delta(struct OMRPortLibrary *portLibrary, uint64_t startTime, uint
 {
 	return 0;
 }
+
 /**
  * Query OS for timestamp.
  * Retrieve the current value of system clock and convert to milliseconds.
  *
- * @param[in] portLibrary The port library.
+ * @param[in] portLibrary The port library
  *
- * @return 0 on failure, time value in milliseconds on success.
+ * @return 0 on failure, time value in milliseconds on success
+ *
  * @deprecated Use @ref omrtime_hires_clock and @ref omrtime_hires_delta
  */
 uintptr_t
@@ -125,13 +130,15 @@ omrtime_msec_clock(struct OMRPortLibrary *portLibrary)
 {
 	return 0;
 }
+
 /**
  * Query OS for timestamp.
  * Retrieve the current value of system clock and convert to microseconds.
  *
- * @param[in] portLibrary The port library.
+ * @param[in] portLibrary The port library
  *
- * @return 0 on failure, time value in microseconds on success.
+ * @return 0 on failure, time value in microseconds on success
+ *
  * @deprecated Use @ref omrtime_hires_clock and @ref omrtime_hires_delta
  */
 uintptr_t
@@ -139,30 +146,31 @@ omrtime_usec_clock(struct OMRPortLibrary *portLibrary)
 {
 	return 0;
 }
+
 /**
  * Query OS for timestamp.
  * Retrieve calendar time in nanoseconds since the Epoch.
  * Some platforms do not support nanosecond resolution, in this case
  * the highest calendar time resolution supported will be converted to nanoseconds.
  *
- * @param[in] portLibrary The port library.
- * @param[out] success Indicates if the call was successful 
- *  
- * @return time value in nanoseconds on success.
+ * @param[in] portLibrary The port library
+ * @param[out] success Indicates if the call was successful
  *
+ * @return time value in nanoseconds on success
  */
 uint64_t
 omrtime_current_time_nanos(struct OMRPortLibrary *portLibrary, uintptr_t *success)
 {
 	return 0;
 }
+
 /**
  * PortLibrary shutdown.
  *
  * This function is called during shutdown of the portLibrary.  Any resources that were created by @ref omrtime_startup
  * should be destroyed here.
  *
- * @param[in] portLib The port library.
+ * @param[in] portLib The port library
  *
  * @note Most implementations will be empty.
  */
@@ -170,6 +178,7 @@ void
 omrtime_shutdown(struct OMRPortLibrary *portLibrary)
 {
 }
+
 /**
  * PortLibrary startup.
  *
@@ -177,7 +186,7 @@ omrtime_shutdown(struct OMRPortLibrary *portLibrary)
  * the time operations may be created here.  All resources created here should be destroyed
  * in @ref omrtime_shutdown.
  *
- * @param[in] portLibrary The port library.
+ * @param[in] portLibrary The port library
  *
  * @return 0 on success, negative error code on failure.  Error code values returned are
  * \arg OMRPORT_ERROR_STARTUP_TIME


### PR DESCRIPTION
- Change the description of return value of omrtime_nano_time()
- Clean up periods at the end of `@param` and `@return` tags for consistency
- Add empty lines between functions