### PR TITLE
WIP: implement support for trampolines within OMR

### DIFF
--- a/compiler/compile/OMRResolvedMethod.hpp
+++ b/compiler/compile/OMRResolvedMethod.hpp
@@ -97,7 +97,14 @@ public:
 
     virtual uint8_t *code() { return NULL; }
 
-    virtual TR_OpaqueMethodBlock *getPersistentIdentifier() { return (TR_OpaqueMethodBlock *)getEntryPoint(); }
+    virtual TR_OpaqueMethodBlock *getPersistentIdentifier()
+    {
+        /*
+         * This has to be kept in sync with OMR::VMMethodEnv::startPC().
+         * If changed, startPC() has to be update accordingly.
+         */
+        return (TR_OpaqueMethodBlock *)getEntryPoint();
+    }
 
     virtual bool isInterpreted() { return startAddressForJittedMethod() == 0; }
 

--- a/compiler/control/SimpleJit.cpp
+++ b/compiler/control/SimpleJit.cpp
@@ -84,7 +84,6 @@ static void initializeCodeCache(TR::CodeCacheManager &codeCacheManager)
     setupCodeCacheParameters(&codeCacheConfig._trampolineCodeSize, &codeCacheConfig._mccCallbacks,
         &codeCacheConfig._numOfRuntimeHelpers, &codeCacheConfig._CCPreLoadedCodeSize);
 
-    codeCacheConfig._needsMethodTrampolines = false;
     codeCacheConfig._trampolineSpacePercentage = 5;
     codeCacheConfig._allowedToGrowCache = true;
     codeCacheConfig._lowCodeCacheThreshold = 0;

--- a/compiler/env/OMRFrontEnd.cpp
+++ b/compiler/env/OMRFrontEnd.cpp
@@ -35,6 +35,8 @@
 #include "infra/Assert.hpp"
 #include "ras/Logger.hpp"
 #include "runtime/CodeCacheManager.hpp"
+#include "codegen/CodeGenerator.hpp"
+#include "il/SymbolReference.hpp"
 
 #if defined(OMR_OS_WINDOWS)
 #include <windows.h>
@@ -76,8 +78,28 @@ TR_Debug *OMR::FrontEnd::createDebug(TR::Compilation *comp) { return createDebug
 void OMR::FrontEnd::reserveTrampolineIfNecessary(TR::Compilation *comp, TR::SymbolReference *symRef,
     bool inBinaryEncoding)
 {
-    // Do we handle trampoline reservations? return here for now.
-    return;
+    TR_OpaqueMethodBlock *method
+        = symRef->getSymbol()->castToResolvedMethodSymbol()->getResolvedMethod()->getPersistentIdentifier();
+
+    auto err = comp->cg()->getCodeCache()->reserveResolvedTrampoline(method, inBinaryEncoding);
+
+    TR_ASSERT(err == CodeCacheErrorCode::ERRORCODE_SUCCESS, "Failed to reserve trampoline!");
+}
+
+intptr_t OMR::FrontEnd::methodTrampolineLookup(TR::Compilation *comp, TR::SymbolReference *symRef, void *callSite)
+{
+    TR_ASSERT(!symRef->isUnresolved(), "No need to lookup trampolines for unresolved methods.\n");
+
+    reserveTrampolineIfNecessary(comp, symRef, false);
+
+    TR_OpaqueMethodBlock *method
+        = symRef->getSymbol()->castToResolvedMethodSymbol()->getResolvedMethod()->getPersistentIdentifier();
+
+    OMR::CodeCacheTrampolineCode *trampoline = TR::CodeCacheManager::instance()->findMethodTrampoline(method, callSite);
+
+    TR_ASSERT(trampoline != nullptr, "It should not fail since it is reserved first.\n");
+
+    return reinterpret_cast<intptr_t>(trampoline);
 }
 
 TR_ResolvedMethod *OMR::FrontEnd::createResolvedMethod(TR_Memory *trMemory, TR_OpaqueMethodBlock *aMethod,

--- a/compiler/env/OMRFrontEnd.hpp
+++ b/compiler/env/OMRFrontEnd.hpp
@@ -92,6 +92,8 @@ public:
     virtual void reserveTrampolineIfNecessary(TR::Compilation *comp, TR::SymbolReference *symRef,
         bool inBinaryEncoding);
 
+    virtual intptr_t methodTrampolineLookup(TR::Compilation *comp, TR::SymbolReference *symRef, void *callSite);
+
     TR_ResolvedMethod *createResolvedMethod(TR_Memory *trMemory, TR_OpaqueMethodBlock *aMethod,
         TR_ResolvedMethod *owningMethod, TR_OpaqueClassBlock *classForNewInstance);
 

--- a/compiler/env/OMRVMMethodEnv.hpp
+++ b/compiler/env/OMRVMMethodEnv.hpp
@@ -58,7 +58,14 @@ public:
      * \brief  Ask for the start PC of the provided method
      * \return the start PC, or 0 if unknown or not compiled
      */
-    uintptr_t startPC(TR_OpaqueMethodBlock *method) { return 0; }
+    uintptr_t startPC(TR_OpaqueMethodBlock *method)
+    {
+        /*
+         * Implementation of this method needs to be kept in sync with
+         * OMR::ResolvedMethod::getPersistentIdentifier().
+         */
+        return reinterpret_cast<uintptr_t>(method);
+    }
 };
 
 } // namespace OMR

