### PR TITLE
WIP: Implement RISC-V specific relocations

### DIFF
--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -42,8 +42,6 @@
 
 void TR::Relocation::apply(TR::CodeGenerator *cg) { TR_ASSERT(0, "Should never get here"); }
 
-void TR::Relocation::trace(TR::Compilation *comp) { TR_ASSERT(0, "Should never get here"); }
-
 void TR::Relocation::setDebugInfo(TR::RelocationDebugInfo *info) { this->_genData = info; }
 
 TR::RelocationDebugInfo *TR::Relocation::getDebugInfo() { return this->_genData; }

--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -40,8 +40,6 @@
 #include "ras/Logger.hpp"
 #include "runtime/Runtime.hpp"
 
-void TR::Relocation::apply(TR::CodeGenerator *cg) { TR_ASSERT(0, "Should never get here"); }
-
 void TR::Relocation::setDebugInfo(TR::RelocationDebugInfo *info) { this->_genData = info; }
 
 TR::RelocationDebugInfo *TR::Relocation::getDebugInfo() { return this->_genData; }

--- a/compiler/codegen/Relocation.hpp
+++ b/compiler/codegen/Relocation.hpp
@@ -96,7 +96,7 @@ public:
 
     virtual void addExternalRelocation(TR::CodeGenerator *cg) {}
 
