### PR TITLE
Prevent x86 Label MemoryReferences from creating address load registers

### DIFF
--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -178,15 +178,15 @@ void OMR::X86::AMD64::MemoryReference::finishInitialization(TR::CodeGenerator *c
         // Binary encoding will fatally assert otherwise.
         //
         mightNeedAddressRegister = false;
+    } else if (getLabel()) {
+        // Assume labels are in RIP range
+        //
+        mightNeedAddressRegister = false;
     } else if (!getBaseRegister() && !getIndexRegister()
         && (cg->needRelocationsForStatics() || cg->needClassAndMethodPointerRelocations()
             || cg->needRelocationsForBodyInfoData() || cg->needRelocationsForPersistentInfoData()
             || cg->needRelocationsForPersistentProfileInfoData())) {
         mightNeedAddressRegister = true;
-    } else if (getLabel()) {
-        // Assume labels are in RIP range
-        //
-        mightNeedAddressRegister = false;
     } else if (sr.getSymbol() != NULL
         && (sr.isUnresolved() || (sr.stackAllocatedArrayAccess() && !IS_32BIT_SIGNED(getDisplacement())))) {
         // Once resolved, the address could be anything, so be conservative.


### PR DESCRIPTION
An instruction label within a method is always assumed to be within RIP-relative range, and an address materialization instruction is not required to synthesize its effective address.  Prevent this from happening during `finishInitialization()` on the 64-bit memory reference.

This also corrects a bug introduced when the special casing of X86DataSnippets in memory references was replaced with just their snippet label.  Earlier, there was special handling for X86DataSnippets that prevented the allocation of an address load register because it was not required.

Fixes: eclipse-openj9/openj9#24631