--- a/compiler/riscv/codegen/RVInstruction.cpp
+++ b/compiler/riscv/codegen/RVInstruction.cpp
@@ -468,13 +468,15 @@ uint8_t *TR::JtypeInstruction::generateBinaryEncoding()
         TR::ResolvedMethodSymbol *sym = getSymbolReference()->getSymbol()->getResolvedMethodSymbol();
         TR_ResolvedMethod *resolvedMethod = sym == NULL ? NULL : sym->getResolvedMethod();
 
-        if (comp()->isRecursiveMethodTarget(resolvedMethod)) {
-            intptr_t jitToJitStart = cg()->getLinkage()->entryPointFromCompiledMethod();
-            offset = jitToJitStart - reinterpret_cast<intptr_t>(cursor);
-        } else {
-            offset = reinterpret_cast<intptr_t>(getSymbolReference()->getMethodAddress())
-                - reinterpret_cast<intptr_t>(cursor);
+        intptr_t destination = comp()->isRecursiveMethodTarget(resolvedMethod)
+            ? cg()->getLinkage()->entryPointFromCompiledMethod()
+            : reinterpret_cast<intptr_t>(getSymbolReference()->getMethodAddress());
+
+        if (cg()->directCallRequiresTrampoline(destination, reinterpret_cast<intptr_t>(cursor))) {
+            destination
+                = cg()->fe()->methodTrampolineLookup(comp(), getSymbolReference(), reinterpret_cast<void *>(cursor));
         }
+        offset = destination - reinterpret_cast<intptr_t>(cursor);
     } else {
         intptr_t destination = reinterpret_cast<intptr_t>(getLabelSymbol()->getCodeLocation());
         if (destination != 0) {

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -698,31 +698,11 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
         Inst_ITYPE(OP::_jalr, callNode, ra, target, 0, dependencies, cg());
     } else {
         auto targetAddr = callNode->getSymbolReference()->getMethodAddress();
-
-        if (targetAddr == NULL) {
-            /*
-             * If the target address is not known yet, we generate `jal` and hope that the target address
-             * offset would fit into 20bit immediate.
-             *
-             * This is the case of recursive calls.
-             */
-            Inst_JTYPE(OP::_jal, callNode, ra, 0, dependencies, callNode->getSymbolReference(), NULL, cg());
-        } else {
-            /*
-             * If the target address is known, we load it into a register and generate `jalr`. This may be
-             * wasteful in cases the target address offset would fit into 20bit immediate of `jal`. However,
-             * more often than not, non-jitted functions (library / runtime functions) are too far to fit in
-             * the immediate value.
-             *
-             * So, until a trampolines are implemented, we pay the price and load the target address into
-             * register.
-             *
-             * Note, that here we load the target address into link register (`ra`). It's going to be clobbered
-             * anyways and this way we do not need to allocate another one.
-             */
-            loadConstant64(cg(), callNode, reinterpret_cast<int64_t>(targetAddr), ra);
-            Inst_ITYPE(OP::_jalr, callNode, ra, ra, 0, dependencies, cg());
-        }
+        /*
+         * For simplicuty, generate `jal` and hope that the target address offset would
+         * fit into 20bit immediate.
+         */
+        Inst_JTYPE(OP::_jal, callNode, ra, 0, dependencies, callNode->getSymbolReference(), NULL, cg());
     }
 
     cg()->machine()->setLinkRegisterKilled(true);

--- a/compiler/runtime/OMRCodeCache.cpp
+++ b/compiler/runtime/OMRCodeCache.cpp
@@ -491,13 +491,16 @@ int32_t OMR::CodeCache::reserveResolvedTrampoline(TR_OpaqueMethodBlock *method, 
     if (!config.needsMethodTrampolines())
         return retValue;
 
-    // scope for cache critical section
     {
-        CacheCriticalSection reserveTrampoline(self());
+        CodeCacheHashEntry *entry = nullptr;
+        { // scope for cache critical section
+            CacheCriticalSection reserveTrampoline(self());
 
-        // see if a reservation for this method already exists, return corresponding
-        // code cache if thats the case
-        CodeCacheHashEntry *entry = _resolvedMethodHT->findResolvedMethod(method);
+            // see if a reservation for this method already exists, return corresponding
+            // code cache if thats the case
+            entry = _resolvedMethodHT->findResolvedMethod(method);
+        }
+
         if (!entry) {
             // Reserve a new trampoline since there is not an active reservation for given method
             //

--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -163,20 +163,7 @@ TR::CodeCache *OMR::CodeCacheManager::initialize(bool allocateMonolithicCodeCach
     if (!(_usageMonitor = TR::Monitor::create("CodeCacheUsageMonitor")))
         return NULL;
 
-#if defined(TR_HOST_POWER)
-#define REACHEABLE_RANGE_KB (32 * 1024)
-#elif defined(TR_HOST_ARM64)
-#define REACHEABLE_RANGE_KB (128 * 1024)
-#else
-#define REACHEABLE_RANGE_KB (2048 * 1024)
-#endif
-
-    config._needsMethodTrampolines = !(config.trampolineCodeSize() == 0 || config.maxNumberOfCodeCaches() == 1
-#if !defined(TR_HOST_POWER)
-        || (!TR::Options::getCmdLineOptions()->getOption(TR_StressTrampolines) && self()->usingRepository()
-            && config.codeCacheTotalKB() <= REACHEABLE_RANGE_KB)
-#endif
-    );
+    config._needsMethodTrampolines = config.trampolineCodeSize() != 0;
 
     _lowCodeCacheSpaceThresholdReached = false;
 

--- a/compiler/runtime/Trampoline.cpp
+++ b/compiler/runtime/Trampoline.cpp
@@ -34,6 +34,11 @@
 #include "runtime/Runtime.hpp"
 #include "env/CompilerEnv.hpp"
 
+#if defined(TR_TARGET_RISCV)
+#include "runtime/CodeSync.hpp"
+#include "codegen/RVInstructionUtils.hpp"
+#endif
+
 namespace TR {
 class CodeGenerator;
 }
@@ -369,6 +374,87 @@ void arm64CodeCacheParameters(int32_t *trampolineSize, void **callBacks, int32_t
 
 #endif /* TR_TARGET_ARM64 */
 
+#if defined(TR_TARGET_RISCV)
+
+#if defined(TR_TARGET_64BIT)
+/**
+ * On RV64, the trampoline is implemented as:
+ *
+ *   auipc t0,   0
+ *   ld    t0,   t0,   16
+ *   jalr  zero, t0,   0
+ *   .4byte 0
+ *   .8byte <target>
+ *
+ * The 4byte padding is there avoid unaligned read
+ * which may or may not be supported.
+ */
+struct RISCVTrampoline {
+    uint32_t code[4];
+    uint64_t target;
+};
+#else
+#error "RV32 not yet supported"
+#endif
+
+static constexpr int TRAMPOLINE_SIZE = sizeof(RISCVTrampoline);
+
+void riscvCodeCacheConfig(int32_t ccSizeInByte, int32_t *numTempTrampolines) { *numTempTrampolines = 0; }
+
+static void riscvCreateTrampoline(void *trampPtr, void *target)
+{
+    RISCVTrampoline *tramp = reinterpret_cast<RISCVTrampoline *>(trampPtr);
+    tramp->code[0] = TR_RISCV_UTYPE(TR::InstOpCode::_auipc, TR::RealRegister::t0, 0);
+    tramp->code[1] = TR_RISCV_ITYPE(TR::InstOpCode::_ld, TR::RealRegister::t0, TR::RealRegister::t0,
+        offsetof(RISCVTrampoline, target));
+    tramp->code[2] = TR_RISCV_ITYPE(TR::InstOpCode::_jalr, TR::RealRegister::zero, TR::RealRegister::t0, 0);
+    tramp->code[3] = 0;
+    tramp->target = reinterpret_cast<uint64_t>(target);
+}
+
+void riscvCreateHelperTrampolines(void *trampPtr, int32_t numHelpers)
+{
+    uint8_t *buffer = reinterpret_cast<uint8_t *>(trampPtr) + TRAMPOLINE_SIZE;
+    for (int32_t i = 1; i < numHelpers; i++, buffer += TRAMPOLINE_SIZE) {
+        riscvCreateTrampoline(buffer, runtimeHelperValue((TR_RuntimeHelper)i));
+    }
+
+#if defined(TR_HOST_RISCV)
+    riscvCodeSync((uint8_t *)trampPtr, TRAMPOLINE_SIZE * numHelpers);
+#endif
+}
+
+void riscvCreateMethodTrampoline(void *trampPtr, void *startPC, void *method)
+{
+    riscvCreateTrampoline(trampPtr, startPC);
+#if defined(TR_HOST_RISCV)
+    riscvCodeSync((uint8_t *)trampPtr, TRAMPOLINE_SIZE);
+#endif
+}
+
+bool riscvCodePatching(void *callee, void *callSite, void *currentPC, void *currentTramp, void *newAddrOfCallee,
+    void *extra)
+{
+    TR_UNIMPLEMENTED();
+}
+
+void riscvCodeCacheParameters(int32_t *trampolineSize, void **callBacks, int32_t *numHelpers,
+    int32_t *CCPreLoadedCodeSize)
+{
+    *trampolineSize = TRAMPOLINE_SIZE;
+    callBacks[0] = (void *)&riscvCodeCacheConfig;
+    callBacks[1] = (void *)&riscvCreateHelperTrampolines;
+    callBacks[2] = (void *)&riscvCreateMethodTrampoline;
+    callBacks[3] = (void *)&riscvCodePatching;
+    callBacks[4] = (void *)0; // CreatePreLoadedCCPreLoadedCode
+    *CCPreLoadedCodeSize = 0;
+    *numHelpers = TR_RISCVnumRuntimeHelpers;
+}
+
+#undef TRAMPOLINE_SIZE
+
+#endif /* TR_TARGET_RISCV */
+
 #if defined(J9ZOS390) && defined(TR_TARGET_S390) && !defined(TR_TARGET_64BIT)
 
 //-----------------------------------------------------------------------------
@@ -545,6 +631,11 @@ void setupCodeCacheParameters(int32_t *trampolineSize, OMR::CodeCacheCodeGenCall
 
 #if defined(TR_TARGET_ARM64)
     arm64CodeCacheParameters(trampolineSize, (void **)callBacks, numHelpers, CCPreLoadedCodeSize);
+    return;
+#endif
+
+#if defined(TR_TARGET_RISCV)
+    riscvCodeCacheParameters(trampolineSize, (void **)callBacks, numHelpers, CCPreLoadedCodeSize);
     return;
 #endif
 

--- a/compiler/runtime/Trampoline.cpp
+++ b/compiler/runtime/Trampoline.cpp
@@ -337,20 +337,36 @@ void arm64CodeCacheConfig(int32_t ccSizeInByte, int32_t *numTempTrampolines)
     *numTempTrampolines = 0;
 }
 
+static void arm64CreateTrampoline(void *trampPtr, void *target)
+{
+    int32_t *buffer = reinterpret_cast<int32_t *>(trampPtr);
+
+    *buffer = 0x58000050; // LDR R16 PC+8
+    buffer += 1;
+    *buffer = 0xD61F0200; // BR R16
+    buffer += 1;
+    *((intptr_t *)buffer) = reinterpret_cast<intptr_t>(target);
+    buffer += 2;
+}
+
 void arm64CreateHelperTrampolines(void *trampPtr, int32_t numHelpers)
 {
-    uint32_t *buffer = (uint32_t *)((uint8_t *)trampPtr + TRAMPOLINE_SIZE); // Skip the first trampoline for index 0
+    uint8_t *buffer = (uint8_t *)trampPtr + TRAMPOLINE_SIZE; // Skip the first trampoline for index 0
 
     omrthread_jit_write_protect_disable();
 
-    for (int32_t i = 1; i < numHelpers; i++) {
-        *((int32_t *)buffer) = 0x58000050; // LDR R16 PC+8
-        buffer += 1;
-        *buffer = 0xD61F0200; // BR R16
-        buffer += 1;
-        *((intptr_t *)buffer) = (intptr_t)runtimeHelperValue((TR_RuntimeHelper)i);
-        buffer += 2;
+    for (int32_t i = 1; i < numHelpers; i++, buffer += TRAMPOLINE_SIZE) {
+        arm64CreateTrampoline(buffer, runtimeHelperValue((TR_RuntimeHelper)i));
     }
+
+    omrthread_jit_write_protect_enable();
+}
+
+void arm64CreateMethodTrampoline(void *trampPtr, void *startPC, void *method)
+{
+    omrthread_jit_write_protect_disable();
+
+    arm64CreateTrampoline(trampPtr, startPC);
 
     omrthread_jit_write_protect_enable();
 }
@@ -361,7 +377,7 @@ void arm64CodeCacheParameters(int32_t *trampolineSize, void **callBacks, int32_t
     *trampolineSize = TRAMPOLINE_SIZE;
     callBacks[0] = (void *)&arm64CodeCacheConfig;
     callBacks[1] = (void *)&arm64CreateHelperTrampolines;
-    callBacks[2] = (void *)NULL;
+    callBacks[2] = (void *)&arm64CreateMethodTrampoline;
     callBacks[3] = (void *)NULL;
     callBacks[4] = (void *)0;
     *CCPreLoadedCodeSize = 0;

--- a/fvtest/compilertriltest/CallTest.cpp
+++ b/fvtest/compilertriltest/CallTest.cpp
@@ -34,7 +34,6 @@ TEST_F(CallTest, icallOracle) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
     char inputTrees[200] = {0};
     const auto format_string = "(method return=Int32 args=[Int32] (block (ireturn (icall address=0x%jX args=[Int32] (iload parm=0)) )  ))";

--- a/fvtest/compilertriltest/LinkageTest.cpp
+++ b/fvtest/compilertriltest/LinkageTest.cpp
@@ -88,7 +88,6 @@ TYPED_TEST(LinkageTest, InvalidLinkageTest) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -117,7 +116,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing1Arg) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -161,7 +159,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing2Arg) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -210,7 +207,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing3Arg) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -263,7 +259,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing4Arg) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -320,7 +315,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing5Arg) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -381,7 +375,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing6Arg) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -446,7 +439,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing7Arg) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -515,7 +507,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing8Arg) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -588,7 +579,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing9Arg) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -695,7 +685,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing2A
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -741,7 +730,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing3A
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -788,7 +776,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing4A
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -836,7 +823,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing5A
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -885,7 +871,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing6A
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -935,7 +920,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing7A
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -986,7 +970,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing8A
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -1038,7 +1021,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing9A
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -1379,7 +1361,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing1Arg) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
     auto callee_entry_point = getJitCompiledMethodReturning1stArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -1426,7 +1407,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing2Arg) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning2ndArgument<TypeParam>();