-    virtual void apply(TR::CodeGenerator *cg);
+    virtual void apply(TR::CodeGenerator *cg) = 0;
 };
 
 class LabelRelocation : public TR::Relocation {

--- a/compiler/codegen/Relocation.hpp
+++ b/compiler/codegen/Relocation.hpp
@@ -94,9 +94,6 @@ public:
 
     void setDebugInfo(TR::RelocationDebugInfo *info);
 
-    /**dumps a trace of the internals - override as required */
-    virtual void trace(TR::Compilation *comp);
-
     virtual void addExternalRelocation(TR::CodeGenerator *cg) {}
 
     virtual void apply(TR::CodeGenerator *cg);

--- a/compiler/riscv/CMakeLists.txt
+++ b/compiler/riscv/CMakeLists.txt
@@ -43,6 +43,7 @@ compiler_library(riscv
 	${CMAKE_CURRENT_LIST_DIR}/codegen/OpBinary.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/UnaryEvaluator.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/RVHelperCallSnippet.cpp
+	${CMAKE_CURRENT_LIST_DIR}/codegen/RVRelocation.cpp
 	${CMAKE_CURRENT_LIST_DIR}/env/OMRDebugEnv.cpp
 	${CMAKE_CURRENT_LIST_DIR}/env/OMRCPU.cpp
 	${CMAKE_CURRENT_LIST_DIR}/runtime/CodeSync.cpp

--- a/compiler/riscv/codegen/OMRCodeGenerator.cpp
+++ b/compiler/riscv/codegen/OMRCodeGenerator.cpp
@@ -391,6 +391,26 @@ void OMR::RV::CodeGenerator::apply32BitLabelRelativeRelocation(int32_t *cursor, 
     *cursor |= ENCODE_UJTYPE_IMM(distance);
 }
 
+void OMR::RV::CodeGenerator::applyR_BRANCH(int32_t *cursor, TR::LabelSymbol *label)
+{
+    TR_ASSERT(label->getCodeLocation(), "Attempt to relocate to a NULL label address!");
+
+    intptr_t distance = (uintptr_t)label->getCodeLocation() - (uintptr_t)cursor;
+
+    TR_ASSERT(VALID_SBTYPE_IMM(distance), "Invalid Branch offset out of range");
+    *cursor |= ENCODE_SBTYPE_IMM(distance);
+}
+
+void OMR::RV::CodeGenerator::applyR_JAL(int32_t *cursor, TR::LabelSymbol *label)
+{
+    TR_ASSERT(label->getCodeLocation(), "Attempt to relocate to a NULL label address!");
+
+    intptr_t distance = (uintptr_t)label->getCodeLocation() - (uintptr_t)cursor;
+
+    TR_ASSERT(VALID_UJTYPE_IMM(distance), "Invalid JAL offset out of range");
+    *cursor |= ENCODE_UJTYPE_IMM(distance);
+}
+
 int64_t OMR::RV::CodeGenerator::getLargestNegConstThatMustBeMaterialized()
 {
     TR_ASSERT(0, "Not Implemented on AArch64");

--- a/compiler/riscv/codegen/OMRCodeGenerator.cpp
+++ b/compiler/riscv/codegen/OMRCodeGenerator.cpp
@@ -411,6 +411,30 @@ void OMR::RV::CodeGenerator::applyR_JAL(int32_t *cursor, TR::LabelSymbol *label)
     *cursor |= ENCODE_UJTYPE_IMM(distance);
 }
 
+void OMR::RV::CodeGenerator::applyR_CALL_PLT(int32_t *cursor, TR::SymbolReference *symRef)
+{
+    TR_ASSERT(symRef->getMethodAddress() != 0 || comp()->isRecursiveMethodTarget(symRef->getSymbol()),
+        "Attempt to relocate to a unresolved symbol!");
+
+    intptr_t target = comp()->isRecursiveMethodTarget(symRef->getSymbol())
+        ? getLinkage()->entryPointFromCompiledMethod()
+        : reinterpret_cast<intptr_t>(symRef->getMethodAddress());
+
+    ptrdiff_t distance = target - reinterpret_cast<intptr_t>(cursor);
+
+    TR_ASSERT(INT32_MIN <= distance && distance <= INT32_MAX, "Call target out of range.");
+
+    uint32_t lo = (uint32_t)distance & ~(0xFFFFFFFF << RISCV_IMM_BITS);
+    uint32_t hi = (uint32_t)distance & (0xFFFFFFFF << RISCV_IMM_BITS);
+
+    if (lo & (1 << (RISCV_IMM_BITS - 1))) {
+        hi += 1 << RISCV_IMM_BITS;
+    }
+
+    *(cursor + 0) |= ENCODE_UTYPE_IMM(hi);
+    *(cursor + 1) |= ENCODE_ITYPE_IMM(lo);
+}
+
 int64_t OMR::RV::CodeGenerator::getLargestNegConstThatMustBeMaterialized()
 {
     TR_ASSERT(0, "Not Implemented on AArch64");

--- a/compiler/riscv/codegen/OMRCodeGenerator.hpp
+++ b/compiler/riscv/codegen/OMRCodeGenerator.hpp
@@ -220,6 +220,20 @@ public:
     void apply32BitLabelRelativeRelocation(int32_t *cursor, TR::LabelSymbol *label);
 
     /**
+     * @brief Applies R_BRANCH label-relative relocation
+     * @param[in] cursor : instruction cursor
+     * @param[in] label : label
+     */
+    void applyR_BRANCH(int32_t *cursor, TR::LabelSymbol *label);
+
+    /**
+     * @brief Applies R_JAL label-relative relocation
+     * @param[in] cursor : instruction cursor
+     * @param[in] label : label
+     */
+    void applyR_JAL(int32_t *cursor, TR::LabelSymbol *label);
+
+    /**
      * @brief Status of IsOutOfLineHotPath flag
      * @return IsOutOfLineHotPath flag
      */

--- a/compiler/riscv/codegen/OMRCodeGenerator.hpp
+++ b/compiler/riscv/codegen/OMRCodeGenerator.hpp
@@ -234,6 +234,14 @@ public:
     void applyR_JAL(int32_t *cursor, TR::LabelSymbol *label);
 
     /**
+     * @brief Applies R_CALL_PLT PC-relative relocation. Passed cursor must point to
+     * AUIPC + JALR pair.
+     * @param[in] cursor : instruction cursor
+     * @param[in] label : label
+     */
+    void applyR_CALL_PLT(int32_t *cursor, TR::SymbolReference *symRef);
+
+    /**
      * @brief Status of IsOutOfLineHotPath flag
      * @return IsOutOfLineHotPath flag
      */

--- a/compiler/riscv/codegen/OMRLinkage.hpp
+++ b/compiler/riscv/codegen/OMRLinkage.hpp
@@ -347,9 +347,14 @@ public:
     /**
      * @brief Builds method arguments
      * @param[in] node : caller node
-     * @param[in] dependencies : register dependency conditions
+     * @param[in] preDependencies : register dependency conditions to be associated with first instruction of calling
+     * sequence
+     * @param[in] postDependencies : register dependency conditions to be associated with last instruction of calling
+     * sequence, may be the same as preDependencies.
      */
-    virtual int32_t buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *dependencies) = 0;
+    virtual int32_t buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *preDependencies,
+        TR::RegisterDependencyConditions *postDependencies)
+        = 0;
 
     /**
      * @brief Builds direct dispatch to method

--- a/compiler/riscv/codegen/RVInstruction.cpp
+++ b/compiler/riscv/codegen/RVInstruction.cpp
@@ -34,7 +34,7 @@
 #include "codegen/RegisterConstants.hpp" // for TR_RegisterKinds, etc
 #include "codegen/RegisterDependency.hpp"
 #include "codegen/RegisterDependencyStruct.hpp" // for RegisterDependency
-#include "codegen/Relocation.hpp" // for TR::ExternalRelocation, etc
+#include "codegen/RVRelocation.hpp" // for R_RISCV_BRANCH and R_RISCV_JAL
 #include "compile/Compilation.hpp" // for Compilation
 #include "compile/ResolvedMethod.hpp" // for TR_ResolvedMethod
 #include "control/Options.hpp"
@@ -365,7 +365,7 @@ uint8_t *TR::BtypeInstruction::generateBinaryEncoding()
         int32_t delta = label->getCodeLocation() - cursor;
         *iPtr |= ENCODE_SBTYPE_IMM(delta);
     } else {
-        cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative16BitRelocation(cursor, label));
+        cg()->addRelocation(new (cg()->trHeapMemory()) R_RISCV_BRANCH(cursor, label));
     }
 
     cursor += RISCV_INSTRUCTION_LENGTH;
@@ -476,11 +476,13 @@ uint8_t *TR::JtypeInstruction::generateBinaryEncoding()
                 - reinterpret_cast<intptr_t>(cursor);
         }
     } else {
+        TR_ASSERT_FATAL(getOpCode().getMnemonic() == OP::_jal, "Instruction is not JAL");
+
         intptr_t destination = reinterpret_cast<intptr_t>(getLabelSymbol()->getCodeLocation());
         if (destination != 0) {
             offset = destination - reinterpret_cast<intptr_t>(cursor);
         } else {
-            cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, getLabelSymbol()));
+            cg()->addRelocation(new (cg()->trHeapMemory()) TR::R_RISCV_JAL(cursor, getLabelSymbol()));
         }
     }
 

--- a/compiler/riscv/codegen/RVInstruction.cpp
+++ b/compiler/riscv/codegen/RVInstruction.cpp
@@ -464,17 +464,11 @@ uint8_t *TR::JtypeInstruction::generateBinaryEncoding()
     intptr_t offset = 0;
 
     if (getSymbolReference() != nullptr) {
+        TR_ASSERT_FATAL(getOpCode().getMnemonic() == OP::_auipc, "Instruction is not AUIPC");
+        TR_ASSERT_FATAL(getNext()->getOpCode().getMnemonic() == OP::_jalr, "AUIPC is not followed by JALR");
         TR_ASSERT_FATAL(getLabelSymbol() == nullptr, "Both symbol reference and symbol set in J-type instruction");
-        TR::ResolvedMethodSymbol *sym = getSymbolReference()->getSymbol()->getResolvedMethodSymbol();
-        TR_ResolvedMethod *resolvedMethod = sym == NULL ? NULL : sym->getResolvedMethod();
 
-        if (comp()->isRecursiveMethodTarget(resolvedMethod)) {
-            intptr_t jitToJitStart = cg()->getLinkage()->entryPointFromCompiledMethod();
-            offset = jitToJitStart - reinterpret_cast<intptr_t>(cursor);
-        } else {
-            offset = reinterpret_cast<intptr_t>(getSymbolReference()->getMethodAddress())
-                - reinterpret_cast<intptr_t>(cursor);
-        }
+        cg()->addRelocation(new (cg()->trHeapMemory()) TR::R_RISCV_CALL_PLT(cursor, getSymbolReference()));
     } else {
         TR_ASSERT_FATAL(getOpCode().getMnemonic() == OP::_jal, "Instruction is not JAL");
 

--- a/compiler/riscv/codegen/RVRelocation.cpp
+++ b/compiler/riscv/codegen/RVRelocation.cpp
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2026
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+#include "codegen/RVRelocation.hpp"
+#include "codegen/CodeGenerator.hpp"
+
+void TR::R_RISCV_BRANCH::apply(TR::CodeGenerator *cg)
+{
+    assertLabelDefined();
+    cg->applyR_BRANCH(reinterpret_cast<int32_t *>(getUpdateLocation()), getLabel());
+}
+
+void TR::R_RISCV_JAL::apply(TR::CodeGenerator *cg)
+{
+    assertLabelDefined();
+    cg->applyR_JAL(reinterpret_cast<int32_t *>(getUpdateLocation()), getLabel());
+}

--- a/compiler/riscv/codegen/RVRelocation.cpp
+++ b/compiler/riscv/codegen/RVRelocation.cpp
@@ -33,3 +33,8 @@ void TR::R_RISCV_JAL::apply(TR::CodeGenerator *cg)
     assertLabelDefined();
     cg->applyR_JAL(reinterpret_cast<int32_t *>(getUpdateLocation()), getLabel());
 }
+
+void TR::R_RISCV_CALL_PLT::apply(TR::CodeGenerator *cg)
+{
+    cg->applyR_CALL_PLT(reinterpret_cast<int32_t *>(getUpdateLocation()), getSymbolReference());
+}

--- a/compiler/riscv/codegen/RVRelocation.hpp
+++ b/compiler/riscv/codegen/RVRelocation.hpp
@@ -23,6 +23,7 @@
 #define RVRELOCATION_INCL
 
 #include "codegen/Relocation.hpp"
+#include "il/SymbolReference.hpp"
 
 namespace TR {
 
@@ -42,6 +43,20 @@ public:
     {}
 
     virtual void apply(TR::CodeGenerator *cg);
+};
+
+class R_RISCV_CALL_PLT : public Relocation {
+    SymbolReference *_symbolReference;
+
+public:
+    R_RISCV_CALL_PLT(uint8_t *p, SymbolReference *s)
+        : TR::Relocation(p)
+        , _symbolReference(s)
+    {}
+
+    virtual void apply(TR::CodeGenerator *cg);
+
+    SymbolReference *getSymbolReference() { return _symbolReference; }
 };
 
 } // namespace TR

--- a/compiler/riscv/codegen/RVRelocation.hpp
+++ b/compiler/riscv/codegen/RVRelocation.hpp
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2026
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+#ifndef RVRELOCATION_INCL
+#define RVRELOCATION_INCL
+
+#include "codegen/Relocation.hpp"
+
+namespace TR {
+
+class R_RISCV_BRANCH : public LabelRelocation {
+public:
+    R_RISCV_BRANCH(uint8_t *p, LabelSymbol *l)
+        : TR::LabelRelocation(p, l)
+    {}
+
+    virtual void apply(TR::CodeGenerator *cg);
+};
+
+class R_RISCV_JAL : public LabelRelocation {
+public:
+    R_RISCV_JAL(uint8_t *p, LabelSymbol *l)
+        : TR::LabelRelocation(p, l)
+    {}
+
+    virtual void apply(TR::CodeGenerator *cg);
+};
+
+} // namespace TR
+
+#endif // RVRELOCATION_INCL

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -677,16 +677,21 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
     const TR::RVLinkageProperties &pp = getProperties();
     TR::RealRegister *sp = cg()->machine()->getRealRegister(pp.getStackPointerRegister());
     TR::RealRegister *ra = cg()->machine()->getRealRegister(TR::RealRegister::ra);
-    TR::Register *target = nullptr;
 
-    if (callNode->getOpCode().isCallIndirect()) {
+    TR::Register *target = nullptr;
+    TR::RegisterDependencyConditions *preDeps = nullptr;
+    TR::RegisterDependencyConditions *postDeps = nullptr;
+
+    if (callNode->getOpCode().isCallIndirect() || callNode->getSymbolReference()->getMethodAddress() != NULL) {
         target = cg()->evaluate(callNode->getFirstChild());
+        preDeps = RegDeps(pp.getNumberOfDependencyRegisters(), pp.getNumberOfDependencyRegisters(), cg());
+        postDeps = preDeps;
+    } else {
+        preDeps = RegDeps(pp.getNumberOfDependencyRegisters(), 0, cg());
+        postDeps = RegDeps(0, pp.getNumberOfDependencyRegisters(), cg());
     }
 
-    TR::RegisterDependencyConditions *dependencies
-        = RegDeps(pp.getNumberOfDependencyRegisters(), pp.getNumberOfDependencyRegisters(), cg());
-
-    int32_t totalSize = buildArgs(callNode, dependencies, dependencies);
+    int32_t totalSize = buildArgs(callNode, preDeps, postDeps);
     if (totalSize > 0) {
         if (VALID_ITYPE_IMM(-totalSize)) {
             Inst_ITYPE(OP::_addi, callNode, sp, sp, -totalSize, cg());
@@ -696,24 +701,27 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
     }
 
     if (callNode->getOpCode().isCallIndirect()) {
-        Inst_ITYPE(OP::_jalr, callNode, ra, target, 0, dependencies, cg());
+        Inst_ITYPE(OP::_jalr, callNode, ra, target, 0, preDeps, cg());
     } else {
         auto targetAddr = callNode->getSymbolReference()->getMethodAddress();
 
         if (targetAddr == NULL) {
             /*
-             * If the target address is not known yet, we generate `jal` and hope that the target address
-             * offset would fit into 20bit immediate.
+             * If the target address is not known yet, we generate `auipc` + `jalr` pair and hope that
+             * the target address is within -2GB, +2GB range.
              *
              * This is the case of recursive calls.
+             *
+             * Note that relocation happens in JtypeInstruction::generateBinaryEncoding().
              */
-            Inst_JTYPE(OP::_jal, callNode, ra, 0, dependencies, callNode->getSymbolReference(), NULL, cg());
+            Inst_JTYPE(OP::_auipc, callNode, ra, 0, preDeps, callNode->getSymbolReference(), NULL, cg());
+            Inst_ITYPE(OP::_jalr, callNode, ra, ra, 0, postDeps, cg());
         } else {
             /*
              * If the target address is known, we load it into a register and generate `jalr`. This may be
-             * wasteful in cases the target address offset would fit into 20bit immediate of `jal`. However,
-             * more often than not, non-jitted functions (library / runtime functions) are too far to fit in
-             * the immediate value.
+             * wasteful in cases the target address is within -2GB, +2GB range (so we could have used
+             * `auipc` + `jalr` pair). However, more often than not, non-jitted functions (library / runtime
+             * functions) are too far to fit in the immediate value.
              *
              * So, until a trampolines are implemented, we pay the price and load the target address into
              * register.
@@ -722,7 +730,7 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
              * anyways and this way we do not need to allocate another one.
              */
             loadConstant64(cg(), callNode, reinterpret_cast<int64_t>(targetAddr), ra);
-            Inst_ITYPE(OP::_jalr, callNode, ra, ra, 0, dependencies, cg());
+            Inst_ITYPE(OP::_jalr, callNode, ra, ra, 0, preDeps, cg());
         }
     }
 
