### PR TITLE
Add OMRPORT_VMEM_NO_AFFINITY flag to Sparse heap allocation

### DIFF
--- a/gc/base/SparseVirtualMemory.hpp
+++ b/gc/base/SparseVirtualMemory.hpp
@@ -84,10 +84,24 @@ protected:
 	bool initialize(MM_EnvironmentBase *env, uint32_t memoryCategory);
 	void tearDown(MM_EnvironmentBase *env);
 
+	/*
+	 * Description of Memory allocation modes require for Sparse heap:
+	 * - OMRPORT_VMEM_MEMORY_MODE_READ - general memory read access for all platforms
+	 * - OMRPORT_VMEM_MEMORY_MODE_WRITE - general memory read access for all platforms
+	 * - OMRPORT_VMEM_MEMORY_MODE_VIRTUAL - impact ZOS only, use virtual memory
+	 * - OMRPORT_VMEM_MEMORY_MODE_GUARDED - impact ZOS only, use memory guarding to not exceed MEMLIMIT
+	 * - OMRPORT_VMEM_NO_AFFINITY - needs to be set for AIX to prevent switch reservation method
+	 *  from default for 4k pages mmap() to shmget() if NUMA is enabled.
+	 */
 	MM_SparseVirtualMemory(MM_EnvironmentBase *env, uintptr_t pageSize, uintptr_t pageFlags, MM_Heap *in_heap)
 		: MM_VirtualMemory(
 				env, in_heap->getHeapRegionManager()->getRegionSize(), pageSize, pageFlags, 0,
-				OMRPORT_VMEM_MEMORY_MODE_READ | OMRPORT_VMEM_MEMORY_MODE_WRITE | OMRPORT_VMEM_MEMORY_MODE_VIRTUAL | OMRPORT_VMEM_MEMORY_MODE_GUARDED)
+					OMRPORT_VMEM_MEMORY_MODE_READ
+					| OMRPORT_VMEM_MEMORY_MODE_WRITE
+					| OMRPORT_VMEM_MEMORY_MODE_VIRTUAL
+					| OMRPORT_VMEM_MEMORY_MODE_GUARDED
+					| OMRPORT_VMEM_NO_AFFINITY
+				)
 		, _heap(in_heap)
 		, _sparseDataPool(NULL)
 		, _largeObjectVirtualMemoryMutex(NULL)


### PR DESCRIPTION
An implementation of getMemoryInRangeForDefaultPages() on AIX switches default allocation method mmap() to shmget() if NUMA is enabled. An allocation using shared memory can be problematic for pure virtual memory manipulation required for Sparse heap logic. One suspected side effect is uncommited Sparse heap shared pages are included to system dump increasing it's size dramatically.
Setting OMRPORT_VMEM_NO_AFFINITY flag explicitly disables switch to shmget().
Despite this is AIX issue only, set this flag for all platforms for consistentcy. If NUMA awareness is going to be required for Sparse heap in the future using this flag should be revised.