### PR TITLE
ddrgen: Fix references to anonymous types

### DIFF
--- a/ddr/include/ddr/scanner/pdb/PdbScanner.hpp
+++ b/ddr/include/ddr/scanner/pdb/PdbScanner.hpp
@@ -45,12 +45,6 @@ using std::set;
 using std::string;
 using std::vector;
 
-typedef struct PostponedType
-{
-	Type **type;
-	string name;
-} PostponedType;
-
 class PdbScanner : public Scanner
 {
 public:
@@ -58,6 +52,12 @@ public:
 			vector<string> *debugFiles, const char *excludesFilePath);
 
 private:
+	struct PostponedType
+	{
+		Type **type;
+		string name;
+	};
+
 	Symbol_IR *_ir;
 	unordered_map<string, Type *> _typeMap;
 	vector<PostponedType> _postponedFields;

--- a/ddr/lib/ddr-scanner/pdb/PdbScanner.cpp
+++ b/ddr/lib/ddr-scanner/pdb/PdbScanner.cpp
@@ -728,28 +728,25 @@ PdbScanner::setTypeUDT(IDiaSymbol *typeSymbol, Type **type, NamespaceUDT *outerU
 	if (DDR_RC_OK == rc) {
 		getNamespaceFromName(symbolName, &outerUDT);
 		string name = getSimpleName(symbolName);
-		string fullName = "";
-		if (NULL == outerUDT) {
-			fullName = name;
-		} else {
-			fullName = outerUDT->getFullName() + "::" + name;
-		}
-		unordered_map<string, Type *>::const_iterator map_it = _typeMap.find(fullName);
-		if (!fullName.empty() && _typeMap.end() != map_it) {
-			*type = map_it->second;
-		} else if (fullName.empty() && (NULL != outerUDT)) {
-			/* Anonymous inner union UDTs are missing the parent
-			 * relationship and cannot be added later.
-			 */
+		if (name.empty()) {
+			/* Anonymous types cannot be referred to by name, so create them here. */
 			ClassUDT *newClass = NULL;
 			rc = createClassUDT(typeSymbol, &newClass, outerUDT);
 			if ((DDR_RC_OK == rc) && (NULL != newClass)) {
 				newClass->_name = "";
 				*type = newClass;
 			}
-		} else if (!name.empty()) {
-			PostponedType p = { type, fullName };
-			_postponedFields.push_back(p);
+		} else {
+			string fullName = (NULL == outerUDT)
+						? name
+						: (outerUDT->getFullName() + "::" + name);
+			unordered_map<string, Type *>::const_iterator map_it = _typeMap.find(fullName);
+			if (_typeMap.end() != map_it) {
+				*type = map_it->second;
+			} else {
+				PostponedType p = { type, fullName };
+				_postponedFields.push_back(p);
+			}
 		}
 	}
 


### PR DESCRIPTION
By refining how anonymous types are handled, the hope is that this fixes https://github.com/eclipse-openj9/openj9/issues/17693. OpenJ9 builds with and without this change produce essentially equivalent DDR blobs.