@@ -740,19 +748,19 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
     switch (callNode->getOpCodeValue()) {
         case TR::icall:
         case TR::icalli:
-            retReg = dependencies->searchPostConditionRegister(pp.getIntegerReturnRegister());
+            retReg = postDeps->searchPostConditionRegister(pp.getIntegerReturnRegister());
             break;
         case TR::lcall:
         case TR::lcalli:
         case TR::acall:
         case TR::acalli:
-            retReg = dependencies->searchPostConditionRegister(pp.getLongReturnRegister());
+            retReg = postDeps->searchPostConditionRegister(pp.getLongReturnRegister());
             break;
         case TR::fcall:
         case TR::fcalli:
         case TR::dcall:
         case TR::dcalli:
-            retReg = dependencies->searchPostConditionRegister(pp.getFloatReturnRegister());
+            retReg = postDeps->searchPostConditionRegister(pp.getFloatReturnRegister());
             break;
         case TR::call:
         case TR::calli:
@@ -768,7 +776,8 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
         callNode->getFirstChild()->decReferenceCount();
     }
 
-    dependencies->stopUsingDepRegs(cg(), retReg);
+    preDeps->stopUsingDepRegs(cg(), retReg);
+    postDeps->stopUsingDepRegs(cg(), retReg);
 
     return retReg;
 }

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -33,20 +33,6 @@
 #include "il/AutomaticSymbol.hpp"
 #include "il/ParameterSymbol.hpp"
 