@@ -1478,7 +1458,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing3Arg) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning3rdArgument<TypeParam>();
@@ -1534,7 +1513,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing4Arg) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning4thArgument<TypeParam>();
@@ -1594,7 +1572,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing5Arg) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning5thArgument<TypeParam>();
@@ -1658,7 +1635,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing6Arg) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning6thArgument<TypeParam>();
@@ -1726,7 +1702,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing7Arg) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning7thArgument<TypeParam>();
@@ -1798,7 +1773,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing8Arg) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning8thArgument<TypeParam>();
@@ -1874,7 +1848,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing9Arg) {
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning9thArgument<TypeParam>();
@@ -2178,7 +2151,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing2ArgW
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning2ndArgumentFromMixedTypes<TypeParam>();
@@ -2227,7 +2199,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing3ArgW
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning3rdArgumentFromMixedTypes<TypeParam>();
@@ -2277,7 +2248,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing4ArgW
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning4thArgumentFromMixedTypes<TypeParam>();
@@ -2328,7 +2298,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing5ArgW
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning5thArgumentFromMixedTypes<TypeParam>();
@@ -2380,7 +2349,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing6ArgW
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning6thArgumentFromMixedTypes<TypeParam>();
@@ -2433,7 +2401,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing7ArgW
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning7thArgumentFromMixedTypes<TypeParam>();
@@ -2487,7 +2454,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing8ArgW
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning8thArgumentFromMixedTypes<TypeParam>();
@@ -2542,7 +2508,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing9ArgW
     SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning9thArgumentFromMixedTypes<TypeParam>();

--- a/fvtest/compilertriltest/MinimalTest.cpp
+++ b/fvtest/compilertriltest/MinimalTest.cpp
@@ -336,7 +336,6 @@ TEST_F(MinimalTest, MeaningOfLife)
    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-   SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
    auto entry = compile<MeaningOfLifeMethod>();
 
@@ -351,7 +350,6 @@ TEST_F(MinimalTest, ReturnArgI32)
    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-   SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
    auto entry = compile<ReturnArgI32Method>();
 
@@ -368,7 +366,6 @@ TEST_F(MinimalTest, MaxIfThen)
    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-   SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
    auto entry = compile<MaxIfThenMethod>();
 
@@ -386,7 +383,6 @@ TEST_F(MinimalTest, AddArgConst)
    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-   SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
    auto entry = compile<AddArgConstMethod>();
 
@@ -402,7 +398,6 @@ TEST_F(MinimalTest, SubArgArg)
    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-   SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
    auto entry = compile<SubArgArgMethod>();
 
@@ -420,7 +415,6 @@ TEST_F(MinimalTest, Factorial)
    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-   SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
    auto entry = compile<FactorialMethod>();
 
@@ -443,7 +437,6 @@ TEST_F(MinimalTest, RecursiveFibonnaci)
    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-   SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
    auto entry = compile<RecursiveFibonnaciMethod>();
 

--- a/fvtest/jitbuildertest/CMakeLists.txt
+++ b/fvtest/jitbuildertest/CMakeLists.txt
@@ -39,7 +39,7 @@ omr_add_executable(jitbuildertest NOWARNINGS
 	GlobalTest.cpp
 )
 
-if(OMR_HOST_ARCH STREQUAL "x86")
+if((OMR_HOST_ARCH STREQUAL "x86") OR (OMR_HOST_ARCH STREQUAL "riscv"))
 	if(OMR_OS_LINUX OR OMR_OS_OSX)
 		target_sources(jitbuildertest PRIVATE CallReturnTest.cpp)
 	endif()

--- a/fvtest/jitbuildertest/CMakeLists.txt
+++ b/fvtest/jitbuildertest/CMakeLists.txt
@@ -39,7 +39,7 @@ omr_add_executable(jitbuildertest NOWARNINGS
 	GlobalTest.cpp
 )
 
-if((OMR_HOST_ARCH STREQUAL "x86") OR (OMR_HOST_ARCH STREQUAL "riscv"))
+if((OMR_HOST_ARCH STREQUAL "x86") OR (OMR_HOST_ARCH STREQUAL "riscv") OR (OMR_HOST_ARCH STREQUAL "aarch64"))
 	if(OMR_OS_LINUX OR OMR_OS_OSX)
 		target_sources(jitbuildertest PRIVATE CallReturnTest.cpp)
 	endif()


### PR DESCRIPTION
For a long time calls to external (external to JIT) functions was really only supported on x86 due to lack of trampolines. This   somewhat hinders practical use of OMR's compiler component on platforms other than x86. 

This WIP PR explores what does it take to support calls to external functions on other platforms via trampolines.  It consist of two parts:

  1. changes to the common parts necessary, mainly initialization and creation of trampolines on demand
  2. changes to individual backends, mainly the code to generate trampoline code.

So far, only RISC-V and AArch64 backends have been changed, meaning on both platforms all call tests pass. This also means that JitBuilder is "supported" on AArch64 (in the sense all jitbuilder tests pass). 

One issue I hit on the way is #8419 - the PR contains a workaround commit. Clearly that commit is not a final solution, but I do not have enough understading as yet how to fix it properly and wanted to move forward. 