-/**
- * @brief Adds dependency
- */
-inline void addDependency(TR::RegisterDependencyConditions *dep, TR::Register *vreg, TR::RealRegister::RegNum rnum,
-    TR_RegisterKinds rk, TR::CodeGenerator *cg)
-{
-    if (vreg == NULL) {
-        vreg = cg->allocateRegister(rk);
-    }
-
-    dep->addPreCondition(vreg, rnum);
-    dep->addPostCondition(vreg, rnum);
-}
-
 TR::RVSystemLinkageProperties::RVSystemLinkageProperties()
 {
     _properties = IntegersInRegisters | FloatsInRegisters | RightToLeft;

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -27,11 +27,24 @@
 #include "codegen/Linkage_inlines.hpp"
 #include "codegen/MemoryReference.hpp"
 #include "codegen/RegisterDependency.hpp"
-#include "codegen/CodeGeneratorUtils.hpp"
 #include "env/StackMemoryRegion.hpp"
 #include "il/Node_inlines.hpp"
 #include "il/AutomaticSymbol.hpp"
 #include "il/ParameterSymbol.hpp"
+
+/**
+ * @brief Adds pre- and post- conditions.
+ */
+static inline void addDependency(TR::RegisterDependencyConditions *preDeps, TR::RegisterDependencyConditions *postDeps,
+    TR::Register *vreg, TR::RealRegister::RegNum rnum, TR_RegisterKinds rk, TR::CodeGenerator *cg)
+{
+    if (vreg == NULL) {
+        vreg = cg->allocateRegister(rk);
+    }
+
+    preDeps->addPreCondition(vreg, rnum);
+    postDeps->addPostCondition(vreg, rnum);
+}
 
 TR::RVSystemLinkageProperties::RVSystemLinkageProperties()
 {
@@ -430,7 +443,8 @@ void TR::RVSystemLinkage::createEpilogue(TR::Instruction *cursor)
     cursor = Inst_ITYPE(OP::_jalr, lastNode, zero, ra, 0, cg, cursor);
 }
 
-int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *dependencies)
+int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *preDependencies,
+    TR::RegisterDependencyConditions *postDependencies)
 
 {
     const TR::RVLinkageProperties &properties = getProperties();
@@ -538,10 +552,10 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependenc
                         else
                             resultReg = cg()->allocateRegister();
 
-                        dependencies->addPreCondition(argRegister, TR::RealRegister::a0);
-                        dependencies->addPostCondition(resultReg, TR::RealRegister::a0);
+                        preDependencies->addPreCondition(argRegister, TR::RealRegister::a0);
+                        postDependencies->addPostCondition(resultReg, TR::RealRegister::a0);
                     } else {
-                        TR::addDependency(dependencies, argRegister,
+                        addDependency(preDependencies, postDependencies, argRegister,
                             properties.getIntegerArgumentRegister(numIntegerArgs + numFloatArgsPassedInGPRs), TR_GPR,
                             cg());
                     }
@@ -581,11 +595,11 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependenc
                         else
                             resultReg = cg()->allocateRegister(TR_FPR);
 
-                        dependencies->addPreCondition(argRegister, TR::RealRegister::fa0);
-                        dependencies->addPostCondition(resultReg, TR::RealRegister::fa0);
+                        preDependencies->addPreCondition(argRegister, TR::RealRegister::fa0);
+                        postDependencies->addPostCondition(resultReg, TR::RealRegister::fa0);
                     } else {
-                        TR::addDependency(dependencies, argRegister, properties.getFloatArgumentRegister(numFloatArgs),
-                            TR_FPR, cg());
+                        addDependency(preDependencies, postDependencies, argRegister,
+                            properties.getFloatArgumentRegister(numFloatArgs), TR_FPR, cg());
                     }
                 } else if ((numIntegerArgs + numFloatArgsPassedInGPRs) < properties.getNumIntArgRegs()) {
                     TR::Register *gprRegister = cg()->allocateRegister(TR_GPR);
@@ -593,7 +607,7 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependenc
                     op = (childType == TR::Float) ? OP::_fmv_x_s : OP::_fmv_x_d;
                     Inst_RTYPE(op, callNode, gprRegister, argRegister, zero, cg());
 
-                    TR::addDependency(dependencies, gprRegister,
+                    addDependency(preDependencies, postDependencies, gprRegister,
                         properties.getIntegerArgumentRegister(numIntegerArgs + numFloatArgsPassedInGPRs), TR_GPR, cg());
                     numFloatArgsPassedInGPRs++;
                 } else {
@@ -614,30 +628,31 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependenc
     // NULL deps for unused integer argument registers
     for (auto i = numIntegerArgs + numFloatArgsPassedInGPRs; i < properties.getNumIntArgRegs(); i++) {
         if (i == 0 && resType.isAddress()) {
-            dependencies->addPreCondition(cg()->allocateRegister(), properties.getIntegerArgumentRegister(0));
-            dependencies->addPostCondition(cg()->allocateCollectedReferenceRegister(),
+            preDependencies->addPreCondition(cg()->allocateRegister(), properties.getIntegerArgumentRegister(0));
+            postDependencies->addPostCondition(cg()->allocateCollectedReferenceRegister(),
                 properties.getIntegerArgumentRegister(0));
         } else {
-            TR::addDependency(dependencies, NULL, properties.getIntegerArgumentRegister(i), TR_GPR, cg());
+            addDependency(preDependencies, postDependencies, NULL, properties.getIntegerArgumentRegister(i), TR_GPR,
+                cg());
         }
     }
 
     // NULL deps for non-preserved non-argument integer registers
     for (auto rn = TR::RealRegister::FirstGPR; rn <= TR::RealRegister::LastGPR; rn++) {
         if (!properties.getPreserved(rn) && !properties.getIntegerArgument(rn)) {
-            TR::addDependency(dependencies, NULL, rn, TR_FPR, cg());
+            addDependency(preDependencies, postDependencies, NULL, rn, TR_FPR, cg());
         }
     }
 
     // NULL deps for unused FP argument registers
     for (auto i = numFloatArgs; i < properties.getNumFloatArgRegs(); i++) {
-        TR::addDependency(dependencies, NULL, properties.getFloatArgumentRegister(i), TR_FPR, cg());
+        addDependency(preDependencies, postDependencies, NULL, properties.getFloatArgumentRegister(i), TR_FPR, cg());
     }
 
     // NULL deps for non-preserved non-argument FP registers
     for (auto rn = TR::RealRegister::FirstFPR; rn <= TR::RealRegister::LastFPR; rn++) {
         if (!properties.getPreserved(rn) && !properties.getFloatArgument(rn)) {
-            TR::addDependency(dependencies, NULL, rn, TR_FPR, cg());
+            addDependency(preDependencies, postDependencies, NULL, rn, TR_FPR, cg());
         }
     }
 
@@ -671,7 +686,7 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
     TR::RegisterDependencyConditions *dependencies
         = RegDeps(pp.getNumberOfDependencyRegisters(), pp.getNumberOfDependencyRegisters(), cg());
 
-    int32_t totalSize = buildArgs(callNode, dependencies);
+    int32_t totalSize = buildArgs(callNode, dependencies, dependencies);
     if (totalSize > 0) {
         if (VALID_ITYPE_IMM(-totalSize)) {
             Inst_ITYPE(OP::_addi, callNode, sp, sp, -totalSize, cg());

--- a/compiler/riscv/codegen/RVSystemLinkage.hpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.hpp
@@ -102,9 +102,13 @@ public:
     /**
      * @brief Builds method arguments
      * @param[in] node : caller node
-     * @param[in] dependencies : register dependency conditions
+     * @param[in] preDependencies : register dependency conditions to be associated with first instruction of calling
+     * sequence
+     * @param[in] postDependencies : register dependency conditions to be associated with last instruction of calling
+     * sequence, may be the same as preDependencies.
      */
-    virtual int32_t buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *dependencies);
+    virtual int32_t buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *preDependencies,
+        TR::RegisterDependencyConditions *postDependencies);
 
     /**
      * @brief Builds dispatch to method (either direct or indirect)


### PR DESCRIPTION
This WIP PR explores the idea of having relocations specific to backend rather than reusing generic 16/24/32bit relocation classes for whatever's needed (as done at least in RISC-V and AArch64 codegen). 

This was prompted by desire to use AUIPC + JALR pair to implement calls on RISC-V. This PR also does that in an attempt to explore how that would look like. 

This PR is opened mostly as supporting material for OMR Architecture meeting ( #8222 )